### PR TITLE
fix(socket): unblock production startup when CRON_SECRET is missing

### DIFF
--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -42,4 +42,11 @@ describe('validateEnv', () => {
 
     expect(() => validateEnv()).not.toThrow()
   })
+
+  it('allows production socket runtime without CRON_SECRET when explicitly opted out', () => {
+    applyBaseEnv('production')
+    delete process.env.CRON_SECRET
+
+    expect(() => validateEnv({ requireCronSecretInProduction: false })).not.toThrow()
+  })
 })

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -56,11 +56,21 @@ const envSchema = z.object({
 
 export type Env = z.infer<typeof envSchema>
 
+interface ValidateEnvOptions {
+  requireCronSecretInProduction?: boolean
+  requireSocketInternalSecretInProduction?: boolean
+}
+
 /**
  * Validate environment variables on startup
  * Throws an error if validation fails
  */
-export function validateEnv(): Env {
+export function validateEnv(options: ValidateEnvOptions = {}): Env {
+  const {
+    requireCronSecretInProduction = true,
+    requireSocketInternalSecretInProduction = true,
+  } = options
+
   try {
     const env = envSchema.parse(process.env)
     
@@ -83,11 +93,11 @@ export function validateEnv(): Env {
         console.warn('⚠️  NEXTAUTH_SECRET not set. Auth token validation and guest socket auth may fail.')
       }
 
-      if (!env.SOCKET_SERVER_INTERNAL_SECRET) {
+      if (requireSocketInternalSecretInProduction && !env.SOCKET_SERVER_INTERNAL_SECRET) {
         throw new Error('SOCKET_SERVER_INTERNAL_SECRET is required in production')
       }
 
-      if (!env.CRON_SECRET) {
+      if (requireCronSecretInProduction && !env.CRON_SECRET) {
         throw new Error('CRON_SECRET is required in production')
       }
     }

--- a/socket-server.ts
+++ b/socket-server.ts
@@ -38,8 +38,8 @@ import {
   SocketRooms
 } from './types/socket-events'
 
-// Validate environment variables on startup
-validateEnv()
+// Socket runtime does not serve /api/cron routes, so CRON_SECRET is not required here.
+validateEnv({ requireCronSecretInProduction: false })
 printEnvInfo()
 
 const port = Number(process.env.PORT) || 3001


### PR DESCRIPTION
## Summary
- allow socket runtime to skip `CRON_SECRET` requirement in production env validation
- keep default validation strict for other runtimes (no global relaxation)
- add env validation test coverage for socket runtime behavior

## Why
Socket server deployment can fail in production when `CRON_SECRET` is missing, even though cron endpoints are handled by the Next.js app, not the standalone websocket service.

## Changes
- `validateEnv(options)` now supports runtime-specific production requirements
- `socket-server.ts` calls `validateEnv({ requireCronSecretInProduction: false })`
- added test: production socket runtime without `CRON_SECRET` when explicitly opted out

## Verification
- `npm test -- --runTestsByPath __tests__/lib/env.test.ts`
- `npm run ci:quick`
- pre-push hook checks passed
