### PR TITLE
fix(socket): unblock Render websocket startup without CRON_SECRET

### DIFF
--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -1,4 +1,4 @@
-import { validateEnv } from '@/lib/env'
+import { printEnvInfo, validateEnv } from '@/lib/env'
 
 describe('validateEnv', () => {
   const originalEnv = process.env
@@ -48,5 +48,12 @@ describe('validateEnv', () => {
     delete process.env.CRON_SECRET
 
     expect(() => validateEnv({ requireCronSecretInProduction: false })).not.toThrow()
+  })
+
+  it('allows printEnvInfo for socket runtime without CRON_SECRET when explicitly opted out', () => {
+    applyBaseEnv('production')
+    delete process.env.CRON_SECRET
+
+    expect(() => printEnvInfo({ requireCronSecretInProduction: false })).not.toThrow()
   })
 })

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -56,7 +56,7 @@ const envSchema = z.object({
 
 export type Env = z.infer<typeof envSchema>
 
-interface ValidateEnvOptions {
+export interface ValidateEnvOptions {
   requireCronSecretInProduction?: boolean
   requireSocketInternalSecretInProduction?: boolean
 }
@@ -142,8 +142,8 @@ export function getEnv(): Env {
 /**
  * Print environment configuration (with secrets masked)
  */
-export function printEnvInfo(): void {
-  const env = getEnv()
+export function printEnvInfo(options: ValidateEnvOptions = {}): void {
+  const env = validateEnv(options)
   
   console.log('🔧 Environment Configuration:')
   console.log(`  - NODE_ENV: ${env.NODE_ENV}`)

--- a/render.yaml
+++ b/render.yaml
@@ -23,6 +23,8 @@ services:
         sync: false
       - key: NEXTAUTH_SECRET
         sync: false
+      - key: SOCKET_SERVER_INTERNAL_SECRET
+        sync: false
       - key: GUEST_JWT_SECRET
         sync: false
     healthCheckPath: /health

--- a/socket-server.ts
+++ b/socket-server.ts
@@ -39,8 +39,9 @@ import {
 } from './types/socket-events'
 
 // Socket runtime does not serve /api/cron routes, so CRON_SECRET is not required here.
-validateEnv({ requireCronSecretInProduction: false })
-printEnvInfo()
+const socketEnvOptions = { requireCronSecretInProduction: false }
+validateEnv(socketEnvOptions)
+printEnvInfo(socketEnvOptions)
 
 const port = Number(process.env.PORT) || 3001
 const hostname = process.env.HOSTNAME || '0.0.0.0'


### PR DESCRIPTION
## Summary
- fix socket startup crash on Render caused by CRON_SECRET validation during env info logging
- make `printEnvInfo` accept validation options and use the same socket runtime options
- add regression test for `printEnvInfo({ requireCronSecretInProduction: false })`
- add `SOCKET_SERVER_INTERNAL_SECRET` to `render.yaml` env vars

## Root cause
Socket startup used:
1) `validateEnv({ requireCronSecretInProduction: false })` (correct), then
2) `printEnvInfo()` which re-validated env with strict defaults and required `CRON_SECRET`, causing crash.

## Verification
- `npm test -- --runTestsByPath __tests__/lib/env.test.ts`
- `npm run ci:quick`
- local production startup simulation no longer fails on missing `CRON_SECRET` for socket runtime
