### PR TITLE
Release: sync develop into main (RLS Users policy cleanup #79)

### DIFF
--- a/prisma/migrations/20260226231000_consolidate_users_select_policies/migration.sql
+++ b/prisma/migrations/20260226231000_consolidate_users_select_policies/migration.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- Migration: Consolidate Users SELECT RLS policies to avoid duplicate permissive
+-- Date: 2026-02-26
+-- Description:
+--   Replace overlapping Users SELECT policies with one policy per role/action:
+--   - authenticated: public user info (single permissive SELECT policy)
+--   - anon: public user info
+--   This preserves existing behavior (users remain publicly readable) while
+--   removing Supabase linter warning for multiple permissive SELECT policies.
+-- ============================================================================
+
+DO $$
+DECLARE
+  has_anon BOOLEAN := EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon');
+  has_authenticated BOOLEAN := EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated');
+  anon_role_clause TEXT;
+  authenticated_role_clause TEXT;
+BEGIN
+  DROP POLICY IF EXISTS "Users can view own profile" ON public."Users";
+  DROP POLICY IF EXISTS "Users can view public info" ON public."Users";
+  DROP POLICY IF EXISTS "Authenticated users can view public user info" ON public."Users";
+  DROP POLICY IF EXISTS "Anon users can view public user info" ON public."Users";
+
+  anon_role_clause := CASE
+    WHEN has_anon THEN 'TO anon'
+    ELSE ''
+  END;
+
+  authenticated_role_clause := CASE
+    WHEN has_authenticated THEN 'TO authenticated'
+    ELSE ''
+  END;
+
+  EXECUTE format(
+    'CREATE POLICY "Authenticated users can view public user info"
+       ON public."Users" FOR SELECT
+       %s
+       USING (true)',
+    authenticated_role_clause
+  );
+
+  EXECUTE format(
+    'CREATE POLICY "Anon users can view public user info"
+       ON public."Users" FOR SELECT
+       %s
+       USING (true)',
+    anon_role_clause
+  );
+END
+$$;

--- a/scripts/rls-smoke.psql
+++ b/scripts/rls-smoke.psql
@@ -93,7 +93,8 @@ BEGIN
 
   WITH required_policy_pairs(table_name, policy_name) AS (
     VALUES
-      ('Users', 'Users can view own profile'),
+      ('Users', 'Authenticated users can view public user info'),
+      ('Users', 'Anon users can view public user info'),
       ('Users', 'Service role can manage users'),
       ('Bots', 'Anyone can view bots'),
       ('Games', 'Players can view their games'),


### PR DESCRIPTION
## Summary
Sync `develop` into `main` to include final DB hardening follow-up from #79.

Included work:
- PR #84: consolidate `Users` SELECT RLS policies to remove `multiple_permissive_policies` warning
- updated `scripts/rls-smoke.psql` policy name checks

## Production state notes
- Prisma migration `20260226231000_consolidate_users_select_policies` has already been applied in production and verified.
- `npm run db:rls:smoke` passes after migration.
- Supabase advisors:
  - `security`: clean
  - `performance`: only accepted `INFO`s remain

## Why merge now
- keep `main` aligned with production DB hardening state and `develop`.
- restore branch parity after #84.

## Post-merge
- fast-forward `develop` to the merge commit so `main...develop = 0/0`.