### PR TITLE
fix(reminders): prevent per-user turn reminder email bursts

### DIFF
--- a/__tests__/lib/turn-reminders.test.ts
+++ b/__tests__/lib/turn-reminders.test.ts
@@ -216,4 +216,56 @@ describe('runTurnReminderCycle', () => {
       })
     )
   })
+
+  it('sends at most one reminder per user per cycle across multiple stale games', async () => {
+    const game1 = buildGame({
+      id: 'game-1',
+      lobby: {
+        id: 'lobby-1',
+        code: 'ABCD',
+        name: 'Ranked Lobby',
+        gameType: 'yahtzee',
+      },
+      lastMoveAt: new Date('2026-02-25T09:00:00.000Z'),
+    })
+
+    const game2 = buildGame({
+      id: 'game-2',
+      lobby: {
+        id: 'lobby-2',
+        code: 'EFGH',
+        name: 'Casual Lobby',
+        gameType: 'guess_the_spy',
+      },
+      lastMoveAt: new Date('2026-02-25T09:10:00.000Z'),
+    })
+
+    mockPrisma.games.findMany.mockResolvedValue([game1, game2])
+
+    const result = await runTurnReminderCycle({
+      now,
+      baseUrl: 'http://localhost:3000',
+      idleMinutes: 15,
+      rateLimitMinutes: 60,
+      recentActiveSkipMinutes: 10,
+    })
+
+    expect(result.scannedGames).toBe(2)
+    expect(result.attempted).toBe(1)
+    expect(result.sent).toBe(1)
+    expect(result.skipped).toBe(1)
+    expect(result.failed).toBe(0)
+
+    expect(mockSendTurnReminderEmail).toHaveBeenCalledTimes(1)
+
+    expect(mockRecordNotificationDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-2',
+        type: 'turn_reminder',
+        status: 'skipped',
+        reason: 'user_already_notified_in_cycle',
+        dedupeKey: 'turn_reminder:game:game-2:recipient:user-2',
+      })
+    )
+  })
 })

--- a/lib/turn-reminders.ts
+++ b/lib/turn-reminders.ts
@@ -85,6 +85,8 @@ export async function runTurnReminderCycle(
     rateLimitMinutes,
     batchLimit,
   }
+  const notifiedUsersInCycle = new Set<string>()
+  const userRateLimitedInCycle = new Set<string>()
 
   const games = await prisma.games.findMany({
     where: {
@@ -210,6 +212,34 @@ export async function runTurnReminderCycle(
         continue
       }
 
+      // Prevent bursty email spam when one user is "current turn" in many stale games.
+      // We still track per-game dedupe below, but cap email sends to one per user per cycle.
+      if (notifiedUsersInCycle.has(recipient.id)) {
+        result.skipped += 1
+        await recordNotificationDelivery({
+          userId: recipient.id,
+          type: 'turn_reminder',
+          status: 'skipped',
+          reason: 'user_already_notified_in_cycle',
+          dedupeKey,
+          payload,
+        })
+        continue
+      }
+
+      if (userRateLimitedInCycle.has(recipient.id)) {
+        result.skipped += 1
+        await recordNotificationDelivery({
+          userId: recipient.id,
+          type: 'turn_reminder',
+          status: 'skipped',
+          reason: 'user_rate_limited_recent_send',
+          dedupeKey,
+          payload,
+        })
+        continue
+      }
+
       const wasRecentlySent = await hasRecentSentNotification({
         userId: recipient.id,
         type: 'turn_reminder',
@@ -224,6 +254,26 @@ export async function runTurnReminderCycle(
           type: 'turn_reminder',
           status: 'skipped',
           reason: 'rate_limited_recent_send',
+          dedupeKey,
+          payload,
+        })
+        continue
+      }
+
+      const userHadRecentTurnReminder = await hasRecentSentNotification({
+        userId: recipient.id,
+        type: 'turn_reminder',
+        since: recentSentCutoff,
+      })
+
+      if (userHadRecentTurnReminder) {
+        userRateLimitedInCycle.add(recipient.id)
+        result.skipped += 1
+        await recordNotificationDelivery({
+          userId: recipient.id,
+          type: 'turn_reminder',
+          status: 'skipped',
+          reason: 'user_rate_limited_recent_send',
           dedupeKey,
           payload,
         })
@@ -250,6 +300,7 @@ export async function runTurnReminderCycle(
 
       if (emailResult.success) {
         result.sent += 1
+        notifiedUsersInCycle.add(recipient.id)
       } else {
         result.failed += 1
         result.success = false


### PR DESCRIPTION
## Incident fix\nTurn reminder emails were sent in bursts when the same user had multiple stale games (one email per game).\n\n## Changes\n- cap turn reminder emails to one send per user per cron cycle\n- add user-level recent-send cooldown check (in addition to per-game dedupe)\n- add regression test for multi-game same-user scenario\n\n## Validation\n- npm test -- __tests__/lib/turn-reminders.test.ts\n- npm run ci:quick\n