### PR TITLE
docs(db): define timestamptz policy and phased migration plan

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,40 @@ Core tables (pluralized schema):
 
 Game state is persisted as JSON in `Games.state` and treated as source of truth for replay/recovery.
 
+## Database timestamp policy
+
+### Policy (effective now)
+
+- For new server-authored timestamps in PostgreSQL, prefer `TIMESTAMPTZ` (`timestamp with time zone`).
+- Treat database timestamps as UTC-backed canonical server time.
+- Do not introduce broad table-wide timestamp conversions in feature PRs.
+- For Prisma migrations that need `TIMESTAMPTZ`, use explicit SQL in migration files (Prisma `DateTime` defaults to `TIMESTAMP(3)` in generated SQL).
+
+### Scope guidance
+
+Use `TIMESTAMPTZ` by default for:
+
+- audit/event timestamps (`occurredAt`, `createdAt`, `processedAt`, `sentAt`)
+- scheduler/cron timestamps
+- timeout/deadline/retry timestamps
+- cross-region/cross-device reconciliation timestamps
+
+`TIMESTAMP WITHOUT TIME ZONE` may be tolerated only when preserving compatibility in existing tables during phased migration.
+
+### Phased migration plan (no big-bang)
+
+1. New tables/columns: `TIMESTAMPTZ` by default (no retroactive conversion in same PR).
+2. Low-risk append-only tables first (events/notifications/operational telemetry).
+3. Medium-risk gameplay/social timestamps (`Games`, `Lobbies`, `Players`, `FriendRequests`, etc.) with targeted migrations and regression tests.
+4. Auth/session-related tables only after adapter/compatibility review.
+5. Legacy cleanup pass when operational telemetry shows no parsing/serialization regressions.
+
+### Compatibility assumptions to preserve
+
+- App/server code should treat Prisma `DateTime` values as JS `Date` objects and serialize via ISO strings (UTC).
+- Do not compare timestamp strings lexicographically in business logic; compare `Date`/epoch values.
+- Client UI may localize display, but server persistence and API payload semantics remain UTC-based.
+
 ## Quality guardrails
 
 - Keep game-specific logic isolated under `lib/games/` and game-specific UI blocks.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,6 +40,7 @@ npm run db:rls:smoke
 - Keep socket event names/types centralized in `types/socket-events.ts`.
 - Keep server-authoritative reconciliation after moves.
 - Keep comments and documentation in English.
+- For new PostgreSQL server timestamps, prefer `TIMESTAMPTZ` (via explicit SQL in Prisma migrations when needed).
 
 ## Adding a new game (minimal checklist)
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -109,6 +109,22 @@ Note: `npm run db:migrate` automatically bootstraps required RLS roles
 (`anon`, `authenticated`, `service_role`) before running `prisma migrate deploy`,
 so CI/local PostgreSQL environments do not require a separate manual role-prep step.
 
+### Timestamp migration rollout notes (`timestamptz` phases)
+
+When migrating existing timestamp columns from `TIMESTAMP` to `TIMESTAMPTZ`:
+
+- batch by table/domain (do not convert unrelated tables in one release)
+- deploy schema migration first, then application changes if parsing/serialization logic changes
+- verify cron/scheduler paths and realtime timer logic after deploy (timestamp-sensitive flows)
+- check for DB locks/statement timeout risk on large tables before running DDL in production
+- validate API payloads still emit ISO timestamps and UI date rendering remains correct
+
+Recommended verification after each phase:
+
+- `npm run check:db`
+- critical cron/manual endpoint smoke (`/api/cron/*` used in that phase)
+- one realtime gameplay flow (create/join/play/reconnect) if gameplay timestamps changed
+
 ## Common troubleshooting
 
 ### Render build hangs after Prisma datasource log


### PR DESCRIPTION
## Summary
Implements the low-risk recommendation for #78: define the DB timestamp standard and a phased migration plan without converting existing columns yet.

## Changes
- `docs/ARCHITECTURE.md`
  - adds database timestamp policy (`TIMESTAMPTZ` for new server-authored timestamps)
  - scope guidance for when to use it
  - phased migration plan (no big-bang)
  - compatibility assumptions (UTC/ISO serialization, avoid string comparisons)
- `docs/OPERATIONS.md`
  - adds rollout checklist for timestamp migration phases (locks, cron, realtime, API payload validation)
- `docs/CONTRIBUTING.md`
  - adds contributor guardrail for new PostgreSQL server timestamps

## Validation
- Docs-only change (no runtime/schema changes)

Closes #78