### PR TITLE
[Ticket #128] Optimize bot handoff and reduce idle delay before actions

### DIFF
--- a/__tests__/api/game-state.test.ts
+++ b/__tests__/api/game-state.test.ts
@@ -454,10 +454,14 @@ describe('POST /api/game/[gameId]/state', () => {
       }),
     )
     const [, requestInit] = mockFetch.mock.calls[0]
-    expect(JSON.parse(requestInit.body)).toEqual({
-      botUserId: 'bot-1',
-      lobbyCode: 'ABCD12',
-    })
+    expect(JSON.parse(requestInit.body)).toEqual(
+      expect.objectContaining({
+        botUserId: 'bot-1',
+        lobbyCode: 'ABCD12',
+        triggerSource: 'state-route-auto',
+        triggeredAt: expect.any(Number),
+      })
+    )
   })
 
   it('auto-triggers RPS bot turn when bot has not submitted choice', async () => {
@@ -526,6 +530,84 @@ describe('POST /api/game/[gameId]/state', () => {
       expect.objectContaining({
         method: 'POST',
       }),
+    )
+    const [, requestInit] = mockFetch.mock.calls[0]
+    expect(JSON.parse(requestInit.body)).toEqual(
+      expect.objectContaining({
+        botUserId: 'bot-1',
+        lobbyCode: 'ABCD12',
+        triggerSource: 'state-route-auto',
+        triggeredAt: expect.any(Number),
+      })
+    )
+  })
+
+  it('auto-triggers Yahtzee bot turn when next player is bot', async () => {
+    const yahtzeeState = {
+      ...persistedState,
+      status: 'playing',
+      currentPlayerIndex: 1,
+      lastMoveAt: Date.now(),
+      data: {
+        ...persistedState.data,
+        rollsLeft: 3,
+      },
+    }
+
+    const yahtzeeDbGame = {
+      ...dbGame,
+      lobby: {
+        ...dbGame.lobby,
+        gameType: 'yahtzee',
+      },
+      players: [
+        { id: 'db-player-1', userId: 'player-1', user: { id: 'player-1', bot: null } },
+        {
+          id: 'db-player-bot',
+          userId: 'bot-1',
+          user: { id: 'bot-1', bot: { id: 'bot-meta-1' } },
+        },
+      ],
+    }
+
+    const mockEngine = {
+      makeMove: jest.fn().mockReturnValue(true),
+      getState: jest.fn(() => yahtzeeState),
+      getCurrentPlayer: jest.fn(() => ({ id: 'bot-1' })),
+      getPlayers: jest.fn(() => [
+        { id: 'player-1', score: 0 },
+        { id: 'bot-1', score: 0 },
+      ]),
+      getScorecard: jest.fn(() => ({})),
+    }
+
+    mockGetRequestAuthUser.mockResolvedValue(mockAuthUser)
+    mockPrisma.games.findUnique.mockResolvedValueOnce(yahtzeeDbGame as any)
+    mockPrisma.games.updateMany.mockResolvedValue({ count: 1 } as any)
+    mockPrisma.players.update.mockResolvedValue({} as any)
+    mockRestoreGameEngine.mockReturnValue(mockEngine as any)
+
+    const response = await POST(buildRequest({
+      move: { type: 'score', data: { category: 'chance' } },
+    }), {
+      params: Promise.resolve({ gameId: 'game-123' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/api/game/game-123/bot-turn',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    )
+    const [, requestInit] = mockFetch.mock.calls[0]
+    expect(JSON.parse(requestInit.body)).toEqual(
+      expect.objectContaining({
+        botUserId: 'bot-1',
+        lobbyCode: 'ABCD12',
+        triggerSource: 'state-route-auto',
+        triggeredAt: expect.any(Number),
+      })
     )
   })
 })

--- a/app/api/game/[gameId]/bot-turn/route.ts
+++ b/app/api/game/[gameId]/bot-turn/route.ts
@@ -26,7 +26,18 @@ export async function POST(
   try {
     const paramsData = await params
     gameId = paramsData.gameId
-    const { botUserId, lobbyCode } = await request.json()
+    const requestBody = await request.json()
+    const { botUserId, lobbyCode, triggerSource, triggeredAt, turnEndToBotTriggerMs } = requestBody
+    const resolvedTriggerSource =
+      typeof triggerSource === 'string' && triggerSource.length > 0 ? triggerSource : 'unknown'
+    const normalizedTriggeredAt =
+      typeof triggeredAt === 'number' && Number.isFinite(triggeredAt) ? triggeredAt : null
+    const triggerToBotApiLatencyMs =
+      normalizedTriggeredAt !== null ? Math.max(0, Date.now() - normalizedTriggeredAt) : null
+    const normalizedTurnEndToBotTriggerMs =
+      typeof turnEndToBotTriggerMs === 'number' && Number.isFinite(turnEndToBotTriggerMs)
+        ? Math.max(0, turnEndToBotTriggerMs)
+        : null
 
     if (!botUserId) {
       return NextResponse.json({ error: 'Bot user ID required' }, { status: 400 })
@@ -34,7 +45,10 @@ export async function POST(
 
     log.info('Bot turn endpoint called', {
       gameId: gameId,
-      botUserId
+      botUserId,
+      triggerSource: resolvedTriggerSource,
+      triggerToBotApiLatencyMs,
+      turnEndToBotTriggerMs: normalizedTurnEndToBotTriggerMs,
     })
 
     // Check if bot turn is already in progress for this game

--- a/app/api/game/[gameId]/state/route.ts
+++ b/app/api/game/[gameId]/state/route.ts
@@ -24,6 +24,7 @@ const autoActionDebounceMap = new Map<string, number>()
 const AUTO_ACTION_DEBOUNCE_MS = 2000
 const AUTO_ACTION_DEBOUNCE_TTL_MS = 60000
 const STATE_CHANGE_NOTIFY_TIMEOUT_MS = 750
+const BOT_TURN_TRIGGER_TIMEOUT_MS = 15000
 
 function normalizeTimestamp(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) return value
@@ -78,6 +79,86 @@ function shouldDebounceAutoAction(key: string): boolean {
   }
 
   return false
+}
+
+function resolveTurnEndToBotTriggerMs(state: unknown, triggeredAt: number): number | null {
+  const stateRecord = typeof state === 'object' && state !== null
+    ? (state as Record<string, unknown>)
+    : null
+  const lastMoveAt = normalizeTimestamp(stateRecord?.lastMoveAt)
+  if (lastMoveAt === null) return null
+
+  const latencyMs = triggeredAt - lastMoveAt
+  return Number.isFinite(latencyMs) && latencyMs >= 0 ? latencyMs : null
+}
+
+function autoTriggerBotTurn(params: {
+  request: NextRequest
+  log: ReturnType<typeof apiLogger>
+  gameId: string
+  gameType: string
+  lobbyCode: string
+  botUserId: string
+  moveType: string
+  authoritativeState: unknown
+}) {
+  const { request, log, gameId, gameType, lobbyCode, botUserId, moveType, authoritativeState } = params
+  const botTurnApiUrl = `${request.nextUrl.origin}/api/game/${gameId}/bot-turn`
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), BOT_TURN_TRIGGER_TIMEOUT_MS)
+  const triggeredAt = Date.now()
+  const turnEndToBotTriggerMs = resolveTurnEndToBotTriggerMs(authoritativeState, triggeredAt)
+
+  log.debug('Auto-triggering bot turn after player move', {
+    gameId,
+    gameType,
+    botUserId,
+    moveType,
+    turnEndToBotTriggerMs,
+  })
+
+  void fetch(botTurnApiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      botUserId,
+      lobbyCode,
+      triggerSource: 'state-route-auto',
+      triggeredAt,
+      turnEndToBotTriggerMs,
+    }),
+    signal: controller.signal,
+  })
+    .then(async (botResponse) => {
+      clearTimeout(timeoutId)
+      if (!botResponse.ok) {
+        const errorPayload = await botResponse.json().catch(() => null)
+        log.warn('Auto-triggered bot turn failed', {
+          gameId,
+          botUserId,
+          status: botResponse.status,
+          error: errorPayload,
+        })
+      }
+    })
+    .catch((triggerError) => {
+      clearTimeout(timeoutId)
+      if ((triggerError as Error)?.name === 'AbortError') {
+        log.warn('Auto-triggered bot turn request timed out', {
+          gameId,
+          botUserId,
+        })
+        return
+      }
+
+      log.warn('Failed to auto-trigger bot turn request', {
+        gameId,
+        botUserId,
+        error: triggerError,
+      })
+    })
 }
 
 export async function POST(
@@ -435,6 +516,43 @@ export async function POST(
       })
     })
 
