### PR TITLE
[Ticket #128] Make bot UX delay configurable and reduce default idle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,25 @@ HOSTNAME=0.0.0.0
 # CORS Origins (comma-separated list of allowed origins)
 CORS_ORIGIN=http://localhost:3000,http://127.0.0.1:3000
 
+# ------------------------------------------------------------
+# BOT UX TIMING (Optional)
+# ------------------------------------------------------------
+# Controls artificial bot "human-like" delays.
+# Defaults if unset:
+# - BOT_UX_DELAY_SCALE=0.55
+# - BOT_UX_DELAY_MIN_MS=0
+# - BOT_UX_DELAY_MAX_MS=1200
+#
+# Force a fixed delay for all bot actions (overrides scale-based timing):
+# BOT_UX_DELAY_MS=180
+#
+# Scale all bot executor base delays (0 = no artificial delay):
+# BOT_UX_DELAY_SCALE=0.55
+#
+# Clamp final delay after scaling/override:
+# BOT_UX_DELAY_MIN_MS=0
+# BOT_UX_DELAY_MAX_MS=1200
+
 # Allowed origins for security (optional)
 # ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 

--- a/__tests__/lib/bots/bot-ux-timing.test.ts
+++ b/__tests__/lib/bots/bot-ux-timing.test.ts
@@ -1,0 +1,46 @@
+import { resolveBotUxDelayMs } from '@/lib/bots/core/bot-ux-timing'
+
+describe('resolveBotUxDelayMs', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env.BOT_UX_DELAY_MS
+    delete process.env.BOT_UX_DELAY_SCALE
+    delete process.env.BOT_UX_DELAY_MIN_MS
+    delete process.env.BOT_UX_DELAY_MAX_MS
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('uses short default delays with difficulty scaling', () => {
+    expect(resolveBotUxDelayMs('easy', 300)).toBe(190)
+    expect(resolveBotUxDelayMs('medium', 300)).toBe(165)
+    expect(resolveBotUxDelayMs('hard', 300)).toBe(140)
+  })
+
+  it('supports fixed delay override', () => {
+    process.env.BOT_UX_DELAY_MS = '220'
+
+    expect(resolveBotUxDelayMs('easy', 300)).toBe(220)
+    expect(resolveBotUxDelayMs('hard', 120)).toBe(220)
+  })
+
+  it('clamps delays to configured bounds', () => {
+    process.env.BOT_UX_DELAY_MS = '900'
+    process.env.BOT_UX_DELAY_MIN_MS = '50'
+    process.env.BOT_UX_DELAY_MAX_MS = '300'
+
+    expect(resolveBotUxDelayMs('medium', 300)).toBe(300)
+  })
+
+  it('swaps min/max bounds when configured in reverse order', () => {
+    process.env.BOT_UX_DELAY_SCALE = '0'
+    process.env.BOT_UX_DELAY_MIN_MS = '140'
+    process.env.BOT_UX_DELAY_MAX_MS = '80'
+
+    expect(resolveBotUxDelayMs('medium', 300)).toBe(80)
+  })
+})

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -72,6 +72,7 @@ Recommended:
 - `GUEST_JWT_SECRET` (guest token signing isolation)
 - `CRON_SECRET` (required in production; recommended locally to test `/api/cron/*`)
 - `NEXT_PUBLIC_SOCKET_URL` (explicit socket endpoint in non-local envs)
+- `BOT_UX_DELAY_MS` or `BOT_UX_DELAY_SCALE` + `BOT_UX_DELAY_MIN_MS` + `BOT_UX_DELAY_MAX_MS` (optional bot UX timing controls)
 - `ANALYTICS_ALLOWED_USER_IDS` / `ANALYTICS_ALLOWED_EMAILS` (restrict analytics endpoints)
 - `OPS_ALERT_WEBHOOK_URL` (alerts channel webhook)
 - `OPS_ALERT_WINDOW_MINUTES`, `OPS_ALERT_BASELINE_DAYS`, `OPS_ALERT_REPEAT_MINUTES`

