### PR TITLE
Release: fix hydration mismatch on locale bootstrap

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,18 +1,39 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { useEffect } from 'react'
 import { SessionProvider } from 'next-auth/react'
 import { ToastProvider } from '@/contexts/ToastContext'
 import { GuestProvider } from '@/contexts/GuestContext'
 import { Toaster } from 'react-hot-toast'
-import '@/i18n' // Initialize i18n
+import i18n, { availableLocales, defaultLocale } from '@/i18n'
 
 const DeferredGlobalEffects = dynamic(
   () => import('@/components/DeferredGlobalEffects'),
   { ssr: false }
 )
 
+function isAvailableLocale(value: string): value is (typeof availableLocales)[number] {
+  return (availableLocales as readonly string[]).includes(value)
+}
+
 export default function Providers({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const persistedLanguage =
+      localStorage.getItem('i18nextLng') || localStorage.getItem('language')
+
+    if (!persistedLanguage) return
+
+    const normalized = persistedLanguage.toLowerCase().split('-')[0]
+    const nextLanguage = isAvailableLocale(normalized)
+      ? normalized
+      : defaultLocale
+
+    if (i18n.language !== nextLanguage) {
+      void i18n.changeLanguage(nextLanguage)
+    }
+  }, [])
+
   return (
     <SessionProvider basePath="/api/auth">
       <GuestProvider>

--- a/i18n.ts
+++ b/i18n.ts
@@ -74,7 +74,9 @@ i18n
     },
     detection: {
       // Order of detection methods
-      order: ['localStorage', 'navigator', 'htmlTag'],
+      // Keep first client render aligned with SSR output (htmlTag from server),
+      // then switch to persisted language after hydration in Providers.
+      order: ['htmlTag'],
       caches: ['localStorage'],
       lookupLocalStorage: 'i18nextLng',
     },
@@ -86,4 +88,3 @@ i18n
 export default i18n
 export { availableLocales, defaultLocale }
 export type { Locale }
-


### PR DESCRIPTION
## Summary
- prevent initial hydration mismatch caused by language detection before hydration
- keep initial client language aligned with SSR output
- apply persisted language (`i18nextLng` / `language`) after hydration in Providers

## Validation
- npm run ci:quick
- pre-push checks (db:generate, check:locales, ci:quick, jest smoke)