+    const requestPlayerIsBot = !!playerRecord.user?.bot
+    const botPlayers = gamePlayers.filter((player) => !!player.user?.bot)
+    let botUserIdToTrigger: string | null = null
+
+    if (!requestPlayerIsBot && authoritativeState.status === 'playing' && botPlayers.length > 0) {
+      if (game.lobby.gameType === 'rock_paper_scissors' && gameMove.type === 'submit-choice') {
+        const rpsData = (authoritativeState as { data?: { playersReady?: string[] } }).data
+        const playersReady = Array.isArray(rpsData?.playersReady) ? rpsData.playersReady : []
+        const pendingBot = botPlayers.find((player) => !playersReady.includes(player.userId))
+        if (pendingBot) {
+          botUserIdToTrigger = pendingBot.userId
+        }
+      } else if (
+        game.lobby.gameType === 'tic_tac_toe' ||
+        game.lobby.gameType === 'yahtzee'
+      ) {
+        const currentPlayerId = enginePlayers[authoritativeState.currentPlayerIndex]?.id
+        const currentBotPlayer = botPlayers.find((player) => player.userId === currentPlayerId)
+        if (currentBotPlayer) {
+          botUserIdToTrigger = currentBotPlayer.userId
+        }
+      }
+    }
+
+    if (botUserIdToTrigger) {
+      autoTriggerBotTurn({
+        request,
+        log,
+        gameId,
+        gameType: game.lobby.gameType,
+        lobbyCode: game.lobby.code,
+        botUserId: botUserIdToTrigger,
+        moveType: gameMove.type,
+        authoritativeState,
+      })
+    }
+
     const scoreSyncPromise = changedPlayerUpdates.length > 0
       ? Promise.all(changedPlayerUpdates)
       : Promise.resolve([])