--- a/lib/bots/core/bot-ux-timing.ts
+++ b/lib/bots/core/bot-ux-timing.ts
@@ -1,0 +1,50 @@
+import { BotDifficulty } from './bot-types'
+
+const DEFAULT_DELAY_SCALE = 0.55
+const MIN_DELAY_SCALE = 0
+const MAX_DELAY_SCALE = 2
+const DEFAULT_DELAY_MIN_MS = 0
+const DEFAULT_DELAY_MAX_MS = 1200
+
+const DIFFICULTY_MULTIPLIER: Record<BotDifficulty, number> = {
+  easy: 1.15,
+  medium: 1,
+  hard: 0.85,
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function parseFiniteNumber(value: string | undefined): number | null {
+  if (!value) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseNonNegativeInt(value: string | undefined): number | null {
+  if (!value) return null
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
+}
+
+export function resolveBotUxDelayMs(difficulty: BotDifficulty, baseDelayMs: number): number {
+  const safeBaseDelayMs = Number.isFinite(baseDelayMs) ? Math.max(0, Math.round(baseDelayMs)) : 0
+  const overrideDelayMs = parseNonNegativeInt(process.env.BOT_UX_DELAY_MS)
+
+  const configuredScale = parseFiniteNumber(process.env.BOT_UX_DELAY_SCALE)
+  const resolvedScale = clamp(configuredScale ?? DEFAULT_DELAY_SCALE, MIN_DELAY_SCALE, MAX_DELAY_SCALE)
+
+  const configuredMinDelayMs = parseNonNegativeInt(process.env.BOT_UX_DELAY_MIN_MS)
+  const configuredMaxDelayMs = parseNonNegativeInt(process.env.BOT_UX_DELAY_MAX_MS)
+  const minDelayMs = configuredMinDelayMs ?? DEFAULT_DELAY_MIN_MS
+  const maxDelayMs = configuredMaxDelayMs ?? DEFAULT_DELAY_MAX_MS
+  const lowerBoundMs = Math.min(minDelayMs, maxDelayMs)
+  const upperBoundMs = Math.max(minDelayMs, maxDelayMs)
+
+  const difficultyMultiplier = DIFFICULTY_MULTIPLIER[difficulty] ?? 1
+  const scaledDelayMs = Math.round(safeBaseDelayMs * resolvedScale * difficultyMultiplier)
+  const candidateDelayMs = overrideDelayMs ?? scaledDelayMs
+
+  return clamp(candidateDelayMs, lowerBoundMs, upperBoundMs)
+}

--- a/lib/bots/rock-paper-scissors/rock-paper-scissors-bot-executor.ts
+++ b/lib/bots/rock-paper-scissors/rock-paper-scissors-bot-executor.ts
@@ -2,6 +2,7 @@ import { RockPaperScissorsGame } from '@/lib/games/rock-paper-scissors-game'
 import { BotDifficulty, MoveCallback } from '../core/bot-types'
 import { RockPaperScissorsBot } from './rock-paper-scissors-bot'
 import { clientLogger } from '@/lib/client-logger'
+import { resolveBotUxDelayMs } from '../core/bot-ux-timing'
 
 export interface RockPaperScissorsBotActionEvent {
   type: 'thinking' | 'choice'
@@ -30,7 +31,7 @@ export class RockPaperScissorsBotExecutor {
       message: `${botPlayer.name} is thinking...`,
     })
 
-    await this.delay(200)
+    await this.delay(difficulty, 200)
 
     const decision = await bot.makeDecision()
     const move = bot.decisionToMove(decision)
@@ -47,7 +48,8 @@ export class RockPaperScissorsBotExecutor {
     })
   }
 
-  private static delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms))
+  private static delay(difficulty: BotDifficulty, baseMs: number): Promise<void> {
+    const delayMs = resolveBotUxDelayMs(difficulty, baseMs)
+    return new Promise((resolve) => setTimeout(resolve, delayMs))
   }
 }

