### PR TITLE
[Ticket #130] Harden lobby lifecycle handling for terminal game states

### DIFF
--- a/__tests__/api/lobby-code.test.ts
+++ b/__tests__/api/lobby-code.test.ts
@@ -188,6 +188,23 @@ describe('GET /api/lobby/[code]', () => {
     expect(data.error).toBe('Lobby not found')
   })
 
+  it('should include terminal statuses when includeFinished=true', async () => {
+    mockPrisma.lobbies.findUnique.mockResolvedValue(mockLobby as any)
+
+    const request = new NextRequest('http://localhost:3000/api/lobby/ABC123?includeFinished=true')
+    const response = await GET(request, { params: { code: 'ABC123' } })
+    expect(response.status).toBe(200)
+
+    const queryArgs = mockPrisma.lobbies.findUnique.mock.calls[0][0] as any
+    expect(queryArgs.select.games.where.status.in).toEqual([
+      'waiting',
+      'playing',
+      'finished',
+      'abandoned',
+      'cancelled',
+    ])
+  })
+
   it('should handle database errors gracefully', async () => {
     mockPrisma.lobbies.findUnique.mockRejectedValue(new Error('Database error'))
 

--- a/__tests__/lib/lobby-snapshot.test.ts
+++ b/__tests__/lib/lobby-snapshot.test.ts
@@ -34,6 +34,24 @@ describe('lobby snapshot helpers', () => {
     expect((pickRelevantLobbyGame(games, { includeFinished: true }) as any)?.id).toBe('finished-1')
   })
 
+  it('includes abandoned/cancelled games when includeFinished=true', () => {
+    const games = [
+      {
+        id: 'cancelled-1',
+        status: 'cancelled',
+        updatedAt: '2026-02-13T11:00:00.000Z',
+      },
+      {
+        id: 'abandoned-1',
+        status: 'abandoned',
+        updatedAt: '2026-02-13T12:00:00.000Z',
+      },
+    ] as any[]
+
+    expect(pickRelevantLobbyGame(games)).toBeNull()
+    expect((pickRelevantLobbyGame(games, { includeFinished: true }) as any)?.id).toBe('abandoned-1')
+  })
+
   it('normalizes payload using activeGame fallback chain', () => {
     const payload = {
       lobby: {

--- a/app/api/lobby/[code]/route.ts
+++ b/app/api/lobby/[code]/route.ts
@@ -84,7 +84,7 @@ export async function GET(
           where: {
             status: {
               in: includeFinished
-                ? ['waiting', 'playing', 'finished']
+                ? ['waiting', 'playing', 'finished', 'abandoned', 'cancelled']
                 : ['waiting', 'playing'],
             },
           },

--- a/app/lobby/[code]/page.tsx
+++ b/app/lobby/[code]/page.tsx
@@ -129,6 +129,8 @@ const RockPaperScissorsLobbyPage = dynamic(() => import('./rock-paper-scissors-p
 
 const LEAVE_REQUEST_TIMEOUT_MS = 2500
 const LEAVE_REDIRECT_FALLBACK_MS = 1500
+const TERMINAL_GAME_STATUSES = new Set(['abandoned', 'cancelled'])
+const LIFECYCLE_REDIRECT_FALLBACK_MS = 1600
 
 function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage?: (gameType: string) => void }) {
   const router = useRouter()
@@ -228,6 +230,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
   // Track if this is initial page load to prevent sounds during hydration
   const isInitialLoadRef = React.useRef(true)
   const isLeavingLobbyRef = React.useRef(false)
+  const lifecycleRedirectInFlightRef = React.useRef(false)
   const finishedGameSoundPlayedForRef = React.useRef<string | null>(null)
   const initializedMobileUiGameIdRef = React.useRef<string | null>(null)
   const hasLobbyPageInteractionRef = React.useRef(false)
@@ -277,13 +280,13 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     []
   )
 
-  const leaveRedirectTarget = React.useMemo(
-    () => `/games/${lobby?.gameType || DEFAULT_GAME_TYPE}/lobbies`,
+  const lifecycleRedirectTarget = React.useMemo(
+    () => `/games/${(lobby?.gameType as string) || DEFAULT_GAME_TYPE}/lobbies`,
     [lobby?.gameType]
   )
 
   const navigateAfterLeave = React.useCallback(() => {
-    router.replace(leaveRedirectTarget)
+    router.replace(lifecycleRedirectTarget)
 
     if (typeof window === 'undefined') {
       return
@@ -291,14 +294,45 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
 
     window.setTimeout(() => {
       if (window.location.pathname.startsWith(`/lobby/${code}`)) {
-        window.location.assign(leaveRedirectTarget)
+        window.location.assign(lifecycleRedirectTarget)
       }
     }, LEAVE_REDIRECT_FALLBACK_MS)
-  }, [router, leaveRedirectTarget, code])
+  }, [router, lifecycleRedirectTarget, code])
 
   useEffect(() => {
-    void router.prefetch(leaveRedirectTarget)
-  }, [router, leaveRedirectTarget])
+    void router.prefetch(lifecycleRedirectTarget)
+  }, [router, lifecycleRedirectTarget])
+
+  const triggerLifecycleRedirect = React.useCallback(
+    (reason: string, options?: { toastKey?: string }) => {
+      if (isLeavingLobbyRef.current || lifecycleRedirectInFlightRef.current) {
+        return
+      }
+
+      lifecycleRedirectInFlightRef.current = true
+
+      if (options?.toastKey) {
+        showToast.error(options.toastKey, undefined, undefined, { id: 'lifecycle-redirect' })
+      }
+
+      clientLogger.warn('Triggering lobby lifecycle redirect', {
+        code,
+        reason,
+        target: lifecycleRedirectTarget,
+      })
+
+      router.replace(lifecycleRedirectTarget)
+
+      if (typeof window !== 'undefined') {
+        window.setTimeout(() => {
+          if (window.location.pathname.startsWith(`/lobby/${code}`)) {
+            window.location.assign(lifecycleRedirectTarget)
+          }
+        }, LIFECYCLE_REDIRECT_FALLBACK_MS)
+      }
+    },
+    [router, lifecycleRedirectTarget, code]
+  )
 
   // Helper functions
   const getCurrentUserId = useCallback(() => {
@@ -386,6 +420,15 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
         const parsedState = typeof state === 'string'
           ? JSON.parse(state)
           : state
+
+        const parsedStatus =
+          typeof parsedState?.status === 'string' ? parsedState.status : null
+        if (parsedStatus && TERMINAL_GAME_STATUSES.has(parsedStatus)) {
+          triggerLifecycleRedirect(`game-update:${parsedStatus}`, {
+            toastKey: 'lobby.gameAbandoned',
+          })
+          return
+        }
 
         if (game?.id) {
           const gt = lobby?.gameType as string || DEFAULT_GAME_TYPE
@@ -513,7 +556,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     } else {
       clientLogger.warn('📡 game-update received but no state found:', payload)
     }
-  }, [game?.id, game?.players, gameEngine, getCurrentUserId, lobby?.gameType, playAmbientSound])
+  }, [game?.id, game?.players, gameEngine, getCurrentUserId, lobby?.gameType, playAmbientSound, triggerLifecycleRedirect])
 
   const onChatMessage = useCallback((message: ChatMessagePayload) => {
     setChatMessages(prev => [...prev, message])
@@ -635,40 +678,44 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
       return
     }
 
-    const reason = data.reason
-    if (reason === 'no_human_players') {
-      showToast.error('lobby.gameAbandoned')
-    } else if (reason === 'insufficient_players') {
-      showToast.error('lobby.gameAbandoned')
-    }
-
-    // Refresh lobby data
     if (loadLobbyRef.current) {
-      loadLobbyRef.current()
+      void loadLobbyRef.current()
     }
 
-    // Navigate back to lobby list after a short delay
-    setTimeout(() => {
-      router.push(`/games/${lobby?.gameType as string || DEFAULT_GAME_TYPE}/lobbies`)
-    }, 3000)
-  }, [router, lobby])
+    triggerLifecycleRedirect(`game-abandoned:${data.reason || 'unknown'}`, {
+      toastKey: 'lobby.gameAbandoned',
+    })
+  }, [triggerLifecycleRedirect])
 
-  const onPlayerLeft = useCallback((data: { userId: string; username: string }) => {
+  const onPlayerLeft = useCallback((data: {
+    userId: string
+    username?: string
+    playerName?: string
+    remainingPlayers?: number
+  }) => {
     clientLogger.log('📡 Player left:', data)
 
     if (isLeavingLobbyRef.current) {
       return
     }
 
-    if (data.username) {
-      showToast.info('toast.playerLeft', undefined, { player: data.username })
+    const departedPlayerName = data.username || data.playerName
+    if (departedPlayerName) {
+      showToast.info('toast.playerLeft', undefined, { player: departedPlayerName })
+    }
+
+    if (typeof data.remainingPlayers === 'number' && data.remainingPlayers <= 1) {
+      triggerLifecycleRedirect('player-left:insufficient-players', {
+        toastKey: 'lobby.gameAbandoned',
+      })
+      return
     }
 
     // Refresh lobby data
     if (loadLobbyRef.current) {
-      loadLobbyRef.current()
+      void loadLobbyRef.current()
     }
-  }, [])
+  }, [triggerLifecycleRedirect])
 
   const currentUserIdForMembership = isGuest ? guestId : session?.user?.id
   const canJoinSocketLobbyRoom = React.useMemo(() => {
@@ -681,7 +728,10 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
       return true
     }
 
-    const activeGameFromState = game
+    const activeGameFromState =
+      game && ['waiting', 'playing', 'finished'].includes(String(game.status))
+        ? game
+        : null
     const activeGameFromLobby = Array.isArray(lobbyData.games)
       ? lobbyData.games.find((candidate: any) => ['waiting', 'playing'].includes(candidate?.status))
       : null
@@ -1241,6 +1291,30 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     (isGuest && p.userId === guestId)
   )
   const isGameStarted = game?.status === 'playing'
+
+  useEffect(() => {
+    if (isLeavingLobbyRef.current) {
+      return
+    }
+
+    const lobbyIsInactive = !!lobby && (lobby as any).isActive === false
+    const currentGameStatus = typeof game?.status === 'string' ? game.status : null
+    const isTerminalGameStatus =
+      typeof currentGameStatus === 'string' && TERMINAL_GAME_STATUSES.has(currentGameStatus)
+
+    if (isTerminalGameStatus) {
+      triggerLifecycleRedirect(`local-game-status:${currentGameStatus}`, {
+        toastKey: 'lobby.gameAbandoned',
+      })
+      return
+    }
+
+    if (lobbyIsInactive && currentGameStatus !== 'playing' && currentGameStatus !== 'waiting') {
+      triggerLifecycleRedirect('local-lobby-inactive', {
+        toastKey: 'lobby.gameAbandoned',
+      })
+    }
+  }, [game?.status, lobby, triggerLifecycleRedirect])
 
   // Reset mobile-only UI state when a new Yahtzee game starts without a page reload
   // (e.g. host starts game, rematch starts, or socket-driven transition).

--- a/lib/lobby-snapshot.ts
+++ b/lib/lobby-snapshot.ts
@@ -1,4 +1,4 @@
-type LobbyGameStatus = 'waiting' | 'playing' | 'finished'
+type LobbyGameStatus = 'waiting' | 'playing' | 'finished' | 'abandoned' | 'cancelled'
 
 interface LobbyGameLike {
   status?: string | null
@@ -23,10 +23,14 @@ export interface NormalizedLobbySnapshot {
 function getStatusPriority(status: string | null | undefined, includeFinished: boolean): number {
   switch (status) {
     case 'playing':
-      return 3
+      return 5
     case 'waiting':
-      return 2
+      return 4
     case 'finished':
+      return includeFinished ? 3 : 0
+    case 'abandoned':
+      return includeFinished ? 2 : 0
+    case 'cancelled':
       return includeFinished ? 1 : 0
     default:
       return 0
@@ -84,5 +88,11 @@ export function normalizeLobbySnapshotResponse(
 }
 
 export function isLobbyGameStatus(value: unknown): value is LobbyGameStatus {
-  return value === 'waiting' || value === 'playing' || value === 'finished'
+  return (
+    value === 'waiting' ||
+    value === 'playing' ||
+    value === 'finished' ||
+    value === 'abandoned' ||
+    value === 'cancelled'
+  )
 }


### PR DESCRIPTION
## Summary
This PR delivers the first hardening slice for #130 focused on terminal lifecycle consistency (`abandoned` / `cancelled`) and bounded redirects.

### 1) Terminal lifecycle redirect path is now explicit and idempotent in lobby UI
Updated:
- `app/lobby/[code]/page.tsx`

Changes:
- Added a single `triggerLifecycleRedirect(...)` path guarded by an in-flight ref to prevent duplicate redirect races/toast storms.
- Added terminal-state handling on:
  - incoming `game-update` payloads (`abandoned` / `cancelled`)
  - `game-abandoned` socket event
  - local state observer (`game.status` terminal or inactive lobby without active waiting/playing game)
- Added hard navigation fallback if client-side route transition does not complete in time.
- Improved `player-left` handling:
  - accepts both `username` and `playerName` payload variants
  - triggers lifecycle exit when `remainingPlayers <= 1` as a safeguard.
- Socket-room membership guard now ignores terminal states (`abandoned/cancelled`) to avoid stale room joins.

### 2) Snapshot/API layer now surfaces terminal statuses for lifecycle resolution
Updated:
- `lib/lobby-snapshot.ts`
- `app/api/lobby/[code]/route.ts`

Changes:
- `pickRelevantLobbyGame(..., { includeFinished: true })` now includes and prioritizes terminal statuses (`abandoned`, `cancelled`) behind active states.
- `GET /api/lobby/[code]?includeFinished=true` now queries terminal game statuses as well.

### 3) Tests
Updated:
- `__tests__/lib/lobby-snapshot.test.ts`
- `__tests__/api/lobby-code.test.ts`

Coverage added:
- terminal status selection behavior in snapshot helper
- API query assertion that `includeFinished=true` includes `abandoned/cancelled`

## Validation
- `npm test -- __tests__/lib/lobby-snapshot.test.ts __tests__/api/lobby-code.test.ts --runInBand`
- `npm test -- __tests__/app/useLobbyRouteState.test.ts --runInBand`
- `npm run ci:quick`
- pre-push hook full run passed

## Issue linkage
- Closes part of #130