@@ -459,79 +577,6 @@ export async function POST(
         lobbyCode: game.lobby.code,
         userId,
       })
-    }
-
-    const requestPlayerIsBot = !!playerRecord.user?.bot
-    const botPlayers = gamePlayers.filter((player) => !!player.user?.bot)
-    let botUserIdToTrigger: string | null = null
-
-    if (!requestPlayerIsBot && authoritativeState.status === 'playing' && botPlayers.length > 0) {
-      if (game.lobby.gameType === 'tic_tac_toe') {
-        const currentPlayerId = enginePlayers[authoritativeState.currentPlayerIndex]?.id
-        const currentBotPlayer = botPlayers.find((player) => player.userId === currentPlayerId)
-        if (currentBotPlayer) {
-          botUserIdToTrigger = currentBotPlayer.userId
-        }
-      } else if (game.lobby.gameType === 'rock_paper_scissors' && gameMove.type === 'submit-choice') {
-        const rpsData = (authoritativeState as { data?: { playersReady?: string[] } }).data
-        const playersReady = Array.isArray(rpsData?.playersReady) ? rpsData.playersReady : []
-        const pendingBot = botPlayers.find((player) => !playersReady.includes(player.userId))
-        if (pendingBot) {
-          botUserIdToTrigger = pendingBot.userId
-        }
-      }
-    }
-
-    if (botUserIdToTrigger) {
-      const botTurnApiUrl = `${request.nextUrl.origin}/api/game/${gameId}/bot-turn`
-      const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), 30000)
-
-      log.debug('Auto-triggering bot turn after player move', {
-        gameId,
-        gameType: game.lobby.gameType,
-        botUserId: botUserIdToTrigger,
-      })
-
-      void fetch(botTurnApiUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          botUserId: botUserIdToTrigger,
-          lobbyCode: game.lobby.code,
-        }),
-        signal: controller.signal,
-      })
-        .then(async (botResponse) => {
-          clearTimeout(timeoutId)
-          if (!botResponse.ok) {
-            const errorPayload = await botResponse.json().catch(() => null)
-            log.warn('Auto-triggered bot turn failed', {
-              gameId,
-              botUserId: botUserIdToTrigger,
-              status: botResponse.status,
-              error: errorPayload,
-            })
-          }
-        })
-        .catch((triggerError) => {
-          clearTimeout(timeoutId)
-          if ((triggerError as Error)?.name === 'AbortError') {
-            log.warn('Auto-triggered bot turn request timed out', {
-              gameId,
-              botUserId: botUserIdToTrigger,
-            })
-            return
-          }
-
-          log.warn('Failed to auto-trigger bot turn request', {
-            gameId,
-            botUserId: botUserIdToTrigger,
-            error: triggerError,
-          })
-        })
     }
 
     const response = {


### PR DESCRIPTION
## Summary
This PR implements the first optimization slice for #128 (bot handoff latency):

1. **Server auto-trigger path now includes Yahtzee**
- `POST /api/game/[gameId]/state` now auto-triggers `/bot-turn` for `yahtzee` (in addition to existing `tic_tac_toe` and `rock_paper_scissors` behavior).

2. **Bot trigger starts earlier in the move pipeline**
- Bot trigger dispatch is now fired immediately after authoritative state is computed and persisted, before waiting on score sync + socket broadcast completion.
- This removes avoidable technical idle between “human move accepted” and “bot starts acting”.

3. **Added handoff telemetry fields**
- State route sends `triggerSource`, `triggeredAt`, and `turnEndToBotTriggerMs` with bot trigger payload.
- Bot-turn route logs `triggerToBotApiLatencyMs` and `turnEndToBotTriggerMs` for timing visibility.

4. **Regression test coverage expanded**
- Updated existing bot-trigger payload assertions.
- Added Yahtzee integration-style API test: auto-trigger when next player is bot.

## Files changed
- `app/api/game/[gameId]/state/route.ts`
- `app/api/game/[gameId]/bot-turn/route.ts`
- `__tests__/api/game-state.test.ts`

## Validation
- `npm test -- __tests__/api/game-state.test.ts --runInBand`
- `npm run ci:quick`
- pre-push hook full run passed (`db:generate`, locale parity, `ci:quick`, jest smoke)

## Issue linkage
- Closes part of #128