### PR TITLE
fix(db): enforce social pair integrity for friendships and friend requests

### DIFF
--- a/app/api/friends/add-by-code/route.ts
+++ b/app/api/friends/add-by-code/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
+import { Prisma } from '@prisma/client'
 import { authOptions } from '@/lib/next-auth'
 import { findUserByFriendCode } from '@/lib/friend-code'
 import { prisma } from '@/lib/db'
@@ -181,6 +182,13 @@ export async function POST(req: NextRequest) {
       user: targetUser
     })
   } catch (error: any) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      return NextResponse.json(
+        { error: 'A friend request is already pending with this user' },
+        { status: 400 }
+      )
+    }
+
     log.error('Error adding friend by code', error)
 
     return NextResponse.json(

--- a/app/api/friends/request/route.ts
+++ b/app/api/friends/request/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { Prisma } from '@prisma/client'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/next-auth'
 import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
@@ -158,6 +159,13 @@ export async function POST(req: NextRequest) {
     })
 
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      return NextResponse.json(
+        { error: 'Friend request already exists' },
+        { status: 400 }
+      )
+    }
+
     log.error('Error sending friend request', error as Error)
     return NextResponse.json(
       { error: 'Failed to send friend request' },

--- a/prisma/migrations/20260226223500_enforce_social_pair_integrity/migration.sql
+++ b/prisma/migrations/20260226223500_enforce_social_pair_integrity/migration.sql
@@ -1,0 +1,104 @@
+-- ============================================================================
+-- Migration: Enforce social pair integrity for friendships and friend requests
+-- Date: 2026-02-26
+-- Description:
+--   1) Enforce canonical order and non-self pairs in Friendships
+--   2) Prevent self friend requests
+--   3) Prevent mirrored duplicate pending friend requests with unordered unique index
+-- ============================================================================
+
+-- Friendships are semantically unordered; keep one canonical row per pair.
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY LEAST("user1Id", "user2Id"), GREATEST("user1Id", "user2Id")
+      ORDER BY "createdAt" ASC, id ASC
+    ) AS rn
+  FROM public."Friendships"
+)
+DELETE FROM public."Friendships" f
+USING ranked r
+WHERE f.id = r.id
+  AND r.rn > 1;
+
+UPDATE public."Friendships"
+SET
+  "user1Id" = LEAST("user1Id", "user2Id"),
+  "user2Id" = GREATEST("user1Id", "user2Id")
+WHERE "user1Id" > "user2Id";
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public."Friendships" WHERE "user1Id" = "user2Id") THEN
+    RAISE EXCEPTION 'Friendships contains self-pairs; cleanup required before adding constraints';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND t.relname = 'Friendships'
+      AND c.conname = 'Friendships_distinct_users_check'
+  ) THEN
+    ALTER TABLE public."Friendships"
+      ADD CONSTRAINT "Friendships_distinct_users_check"
+      CHECK ("user1Id" <> "user2Id");
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND t.relname = 'Friendships'
+      AND c.conname = 'Friendships_canonical_order_check'
+  ) THEN
+    ALTER TABLE public."Friendships"
+      ADD CONSTRAINT "Friendships_canonical_order_check"
+      CHECK ("user1Id" < "user2Id");
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public."FriendRequests" WHERE "senderId" = "receiverId") THEN
+    RAISE EXCEPTION 'FriendRequests contains self-requests; cleanup required before adding constraints';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public."FriendRequests"
+    WHERE "status" = 'pending'
+    GROUP BY LEAST("senderId", "receiverId"), GREATEST("senderId", "receiverId")
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'FriendRequests contains mirrored duplicate pending requests; cleanup required before adding unordered unique index';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND t.relname = 'FriendRequests'
+      AND c.conname = 'FriendRequests_distinct_users_check'
+  ) THEN
+    ALTER TABLE public."FriendRequests"
+      ADD CONSTRAINT "FriendRequests_distinct_users_check"
+      CHECK ("senderId" <> "receiverId");
+  END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "FriendRequests_pending_unordered_pair_unique_idx"
+ON public."FriendRequests" (
+  LEAST("senderId", "receiverId"),
+  GREATEST("senderId", "receiverId")
+)
+WHERE "status" = 'pending';


### PR DESCRIPTION
## Summary
Implements issue #77 by enforcing social-pair integrity at the database layer and making friend-request create routes race-safe.

## Changes
- New Prisma SQL migration `20260226223500_enforce_social_pair_integrity`
  - deduplicates mirrored `Friendships` rows (unordered pair semantics)
  - normalizes `Friendships` row ordering (`user1Id < user2Id`)
  - adds DB checks for non-self friendships and canonical order
  - adds DB check to prevent self friend requests
  - adds partial unique unordered-pair index for pending friend requests to block mirrored pending duplicates (`A->B` vs `B->A`)
- API robustness
  - `POST /api/friends/request`
  - `POST /api/friends/add-by-code`
  - handle Prisma `P2002` as user-facing `400` (duplicate pending request race) instead of generic `500`

## Validation
- Prod preflight audit before implementation: no existing self-pairs / mirrored duplicates / unsorted friendships
- `npm run ci:quick` ✅

## Notes
- `FriendRequests` remains directional (sender/receiver semantics preserved).
- Unordered uniqueness is enforced only for `status='pending'` so historical non-pending rows remain allowed.

Closes #77