### PR TITLE
docs(workflow): require post-merge branch cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -165,3 +165,4 @@ npx prisma migrate dev --name migration_name
 - [ ] I updated relevant documentation
 - [ ] My changes introduce no new warnings/errors
 - [ ] I reviewed changes for security risks
+- [ ] After merge, I will delete the local task branch (`git branch -d <branch>`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,7 @@ State flow:
 - **Auth and guest identity**: use `NEXTAUTH_SECRET` as primary signing secret. `JWT_SECRET` is deprecated; do not introduce new logic based on it. Guest identity must use signed tokens (`X-Guest-Token`), not raw client IDs/names.
 - **Realtime robustness**: protect timer/auto-action paths against duplicate processing, handle reconnect/out-of-order events defensively, and advance turn safely when the current player disconnects.
 - **Code quality**: keep TypeScript strictness and minimal readable changes. Keep comments in English and never put secrets in code or docs.
-- **Branching workflow**: for every ticket/feature/fix, create a dedicated branch from `develop` and open a PR back into `develop`. Do not commit task work directly to `develop` or `main`.
+- **Branching workflow**: for every ticket/feature/fix, create a dedicated branch from `develop` and open a PR back into `develop`. Do not commit task work directly to `develop` or `main`. After PR merge, delete the local task branch; remote source branches are auto-deleted by repository settings.
 
 ## High-priority areas when touching code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Core flow:
 - Open PRs from task branches into `develop`. Do not push task commits directly to `develop`.
 - Promote to production only through PRs from `develop` into `main`.
 - Treat direct pushes to `main` and `develop` as emergency-only exceptions.
+- After PR merge, delete the local task branch (`git branch -d <branch>`). The remote branch is auto-deleted by repository settings.
 
 ## Fast Command Cookbook
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,6 +18,7 @@ npm run dev:all
 4. Run verification commands.
 5. Open PR into `develop` with issue reference.
 6. Release via PR from `develop` to `main` (no direct pushes to protected branches).
+7. After PR merge, delete the local task branch (`git branch -d <branch>`). Remote source branches are auto-deleted by repository settings.
 
 ## Verification commands
 


### PR DESCRIPTION
## Summary
- add explicit branch-cleanup rule to AGENTS guide
- mirror the same rule in copilot instructions and CONTRIBUTING workflow
- add PR checklist reminder to delete local task branch after merge

## Validation
- npm run ci:quick
- pre-push checks (db:generate, check:locales, ci:quick, jest smoke)