--- a/lib/bots/tic-tac-toe/tic-tac-toe-bot-executor.ts
+++ b/lib/bots/tic-tac-toe/tic-tac-toe-bot-executor.ts
@@ -2,6 +2,7 @@ import { TicTacToeGame } from '@/lib/games/tic-tac-toe-game'
 import { BotDifficulty, MoveCallback } from '../core/bot-types'
 import { TicTacToeBot } from './tic-tac-toe-bot'
 import { clientLogger } from '@/lib/client-logger'
+import { resolveBotUxDelayMs } from '../core/bot-ux-timing'
 
 export interface TicTacToeBotActionEvent {
   type: 'thinking' | 'place'
@@ -34,7 +35,7 @@ export class TicTacToeBotExecutor {
       message: `${botPlayer.name} is thinking...`,
     })
 
-    await this.delay(250)
+    await this.delay(difficulty, 250)
 
     const decision = await bot.makeDecision()
     const move = bot.decisionToMove(decision)
@@ -58,7 +59,8 @@ export class TicTacToeBotExecutor {
     })
   }
 
-  private static delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms))
+  private static delay(difficulty: BotDifficulty, baseMs: number): Promise<void> {
+    const delayMs = resolveBotUxDelayMs(difficulty, baseMs)
+    return new Promise((resolve) => setTimeout(resolve, delayMs))
   }
 }

--- a/lib/bots/yahtzee/yahtzee-bot-executor.ts
+++ b/lib/bots/yahtzee/yahtzee-bot-executor.ts
@@ -10,6 +10,7 @@ import { YahtzeeCategory, calculateScore } from '@/lib/yahtzee'
 import { BotDifficulty, MoveCallback } from '../core/bot-types'
 import { clientLogger } from '@/lib/client-logger'
 import { getCategoryDisplayName } from '@/lib/celebrations'
+import { resolveBotUxDelayMs } from '../core/bot-ux-timing'
 
 export interface YahtzeeBotActionEvent {
     type: 'thinking' | 'roll' | 'hold' | 'score'
@@ -54,7 +55,7 @@ export class YahtzeeBotExecutor {
                 botName: botPlayer.name,
                 message: `${botPlayer.name} is thinking...`,
             })
-            await this.delay(300)
+            await this.delay(difficulty, 300)
 
             // Execute turn step by step
             let rollNumber = 0
