### PR TITLE
feat(lobby): remove mandatory lobby name and auto-generate fallback

### DIFF
--- a/__tests__/api/guest-mode.test.ts
+++ b/__tests__/api/guest-mode.test.ts
@@ -148,6 +148,37 @@ describe('Guest mode API endpoints', () => {
     expect(mockPrisma.lobbies.create).toHaveBeenCalled()
   })
 
+  it('creates lobby with generated name when request omits name', async () => {
+    mockPrisma.lobbies.create.mockResolvedValue({
+      id: 'lobby_2',
+      code: 'TEST123',
+      name: 'Lobby TEST123',
+      games: [
+        {
+          id: 'game_2',
+          status: 'waiting',
+          players: [{ userId: guestUser.id, position: 0 }],
+        },
+      ],
+    } as any)
+
+    const req = new NextRequest('http://localhost:3000/api/lobby', {
+      method: 'POST',
+      body: JSON.stringify({
+        maxPlayers: 4,
+        gameType: 'yahtzee',
+      }),
+    })
+
+    const response = await CREATE_LOBBY(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.lobby.name).toBe('Lobby TEST123')
+    const createArgs = mockPrisma.lobbies.create.mock.calls[0][0] as any
+    expect(createArgs.data.name).toBe('Lobby TEST123')
+  })
+
   it('rejects lobby creation for temporarily unavailable game type', async () => {
     const req = new NextRequest('http://localhost:3000/api/lobby', {
       method: 'POST',

--- a/app/api/lobby/route.ts
+++ b/app/api/lobby/route.ts
@@ -14,7 +14,7 @@ import { toPersistedGameType } from '@/lib/game-type-storage'
 const log = apiLogger('/api/lobby')
 
 const createLobbySchema = z.object({
-  name: z.string().min(1).max(50),
+  name: z.string().trim().max(50).optional().default(''),
   password: z.string().optional(),
   maxPlayers: z.number().min(2).max(10).default(6),
   allowSpectators: z.boolean().default(false),
@@ -90,6 +90,7 @@ export async function POST(request: NextRequest) {
     }
 
     const persistedGameType = toPersistedGameType(gameType)
+    const normalizedLobbyName = name.trim()
     const hashedLobbyPassword = await hashLobbyPassword(password)
     const normalizedTicTacToeRounds = gameType === 'tic_tac_toe' ? (ticTacToeRounds ?? null) : undefined
     const normalizedMemoryDifficulty = gameType === 'memory' ? (memoryDifficulty ?? 'easy') : undefined
@@ -145,12 +146,14 @@ export async function POST(request: NextRequest) {
 
     for (let attempt = 1; attempt <= MAX_LOBBY_CODE_ATTEMPTS; attempt += 1) {
       const code = generateLobbyCode()
+      const resolvedLobbyName =
+        normalizedLobbyName.length > 0 ? normalizedLobbyName : `Lobby ${code}`
 
       try {
         lobby = await prisma.lobbies.create({
           data: {
             code,
-            name,
+            name: resolvedLobbyName,
             password: hashedLobbyPassword,
             maxPlayers,
             allowSpectators,

--- a/app/lobby/create/page.tsx
+++ b/app/lobby/create/page.tsx
@@ -348,11 +348,10 @@ function CreateLobbyPage() {
             <form onSubmit={handleSubmit} className="md:w-2/4 w-full p-4 md:p-6 space-y-2.5 md:space-y-3 flex flex-col order-3 md:order-2 overflow-y-auto max-h-[70vh] md:max-h-none">
               <div>
                 <label className="block text-xs md:text-sm font-bold text-white mb-1.5 md:mb-2">
-                  🎮 {t('lobby.create.lobbyName')} *
+                  🎮 {t('lobby.create.lobbyName')}
                 </label>
                 <input
                   type="text"
-                  required
                   placeholder={t('lobby.create.lobbyNamePlaceholder')}
                   maxLength={LOBBY_NAME_MAX}
                   className="w-full px-4 py-2.5 border-2 border-white/30 rounded-xl focus:ring-2 focus:ring-white focus:border-transparent bg-white/20 backdrop-blur-sm text-white placeholder-white/60 transition-all"


### PR DESCRIPTION
## Summary
- make lobby name optional in create-lobby UI
- accept missing/empty `name` in `POST /api/lobby`
- generate fallback name on server as `Lobby <CODE>` when `name` is omitted
- keep existing creation flow and payload compatibility intact
- add API regression test for omitted-name behavior

## Linked
- Closes #145

## Validation
- `npm test -- __tests__/api/guest-mode.test.ts`
- `npm run ci:quick`
