### PR TITLE
feat(games): move RPS to coming-soon and disable lobby creation

### DIFF
--- a/__tests__/api/guest-mode.test.ts
+++ b/__tests__/api/guest-mode.test.ts
@@ -148,6 +148,24 @@ describe('Guest mode API endpoints', () => {
     expect(mockPrisma.lobbies.create).toHaveBeenCalled()
   })
 
+  it('rejects lobby creation for temporarily unavailable game type', async () => {
+    const req = new NextRequest('http://localhost:3000/api/lobby', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Guest Lobby',
+        maxPlayers: 2,
+        gameType: 'rock_paper_scissors',
+      }),
+    })
+
+    const response = await CREATE_LOBBY(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toBe('Game type is temporarily unavailable')
+    expect(mockPrisma.lobbies.create).not.toHaveBeenCalled()
+  })
+
   it('joins waiting lobby as guest player', async () => {
     mockPrisma.lobbies.findUnique.mockResolvedValue({
       id: 'lobby_1',

--- a/app/api/lobby/route.ts
+++ b/app/api/lobby/route.ts
@@ -82,6 +82,12 @@ export async function POST(request: NextRequest) {
     if (!isSupportedGameType(gameType)) {
       return NextResponse.json({ error: 'Unsupported game type' }, { status: 400 })
     }
+    if (gameType === 'rock_paper_scissors') {
+      return NextResponse.json(
+        { error: 'Game type is temporarily unavailable' },
+        { status: 409 }
+      )
+    }
 
     const persistedGameType = toPersistedGameType(gameType)
     const hashedLobbyPassword = await hashLobbyPassword(password)

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -78,8 +78,7 @@ export default function GamesPage() {
       descriptionKey: 'games.rock_paper_scissors.description',
       players: '2',
       difficultyKey: 'games.rock_paper_scissors.difficulty',
-      status: 'available',
-      route: '/lobby/create?gameType=rock_paper_scissors',
+      status: 'coming-soon',
       color: 'from-indigo-400 to-purple-500'
     },
     {

--- a/app/lobby/create/page.tsx
+++ b/app/lobby/create/page.tsx
@@ -118,6 +118,16 @@ const GAME_INFO: Record<GameType, GameInfo> = {
   },
 }
 
+const TEMPORARILY_UNAVAILABLE_GAME_TYPES = new Set<GameType>(['rock_paper_scissors'])
+
+function isSelectableGameType(value: string | null | undefined): value is GameType {
+  if (typeof value !== 'string' || !(value in GAME_INFO)) {
+    return false
+  }
+
+  return !TEMPORARILY_UNAVAILABLE_GAME_TYPES.has(value as GameType)
+}
+
 
 import { Disclosure } from '@headlessui/react'
 
@@ -128,7 +138,10 @@ function CreateLobbyPage() {
   const { data: session, status } = useSession()
   const { isGuest } = useGuest()
 
-  const [selectedGameType, setSelectedGameType] = useState<GameType>((searchParams.get('gameType') as GameType) || 'yahtzee')
+  const requestedGameType = searchParams.get('gameType')
+  const [selectedGameType, setSelectedGameType] = useState<GameType>(
+    isSelectableGameType(requestedGameType) ? requestedGameType : 'yahtzee'
+  )
   const gameInfo = GAME_INFO[selectedGameType]
 
   const [formData, setFormData] = useState({
@@ -313,6 +326,7 @@ function CreateLobbyPage() {
             {/* 1. Game Type Selector - clean scrollable list */}
             <div className="md:w-1/4 w-full flex flex-col overflow-y-auto bg-white/5 border-b-2 md:border-b-0 md:border-r-2 border-white/10 order-1">
               {Object.entries(GAME_INFO)
+                .filter(([key]) => !TEMPORARILY_UNAVAILABLE_GAME_TYPES.has(key as GameType))
                 .sort(([, a], [, b]) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
                 .map(([key, info]) => (
                 <button
@@ -379,7 +393,7 @@ function CreateLobbyPage() {
                 </label>
 
                 {gameInfo.allowedPlayers.length === 1 ? (
-                  // Static display for games with fixed player count (e.g., Tic-Tac-Toe, Rock Paper Scissors)
+                  // Static display for games with fixed player count (e.g., Tic-Tac-Toe)
                   <div className="flex flex-col items-center py-2">
                     <div className="inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-white/20 backdrop-blur-sm rounded-xl border border-white/30">
                       <span className="text-2xl font-extrabold text-white">


### PR DESCRIPTION
## Summary
- move Rock Paper Scissors card in game hub from `available` to `coming-soon`
- remove RPS from selectable game types in lobby creation UI
- safely handle direct `/lobby/create?gameType=rock_paper_scissors` by falling back to a supported game
- block RPS lobby creation at API level with explicit `409` response
- add API regression test for temporary unavailability behavior

## Linked
- Closes #146

## Validation
- `npm test -- __tests__/api/guest-mode.test.ts`
- `npm run ci:quick`
