### PR TITLE
docs(workflow): formalize task-branch to develop PR flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,7 @@ State flow:
 - **Auth and guest identity**: use `NEXTAUTH_SECRET` as primary signing secret. `JWT_SECRET` is deprecated; do not introduce new logic based on it. Guest identity must use signed tokens (`X-Guest-Token`), not raw client IDs/names.
 - **Realtime robustness**: protect timer/auto-action paths against duplicate processing, handle reconnect/out-of-order events defensively, and advance turn safely when the current player disconnects.
 - **Code quality**: keep TypeScript strictness and minimal readable changes. Keep comments in English and never put secrets in code or docs.
+- **Branching workflow**: for every ticket/feature/fix, create a dedicated branch from `develop` and open a PR back into `develop`. Do not commit task work directly to `develop` or `main`.
 
 ## High-priority areas when touching code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,13 @@ Core flow:
 - Be defensive around reconnects, duplicate events, and timer/auto-action paths.
 - Keep changes minimal and readable; avoid broad refactors unless requested.
 
+## Branch and PR Policy
+
+- For each ticket/feature/fix, create a dedicated branch from `develop` (for example `feature/<ticket>-<short-name>`, `fix/<ticket>-<short-name>`, `chore/<short-name>`).
+- Open PRs from task branches into `develop`. Do not push task commits directly to `develop`.
+- Promote to production only through PRs from `develop` into `main`.
+- Treat direct pushes to `main` and `develop` as emergency-only exceptions.
+
 ## Fast Command Cookbook
 
 Setup:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,10 +13,11 @@ npm run dev:all
 ## Workflow
 
 1. Pick a GitHub Issue.
-2. Create a branch.
+2. Create a dedicated branch from `develop` (`feature/*`, `fix/*`, or `chore/*`).
 3. Implement with tests.
 4. Run verification commands.
-5. Open PR with issue reference.
+5. Open PR into `develop` with issue reference.
+6. Release via PR from `develop` to `main` (no direct pushes to protected branches).
 
 ## Verification commands
 


### PR DESCRIPTION
## Summary
- define branch policy for agents/Codex: one task branch per ticket/feature/fix
- require PR flow into `develop` (no direct task pushes)
- document release flow from `develop` to `main`

## Files
- `AGENTS.md`
- `.github/copilot-instructions.md`
- `docs/CONTRIBUTING.md`

## Verification
- `npm run ci:quick`
- pre-push smoke checks passed
