### PR TITLE
[Ticket #129] Add leave redirect telemetry and harden host/bot-only leave branches

### DIFF
--- a/__tests__/api/lobby-code.test.ts
+++ b/__tests__/api/lobby-code.test.ts
@@ -428,6 +428,73 @@ describe('POST /api/lobby/[code]/leave', () => {
     })
   })
 
+  it('deactivates waiting lobby when host leaves and only bot players remain', async () => {
+    const waitingLobbyWithHostAndBot = {
+      ...mockLobby,
+      creatorId: 'user-123',
+      games: [
+        {
+          id: 'game-123',
+          status: 'waiting',
+          players: [
+            {
+              id: 'player-host',
+              userId: 'user-123',
+              gameId: 'game-123',
+              user: {
+                id: 'user-123',
+                username: 'host-user',
+                bot: null,
+              },
+            },
+            {
+              id: 'player-bot',
+              userId: 'bot-user-1',
+              gameId: 'game-123',
+              user: {
+                id: 'bot-user-1',
+                username: 'ai-bot',
+                bot: { id: 'bot-1' },
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    mockGetServerSession.mockResolvedValue(mockSession as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-123',
+      username: 'host-user',
+      suspended: false,
+    } as any)
+    mockPrisma.lobbies.findUnique.mockResolvedValue(waitingLobbyWithHostAndBot as any)
+    mockPrisma.players.delete.mockResolvedValue({ id: 'player-host' } as any)
+    mockPrisma.players.count
+      .mockResolvedValueOnce(1) // remaining players (bot only)
+      .mockResolvedValueOnce(0) // remaining human players
+
+    const request = new NextRequest('http://localhost:3000/api/lobby/ABC123/leave', {
+      method: 'POST',
+    })
+    const response = await LEAVE(request, { params: { code: 'ABC123' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(
+      expect.objectContaining({
+        gameEnded: false,
+        lobbyDeactivated: true,
+      })
+    )
+    expect(mockPrisma.lobbies.update).toHaveBeenCalledWith({
+      where: { id: 'lobby-123' },
+      data: { isActive: false },
+    })
+    expect(mockPrisma.games.update).not.toHaveBeenCalled()
+    expect(mockNotifySocket).not.toHaveBeenCalled()
+  })
+
   it('should return success when player is already absent from lobby', async () => {
     const lobbyWithoutPlayer = {
       ...mockLobby,
@@ -576,5 +643,80 @@ describe('POST /api/lobby/[code]/leave', () => {
     )
 
     resolveNotify?.(true)
+  })
+
+  it('abandons playing game when leave results in bot-only players', async () => {
+    const playingLobbyWithBotLeft = {
+      ...mockLobby,
+      games: [
+        {
+          id: 'game-123',
+          status: 'playing',
+          players: [
+            {
+              id: 'player-human',
+              userId: 'user-123',
+              gameId: 'game-123',
+              user: {
+                id: 'user-123',
+                username: 'testuser',
+                bot: null,
+              },
+            },
+            {
+              id: 'player-bot',
+              userId: 'bot-user-1',
+              gameId: 'game-123',
+              user: {
+                id: 'bot-user-1',
+                username: 'ai-bot',
+                bot: { id: 'bot-1' },
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    mockGetServerSession.mockResolvedValue(mockSession as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-123',
+      username: 'testuser',
+      suspended: false,
+    } as any)
+    mockPrisma.lobbies.findUnique.mockResolvedValue(playingLobbyWithBotLeft as any)
+    mockPrisma.players.delete.mockResolvedValue({ id: 'player-human' } as any)
+    mockPrisma.players.count
+      .mockResolvedValueOnce(1) // remaining players
+      .mockResolvedValueOnce(0) // remaining human players
+    mockPrisma.games.update.mockResolvedValue({ id: 'game-123', status: 'abandoned' } as any)
+    mockPrisma.lobbies.update.mockResolvedValue({ id: 'lobby-123', isActive: false } as any)
+
+    const request = new NextRequest('http://localhost:3000/api/lobby/ABC123/leave', {
+      method: 'POST',
+    })
+    const response = await LEAVE(request, { params: { code: 'ABC123' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(
+      expect.objectContaining({
+        gameEnded: true,
+        gameAbandoned: true,
+        lobbyDeactivated: true,
+      })
+    )
+    expect(mockPrisma.games.update).toHaveBeenCalledWith({
+      where: { id: 'game-123' },
+      data: expect.objectContaining({
+        status: 'abandoned',
+      }),
+    })
+    expect(mockNotifySocket).toHaveBeenCalledWith(
+      'lobby:ABC123',
+      'game-abandoned',
+      expect.objectContaining({ reason: 'no_human_players' }),
+      0
+    )
   })
 })

--- a/__tests__/lib/analytics.test.ts
+++ b/__tests__/lib/analytics.test.ts
@@ -1,5 +1,6 @@
 import {
   MOVE_APPLY_TARGET_MS,
+  trackLobbyLeaveRedirect,
   trackMoveSubmitApplied,
   trackStartAloneAutoBotResult,
   trackSocketAuthRefreshFailed,
@@ -99,6 +100,28 @@ describe('analytics reliability alerts', () => {
       success: true,
       reason: 'started',
       is_guest: true,
+    })
+  })
+
+  it('tracks leave-to-redirect telemetry with navigation and API outcome metadata', () => {
+    trackLobbyLeaveRedirect({
+      durationMs: 188.2,
+      isGuest: false,
+      source: 'lobby_page',
+      navigation: 'window_assign_fallback',
+      apiOutcome: 'timeout',
+      statusCode: 504,
+      gameType: 'yahtzee',
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith('lobby_leave_redirect', {
+      latency_ms: 188,
+      is_guest: false,
+      source: 'lobby_page',
+      navigation: 'window_assign_fallback',
+      api_outcome: 'timeout',
+      status_code: 504,
+      game_type: 'yahtzee',
     })
   })
 })

--- a/app/lobby/[code]/page.tsx
+++ b/app/lobby/[code]/page.tsx
@@ -87,6 +87,7 @@ import { fetchWithGuest } from '@/lib/fetch-with-guest'
 import { getLobbyPlayerRequirements } from '@/lib/lobby-player-requirements'
 import { useLobbyRouteState } from './hooks/useLobbyRouteState'
 import type { BotDifficulty } from '@/lib/bot-profiles'
+import { trackLobbyLeaveRedirect } from '@/lib/analytics'
 
 function CenteredLoadingFallback() {
   return (
@@ -131,6 +132,7 @@ const LEAVE_REQUEST_TIMEOUT_MS = 2500
 const LEAVE_REDIRECT_FALLBACK_MS = 1500
 const TERMINAL_GAME_STATUSES = new Set(['abandoned', 'cancelled'])
 const LIFECYCLE_REDIRECT_FALLBACK_MS = 1600
+type LeaveApiOutcome = 'pending' | 'ok' | 'non_ok' | 'timeout' | 'error'
 
 function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage?: (gameType: string) => void }) {
   const router = useRouter()
@@ -234,6 +236,9 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
   const finishedGameSoundPlayedForRef = React.useRef<string | null>(null)
   const initializedMobileUiGameIdRef = React.useRef<string | null>(null)
   const hasLobbyPageInteractionRef = React.useRef(false)
+  const leaveStartedAtRef = React.useRef<number | null>(null)
+  const leaveApiOutcomeRef = React.useRef<LeaveApiOutcome>('pending')
+  const leaveApiStatusCodeRef = React.useRef<number | null>(null)
 
   // Mark initial load as complete after 2 seconds
   useEffect(() => {
@@ -285,8 +290,29 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     [lobby?.gameType]
   )
 
+  const trackLeaveRedirectEvent = React.useCallback(
+    (navigation: 'router_replace' | 'window_assign_fallback') => {
+      const leaveStartedAt = leaveStartedAtRef.current
+      if (leaveStartedAt === null) return
+
+      trackLobbyLeaveRedirect({
+        durationMs: Date.now() - leaveStartedAt,
+        isGuest,
+        source: 'lobby_page',
+        navigation,
+        apiOutcome: leaveApiOutcomeRef.current,
+        ...(typeof leaveApiStatusCodeRef.current === 'number'
+          ? { statusCode: leaveApiStatusCodeRef.current }
+          : {}),
+        ...(typeof lobby?.gameType === 'string' ? { gameType: lobby.gameType } : {}),
+      })
+    },
+    [isGuest, lobby?.gameType]
+  )
+
   const navigateAfterLeave = React.useCallback(() => {
     router.replace(lifecycleRedirectTarget)
+    trackLeaveRedirectEvent('router_replace')
 
     if (typeof window === 'undefined') {
       return
@@ -294,10 +320,11 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
 
     window.setTimeout(() => {
       if (window.location.pathname.startsWith(`/lobby/${code}`)) {
+        trackLeaveRedirectEvent('window_assign_fallback')
         window.location.assign(lifecycleRedirectTarget)
       }
     }, LEAVE_REDIRECT_FALLBACK_MS)
-  }, [router, lifecycleRedirectTarget, code])
+  }, [router, lifecycleRedirectTarget, code, trackLeaveRedirectEvent])
 
   useEffect(() => {
     void router.prefetch(lifecycleRedirectTarget)
@@ -1123,6 +1150,9 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
 
     isLeavingLobbyRef.current = true
     setShowLeaveConfirmModal(false)
+    leaveStartedAtRef.current = Date.now()
+    leaveApiOutcomeRef.current = 'pending'
+    leaveApiStatusCodeRef.current = null
 
     if (socket) {
       socket.emit('leave-lobby', code)
@@ -1142,9 +1172,11 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     })
       .then(async (res) => {
         clearTimeout(timeoutId)
+        leaveApiStatusCodeRef.current = res.status
         const data = await res.json().catch(() => null)
 
         if (!res.ok) {
+          leaveApiOutcomeRef.current = 'non_ok'
           clientLogger.warn('Leave lobby API returned non-ok status; using local redirect fallback', {
             code,
             status: res.status,
@@ -1153,6 +1185,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
           return
         }
 
+        leaveApiOutcomeRef.current = 'ok'
         if (data?.gameAbandoned) {
           showToast.info('lobby.gameAbandoned', undefined, undefined, { id: 'leave-lobby-result' })
           return
@@ -1163,6 +1196,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
       .catch((error) => {
         clearTimeout(timeoutId)
         if ((error as Error)?.name === 'AbortError') {
+          leaveApiOutcomeRef.current = 'timeout'
           clientLogger.warn('Leave lobby API timed out; local redirect already performed', {
             code,
             timeoutMs: LEAVE_REQUEST_TIMEOUT_MS,
@@ -1170,6 +1204,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
           return
         }
 
+        leaveApiOutcomeRef.current = 'error'
         clientLogger.warn('Leave lobby API failed; local redirect fallback used', {
           code,
           error,

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -19,7 +19,7 @@ import TicTacToeGameBoard from '@/components/TicTacToeGameBoard'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ConfirmModal from '@/components/ConfirmModal'
 import { Move } from '@/lib/game-engine'
-import { trackMoveSubmitApplied } from '@/lib/analytics'
+import { trackLobbyLeaveRedirect, trackMoveSubmitApplied } from '@/lib/analytics'
 
 interface Lobby {
     id: string
@@ -35,6 +35,7 @@ interface TicTacToeLobbyPageProps {
 
 const LEAVE_REQUEST_TIMEOUT_MS = 2500
 const LEAVE_REDIRECT_FALLBACK_MS = 1500
+type LeaveApiOutcome = 'pending' | 'ok' | 'non_ok' | 'timeout' | 'error'
 
 export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
     const router = useRouter()
@@ -51,9 +52,33 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
     const [isMoveSubmitting, setIsMoveSubmitting] = useState(false)
     const [isRematchSubmitting, setIsRematchSubmitting] = useState(false)
     const isLeavingLobbyRef = React.useRef(false)
+    const leaveStartedAtRef = React.useRef<number | null>(null)
+    const leaveApiOutcomeRef = React.useRef<LeaveApiOutcome>('pending')
+    const leaveApiStatusCodeRef = React.useRef<number | null>(null)
+
+    const trackLeaveRedirectEvent = useCallback(
+        (navigation: 'router_replace' | 'window_assign_fallback') => {
+            const leaveStartedAt = leaveStartedAtRef.current
+            if (leaveStartedAt === null) return
+
+            trackLobbyLeaveRedirect({
+                durationMs: Date.now() - leaveStartedAt,
+                isGuest,
+                source: 'tic_tac_toe_page',
+                navigation,
+                apiOutcome: leaveApiOutcomeRef.current,
+                ...(typeof leaveApiStatusCodeRef.current === 'number'
+                    ? { statusCode: leaveApiStatusCodeRef.current }
+                    : {}),
+                gameType: 'tic_tac_toe',
+            })
+        },
+        [isGuest]
+    )
 
     const navigateAfterLeave = useCallback(() => {
         router.replace('/games')
+        trackLeaveRedirectEvent('router_replace')
 
         if (typeof window === 'undefined') {
             return
@@ -61,10 +86,11 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
 
         window.setTimeout(() => {
             if (window.location.pathname.startsWith(`/lobby/${code}`)) {
+                trackLeaveRedirectEvent('window_assign_fallback')
                 window.location.assign('/games')
             }
         }, LEAVE_REDIRECT_FALLBACK_MS)
-    }, [router, code])
+    }, [router, code, trackLeaveRedirectEvent])
 
     useEffect(() => {
         void router.prefetch('/games')
@@ -354,6 +380,9 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
 
         isLeavingLobbyRef.current = true
         setShowLeaveConfirmModal(false)
+        leaveStartedAtRef.current = Date.now()
+        leaveApiOutcomeRef.current = 'pending'
+        leaveApiStatusCodeRef.current = null
 
         if (socket?.connected) {
             socket.emit('leave-lobby', code)
@@ -371,24 +400,30 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
         })
             .then(async (response) => {
                 clearTimeout(timeoutId)
+                leaveApiStatusCodeRef.current = response.status
                 if (!response.ok) {
+                    leaveApiOutcomeRef.current = 'non_ok'
                     const payload = await response.json().catch(() => null)
                     clientLogger.warn('Tic-Tac-Toe leave API returned non-ok status', {
                         code,
                         status: response.status,
                         payload,
                     })
+                } else {
+                    leaveApiOutcomeRef.current = 'ok'
                 }
             })
             .catch((error) => {
                 clearTimeout(timeoutId)
                 if ((error as Error)?.name === 'AbortError') {
+                    leaveApiOutcomeRef.current = 'timeout'
                     clientLogger.warn('Tic-Tac-Toe leave API timed out after redirect', {
                         code,
                         timeoutMs: LEAVE_REQUEST_TIMEOUT_MS,
                     })
                     return
                 }
+                leaveApiOutcomeRef.current = 'error'
                 clientLogger.warn('Tic-Tac-Toe leave API failed after redirect', {
                     code,
                     error,

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -101,6 +101,16 @@ interface StartAloneAutoBotResultEvent {
   isGuest: boolean
 }
 
+interface LobbyLeaveRedirectEvent {
+  durationMs: number
+  isGuest: boolean
+  source: 'lobby_page' | 'tic_tac_toe_page'
+  navigation: 'router_replace' | 'window_assign_fallback'
+  apiOutcome: 'pending' | 'ok' | 'non_ok' | 'timeout' | 'error'
+  statusCode?: number
+  gameType?: string
+}
+
 function normalizeDurationMs(value: number): number {
   if (!Number.isFinite(value)) return 0
   return Math.max(0, Math.round(value))
@@ -386,6 +396,25 @@ export function trackLobbyCreateReady(event: LobbyCreateReadyEvent): void {
       is_guest: event.isGuest,
     })
   }
+}
+
+export function trackLobbyLeaveRedirect(event: LobbyLeaveRedirectEvent): void {
+  const durationMs = normalizeDurationMs(event.durationMs)
+
+  track('lobby_leave_redirect', {
+    latency_ms: durationMs,
+    is_guest: event.isGuest,
+    source: event.source,
+    navigation: event.navigation,
+    api_outcome: event.apiOutcome,
+    ...(typeof event.statusCode === 'number' ? { status_code: event.statusCode } : {}),
+    ...(event.gameType ? { game_type: event.gameType } : {}),
+  })
+
+  clientLogger.log('[analytics] Lobby leave redirect', {
+    latencyMs: durationMs,
+    ...event,
+  })
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `lobby_leave_redirect` client telemetry with leave-to-redirect latency, navigation method, and leave API outcome metadata
- wire telemetry into leave handlers on the main lobby page and Tic-Tac-Toe dedicated page
- add regression tests for host leave in waiting lobby (bot-only remainder) and playing game -> bot-only abandonment path
- extend analytics unit tests for the new leave redirect event payload

## Why
Issue #129 required faster/more reliable leave flow plus explicit leave-to-redirect latency observability and lifecycle coverage across edge branches.

## Validation
- `npm test -- __tests__/lib/analytics.test.ts __tests__/api/lobby-code.test.ts --runInBand`
- `npm run ci:quick`
- pre-push hook suite (db:generate, locales check, ci:quick, jest smoke)

## Related
- Closes #129