@@ -72,6 +73,7 @@ export class YahtzeeBotExecutor {
                         decision,
                         bot,
                         botPlayer.name,
+                        difficulty,
                         gameEngine,
                         onMove,
                         onBotAction
@@ -86,6 +88,7 @@ export class YahtzeeBotExecutor {
                         bot,
                         botPlayer.name,
                         rollNumber,
+                        difficulty,
                         gameEngine,
                         onMove,
                         onBotAction
@@ -101,6 +104,7 @@ export class YahtzeeBotExecutor {
                     decision,
                     bot,
                     botPlayer.name,
+                    difficulty,
                     gameEngine,
                     onMove,
                     onBotAction
@@ -123,11 +127,12 @@ export class YahtzeeBotExecutor {
         bot: YahtzeeBot,
         botName: string,
         rollNumber: number,
+        difficulty: BotDifficulty,
         gameEngine: YahtzeeGame,
         onMove: MoveCallback,
         onBotAction?: (event: YahtzeeBotActionEvent) => void
     ): Promise<void> {
-        await this.delay(200)
+        await this.delay(difficulty, 200)
 
         onBotAction?.({
             type: 'roll',
@@ -156,7 +161,7 @@ export class YahtzeeBotExecutor {
         })
 
         if (heldIndices.length > 0) {
-            await this.delay(150)
+            await this.delay(difficulty, 150)
             onBotAction?.({
                 type: 'hold',
                 botName,
@@ -169,7 +174,7 @@ export class YahtzeeBotExecutor {
             })
         }
 
-        await this.delay(400)
+        await this.delay(difficulty, 400)
     }
 
     /**
@@ -179,6 +184,7 @@ export class YahtzeeBotExecutor {
         decision: YahtzeeBotDecision,
         bot: YahtzeeBot,
         botName: string,
+        difficulty: BotDifficulty,
         gameEngine: YahtzeeGame,
         onMove: MoveCallback,
         onBotAction?: (event: YahtzeeBotActionEvent) => void
@@ -190,7 +196,7 @@ export class YahtzeeBotExecutor {
         const dice = gameEngine.getDice()
         const score = calculateScore(dice, decision.category)
 
-        await this.delay(300)
+        await this.delay(difficulty, 300)
 
         const categoryName = getCategoryDisplayName(decision.category)
         onBotAction?.({
@@ -204,7 +210,7 @@ export class YahtzeeBotExecutor {
             message: `${botName} scores ${score} in ${categoryName}`,
         })
 
-        await this.delay(200)
+        await this.delay(difficulty, 200)
 
         const move = bot.decisionToMove(decision)
         await onMove(move)
@@ -215,7 +221,8 @@ export class YahtzeeBotExecutor {
     /**
      * Delay helper
      */
-    private static delay(ms: number): Promise<void> {
-        return new Promise(resolve => setTimeout(resolve, ms))
+    private static delay(difficulty: BotDifficulty, baseMs: number): Promise<void> {
+        const delayMs = resolveBotUxDelayMs(difficulty, baseMs)
+        return new Promise(resolve => setTimeout(resolve, delayMs))
     }
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -37,6 +37,10 @@ const envSchema = z.object({
   NEXT_PUBLIC_SOCKET_URL: z.string().url().optional(),
   CORS_ORIGIN: z.string().optional(),
   SOCKET_SERVER_INTERNAL_SECRET: z.string().min(16, 'SOCKET_SERVER_INTERNAL_SECRET must be at least 16 characters').optional(),
+  BOT_UX_DELAY_MS: z.string().optional(),
+  BOT_UX_DELAY_SCALE: z.string().optional(),
+  BOT_UX_DELAY_MIN_MS: z.string().optional(),
+  BOT_UX_DELAY_MAX_MS: z.string().optional(),
   
   // Server Configuration
   HOSTNAME: z.string().default('0.0.0.0'),
@@ -177,6 +181,11 @@ export function printEnvInfo(options: ValidateEnvOptions = {}): void {
   
   console.log(`  - Socket.IO URL: ${env.NEXT_PUBLIC_SOCKET_URL || 'Not set (using default)'}`)
   console.log(`  - Socket Internal Secret: ${env.SOCKET_SERVER_INTERNAL_SECRET ? '✅ Set' : '⚠️  Not set'}`)
+  console.log(`  - Bot UX Delay Override: ${env.BOT_UX_DELAY_MS || 'auto'}`)
+  console.log(`  - Bot UX Delay Scale: ${env.BOT_UX_DELAY_SCALE || '0.55 (default)'}`)
+  console.log(
+    `  - Bot UX Delay Range: ${env.BOT_UX_DELAY_MIN_MS || '0'}-${env.BOT_UX_DELAY_MAX_MS || '1200'} ms`
+  )
   console.log(`  - Cron Secret: ${env.CRON_SECRET ? '✅ Set' : '⚠️  Not set'}`)
   console.log(`  - CORS Origin: ${env.CORS_ORIGIN || 'Not set'}`)
   console.log(


### PR DESCRIPTION
## Summary
- add centralized bot UX timing helper to replace hardcoded delays in bot executors
- make bot pacing configurable via env (`BOT_UX_DELAY_MS`, `BOT_UX_DELAY_SCALE`, `BOT_UX_DELAY_MIN_MS`, `BOT_UX_DELAY_MAX_MS`)
- wire helper into Yahtzee / Tic-Tac-Toe / Rock-Paper-Scissors executors
- add unit tests for default timing, override, and clamp behavior
- document new env knobs in `.env.example` and `docs/OPERATIONS.md`

## Why
Follow-up on #128: keep handoff responsive while preserving a short configurable "human-like" delay profile.

## Validation
- `npm test -- __tests__/lib/bots/bot-ux-timing.test.ts __tests__/api/game-state.test.ts --runInBand`
- `npm run ci:quick`

## Related
- #128