### PR TITLE
feat: numeric-first 4-char lobby codes with alphanumeric fallback

### DIFF
--- a/__tests__/lib/lobby.test.ts
+++ b/__tests__/lib/lobby.test.ts
@@ -1,28 +1,32 @@
 // Override the global nanoid mock for this test to actually generate random codes
 jest.mock('nanoid', () => ({
-  customAlphabet: () => () => {
-    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+  customAlphabet: (alphabet: string, size: number) => () => {
     let result = ''
-    for (let i = 0; i < 6; i++) {
-      result += chars[Math.floor(Math.random() * chars.length)]
+    for (let i = 0; i < size; i++) {
+      result += alphabet[Math.floor(Math.random() * alphabet.length)]
     }
     return result
   },
   nanoid: () => 'test-id-123',
 }))
 
-import { generateLobbyCode } from '@/lib/lobby'
+import { generateLobbyCode, LOBBY_CODE_LENGTH } from '@/lib/lobby'
 
 describe('Lobby Utilities', () => {
   describe('generateLobbyCode', () => {
-    it('should generate a 6-character code', () => {
+    it('should generate a fixed-length code', () => {
       const code = generateLobbyCode()
-      expect(code).toHaveLength(6)
+      expect(code).toHaveLength(LOBBY_CODE_LENGTH)
     })
 
-    it('should generate codes with only uppercase letters and numbers', () => {
+    it('should generate digit-only codes by default', () => {
       const code = generateLobbyCode()
-      expect(code).toMatch(/^[A-Z0-9]{6}$/)
+      expect(code).toMatch(/^\d{4}$/)
+    })
+
+    it('should generate alphanumeric codes when fallback is enabled', () => {
+      const code = generateLobbyCode({ fallbackToAlphanumeric: true })
+      expect(code).toMatch(/^[A-Z0-9]{4}$/)
     })
 
     it('should generate unique codes', () => {
@@ -33,9 +37,9 @@ describe('Lobby Utilities', () => {
         codes.add(generateLobbyCode())
       }
 
-      // With 36^6 = 2,176,782,336 possible combinations,
-      // collisions should be rare in 100 attempts
-      expect(codes.size).toBeGreaterThan(95)
+      // With 10^4 = 10,000 possible numeric combinations,
+      // collisions should still be relatively rare in 100 attempts.
+      expect(codes.size).toBeGreaterThan(90)
     })
 
     it('should generate different codes on consecutive calls', () => {
@@ -49,7 +53,7 @@ describe('Lobby Utilities', () => {
     it('should generate codes without lowercase letters', () => {
       const codes = Array.from({ length: 100 }, () => generateLobbyCode())
       
-      codes.forEach(code => {
+      codes.forEach((code) => {
         expect(code).not.toMatch(/[a-z]/)
       })
     })
@@ -57,7 +61,7 @@ describe('Lobby Utilities', () => {
     it('should generate codes without special characters', () => {
       const codes = Array.from({ length: 100 }, () => generateLobbyCode())
       
-      codes.forEach(code => {
+      codes.forEach((code) => {
         expect(code).not.toMatch(/[^A-Z0-9]/)
       })
     })

--- a/__tests__/lib/yahtzee-utils.test.ts
+++ b/__tests__/lib/yahtzee-utils.test.ts
@@ -9,14 +9,14 @@ import { YahtzeeCategory } from '@/lib/yahtzee'
 
 describe('Lobby Utilities', () => {
   describe('generateLobbyCode', () => {
-    it('should generate 6-character code', () => {
+    it('should generate 4-character code', () => {
       const code = generateLobbyCode()
-      expect(code).toHaveLength(6)
+      expect(code).toHaveLength(4)
     })
 
-    it('should generate alphanumeric code', () => {
+    it('should generate numeric code by default', () => {
       const code = generateLobbyCode()
-      expect(code).toMatch(/^[A-Z0-9]{6}$/)
+      expect(code).toMatch(/^\d{4}$/)
     })
 
     it('should generate codes with high randomness', () => {
@@ -25,9 +25,9 @@ describe('Lobby Utilities', () => {
       const code3 = generateLobbyCode()
       
       // Each code should be valid
-      expect(code1).toMatch(/^[A-Z0-9]{6}$/)
-      expect(code2).toMatch(/^[A-Z0-9]{6}$/)
-      expect(code3).toMatch(/^[A-Z0-9]{6}$/)
+      expect(code1).toMatch(/^\d{4}$/)
+      expect(code2).toMatch(/^\d{4}$/)
+      expect(code3).toMatch(/^\d{4}$/)
       
       // Note: In some test environments nanoid can be mocked for determinism
       // In production, codes would be unique

--- a/app/api/lobby/route.ts
+++ b/app/api/lobby/route.ts
@@ -26,7 +26,8 @@ const createLobbySchema = z.object({
 
 const createLimiter = rateLimit(rateLimitPresets.lobbyCreation)
 const WAITING_LOBBY_STALE_MS = 60 * 60 * 1000
-const MAX_LOBBY_CODE_ATTEMPTS = 10
+const NUMERIC_LOBBY_CODE_ATTEMPTS_BEFORE_FALLBACK = 10
+const MAX_LOBBY_CODE_ATTEMPTS = 20
 const UNLIMITED_SPECTATORS_VALUE = 0
 
 function isLobbyCodeConflict(error: unknown): boolean {
@@ -145,7 +146,9 @@ export async function POST(request: NextRequest) {
       | null = null
 
     for (let attempt = 1; attempt <= MAX_LOBBY_CODE_ATTEMPTS; attempt += 1) {
-      const code = generateLobbyCode()
+      const code = generateLobbyCode({
+        fallbackToAlphanumeric: attempt > NUMERIC_LOBBY_CODE_ATTEMPTS_BEFORE_FALLBACK,
+      })
       const resolvedLobbyName =
         normalizedLobbyName.length > 0 ? normalizedLobbyName : `Lobby ${code}`
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -51,7 +51,22 @@ require('whatwg-fetch')
 
 // Mock nanoid for lobby code generation
 jest.mock('nanoid', () => ({
-  customAlphabet: () => () => 'AB12CD',
+  customAlphabet: (alphabet, size) => {
+    let counter = 0
+    return () => {
+      // Deterministic generator that respects alphabet and requested size.
+      // This keeps tests stable while matching runtime signature.
+      const start = counter
+      counter += 1
+
+      let code = ''
+      for (let i = 0; i < size; i += 1) {
+        code += alphabet[(start + i) % alphabet.length]
+      }
+
+      return code
+    }
+  },
   nanoid: () => 'test-id-123',
 }))
 

--- a/lib/lobby.ts
+++ b/lib/lobby.ts
@@ -1,11 +1,16 @@
 import { customAlphabet } from 'nanoid'
 
-export const LOBBY_CODE_LENGTH = 6
-const LOBBY_CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+export const LOBBY_CODE_LENGTH = 4
+const NUMERIC_LOBBY_CODE_ALPHABET = '0123456789'
+const ALPHANUMERIC_LOBBY_CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
-// Generate stronger uppercase alphanumeric lobby codes.
-const nanoid = customAlphabet(LOBBY_CODE_ALPHABET, LOBBY_CODE_LENGTH)
+const numericLobbyCodeGenerator = customAlphabet(NUMERIC_LOBBY_CODE_ALPHABET, LOBBY_CODE_LENGTH)
+const alphanumericLobbyCodeGenerator = customAlphabet(ALPHANUMERIC_LOBBY_CODE_ALPHABET, LOBBY_CODE_LENGTH)
 
-export function generateLobbyCode(): string {
-  return nanoid()
+export function generateLobbyCode(options?: { fallbackToAlphanumeric?: boolean }): string {
+  if (options?.fallbackToAlphanumeric) {
+    return alphanumericLobbyCodeGenerator()
+  }
+
+  return numericLobbyCodeGenerator()
 }


### PR DESCRIPTION
## Summary
- change lobby code length to 4 characters
- generate numeric-only lobby codes by default (`0000-9999`)
- add deterministic fallback to alphanumeric generation after numeric retry threshold
- keep collision handling safe with bounded retry loop and conflict detection

## Implementation details
- `lib/lobby.ts`
  - `LOBBY_CODE_LENGTH` set to `4`
  - `generateLobbyCode()` now supports `fallbackToAlphanumeric`
- `app/api/lobby/route.ts`
  - use numeric-first generation for first 10 attempts
  - fallback to alphanumeric for remaining attempts
  - increase max attempts to 20 to preserve resilience under collisions
- tests updated for new generation rules and length
- fixed global `nanoid` jest mock in `jest.setup.js` to honor `(alphabet, size)` so tests match runtime behavior

## Verification
- `npm test -- __tests__/lib/lobby.test.ts __tests__/lib/yahtzee-utils.test.ts __tests__/api/guest-mode.test.ts`
- `npm run ci:quick`
- pre-push hook suite passed (prisma generate, locale parity, ci:quick, jest smoke)

Closes #149