### PR TITLE
fix(header): stop tablet mobile-menu auto-close after open

### DIFF
--- a/__tests__/components/mobile-menu.test.tsx
+++ b/__tests__/components/mobile-menu.test.tsx
@@ -39,6 +39,25 @@ describe('MobileMenu', () => {
     jest.clearAllMocks()
   })
 
+  it('does not auto-close immediately after opening without pathname change', () => {
+    render(
+      <MobileMenu
+        isAuthenticated
+        isAdmin={false}
+        userName="Tester"
+        userEmail="tester@example.com"
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('Open menu'))
+
+    act(() => {
+      jest.advanceTimersByTime(350)
+    })
+
+    expect(screen.getAllByLabelText('Close menu').length).toBeGreaterThan(0)
+  })
+
   it('closes menu when pathname changes', () => {
     const { rerender } = render(
       <MobileMenu

--- a/components/Header/MobileMenu.tsx
+++ b/components/Header/MobileMenu.tsx
@@ -24,6 +24,7 @@ export function MobileMenu({
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [isClosing, setIsClosing] = useState(false)
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const previousPathnameRef = useRef(pathname)
   const { isGuest, guestName, clearGuestMode } = useGuest()
   const isGuestSession = isGuest && !isAuthenticated
   const canAccessGames = isAuthenticated || isGuestSession
@@ -76,7 +77,10 @@ export function MobileMenu({
 
   // Close on route change
   useEffect(() => {
-    if (mobileMenuOpen) {
+    const pathnameChanged = previousPathnameRef.current !== pathname
+    previousPathnameRef.current = pathname
+
+    if (mobileMenuOpen && pathnameChanged) {
       closeMenu()
     }
   }, [pathname, mobileMenuOpen, closeMenu])


### PR DESCRIPTION
## Summary
- fix `MobileMenu` route-change effect so it only closes when `pathname` actually changes
- prevent immediate close timer from triggering right after opening the menu
- add regression test covering "open menu stays open without pathname change"

## Linked
- Closes #148

## Validation
- `npm test -- __tests__/components/mobile-menu.test.tsx`
- `npm run ci:quick`
