### PR TITLE
feat(auth): guest-to-user progress migration on account upgrade

### DIFF
--- a/__tests__/api/upgrade-guest-account.test.ts
+++ b/__tests__/api/upgrade-guest-account.test.ts
@@ -1,0 +1,276 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+// @ts-nocheck - Route-level Prisma transaction mocks are intentionally lightweight.
+
+import { NextRequest } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { POST } from '@/app/api/user/upgrade-guest/route'
+import { prisma } from '@/lib/db'
+import { getGuestClaimsFromRequest } from '@/lib/guest-auth'
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}))
+
+jest.mock('@/lib/next-auth', () => ({
+  authOptions: {},
+}))
+
+const mockTx = {
+  users: {
+    findUnique: jest.fn(),
+    delete: jest.fn(),
+  },
+  players: {
+    findMany: jest.fn(),
+    update: jest.fn(),
+    deleteMany: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  lobbies: {
+    updateMany: jest.fn(),
+  },
+  lobbyInvites: {
+    updateMany: jest.fn(),
+  },
+  notifications: {
+    updateMany: jest.fn(),
+  },
+  notificationPreferences: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+}
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    $transaction: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/guest-auth', () => ({
+  getGuestClaimsFromRequest: jest.fn(),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+  },
+  apiLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}))
+
+const mockGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockGetGuestClaimsFromRequest = getGuestClaimsFromRequest as jest.MockedFunction<
+  typeof getGuestClaimsFromRequest
+>
+
+describe('POST /api/user/upgrade-guest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockPrisma.$transaction.mockImplementation(async (callback: any) => callback(mockTx as any))
+
+    mockTx.users.findUnique.mockReset()
+    mockTx.users.delete.mockReset()
+    mockTx.players.findMany.mockReset()
+    mockTx.players.update.mockReset()
+    mockTx.players.deleteMany.mockReset()
+    mockTx.players.updateMany.mockReset()
+    mockTx.lobbies.updateMany.mockReset()
+    mockTx.lobbyInvites.updateMany.mockReset()
+    mockTx.notifications.updateMany.mockReset()
+    mockTx.notificationPreferences.findUnique.mockReset()
+    mockTx.notificationPreferences.update.mockReset()
+    mockTx.notificationPreferences.delete.mockReset()
+  })
+
+  it('returns 401 when session is missing', async () => {
+    mockGetServerSession.mockResolvedValue(null as any)
+
+    const request = new NextRequest('http://localhost:3000/api/user/upgrade-guest', {
+      method: 'POST',
+      headers: {
+        'X-Guest-Token': 'guest.token',
+      },
+    })
+
+    const response = await POST(request)
+    const payload = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(payload.error).toBe('Unauthorized')
+  })
+
+  it('returns 400 when guest token is invalid or missing', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as any)
+    mockGetGuestClaimsFromRequest.mockReturnValue(null)
+
+    const request = new NextRequest('http://localhost:3000/api/user/upgrade-guest', {
+      method: 'POST',
+    })
+
+    const response = await POST(request)
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('Missing or invalid guest token')
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('returns idempotent success when guest account is already migrated', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as any)
+    mockGetGuestClaimsFromRequest.mockReturnValue({
+      guestId: 'guest-1',
+      guestName: 'Guest One',
+    } as any)
+    mockTx.users.findUnique.mockResolvedValue(null)
+
+    const request = new NextRequest('http://localhost:3000/api/user/upgrade-guest', {
+      method: 'POST',
+      headers: {
+        'X-Guest-Token': 'guest.token',
+      },
+    })
+
+    const response = await POST(request)
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.success).toBe(true)
+    expect(payload.migrated).toBe(false)
+    expect(payload.alreadyMigrated).toBe(true)
+    expect(mockTx.users.delete).not.toHaveBeenCalled()
+  })
+
+  it('migrates guest data and merges conflicting player rows safely', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as any)
+    mockGetGuestClaimsFromRequest.mockReturnValue({
+      guestId: 'guest-1',
+      guestName: 'Guest One',
+    } as any)
+
+    mockTx.users.findUnique.mockResolvedValue({
+      id: 'guest-1',
+      isGuest: true,
+    })
+
+    mockTx.players.findMany
+      .mockResolvedValueOnce([
+        {
+          id: 'source-player-1',
+          gameId: 'game-1',
+          score: 12,
+          finalScore: 21,
+          placement: null,
+          isWinner: true,
+          isReady: false,
+          scorecard: '{"a":1}',
+        },
+        {
+          id: 'source-player-2',
+          gameId: 'game-2',
+          score: 7,
+          finalScore: null,
+          placement: 2,
+          isWinner: false,
+          isReady: true,
+          scorecard: '{"b":2}',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'target-player-1',
+          gameId: 'game-1',
+          score: 20,
+          finalScore: null,
+          placement: 1,
+          isWinner: false,
+          isReady: true,
+          scorecard: null,
+        },
+      ])
+
+    mockTx.players.deleteMany.mockResolvedValue({ count: 1 })
+    mockTx.players.updateMany.mockResolvedValue({ count: 1 })
+    mockTx.lobbies.updateMany.mockResolvedValue({ count: 2 })
+    mockTx.lobbyInvites.updateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 })
+    mockTx.notifications.updateMany.mockResolvedValue({ count: 3 })
+    mockTx.notificationPreferences.findUnique
+      .mockResolvedValueOnce({
+        userId: 'guest-1',
+        gameInvites: true,
+        turnReminders: true,
+        friendRequests: true,
+        friendAccepted: true,
+        unsubscribedAll: false,
+      })
+      .mockResolvedValueOnce({
+        userId: 'user-1',
+        gameInvites: false,
+        turnReminders: false,
+        friendRequests: false,
+        friendAccepted: false,
+        unsubscribedAll: false,
+      })
+
+    const request = new NextRequest('http://localhost:3000/api/user/upgrade-guest', {
+      method: 'POST',
+      headers: {
+        'X-Guest-Token': 'guest.token',
+      },
+    })
+
+    const response = await POST(request)
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.success).toBe(true)
+    expect(payload.migrated).toBe(true)
+    expect(payload.alreadyMigrated).toBe(false)
+    expect(payload.movedPlayers).toBe(1)
+    expect(payload.mergedPlayerConflicts).toBe(1)
+    expect(payload.movedLobbies).toBe(2)
+    expect(payload.movedInvites).toBe(1)
+    expect(payload.movedNotifications).toBe(3)
+    expect(payload.mergedNotificationPreferences).toBe(true)
+
+    expect(mockTx.players.update).toHaveBeenCalledWith({
+      where: { id: 'target-player-1' },
+      data: {
+        score: 20,
+        finalScore: 21,
+        placement: 1,
+        isWinner: true,
+        isReady: true,
+        scorecard: '{"a":1}',
+      },
+    })
+    expect(mockTx.players.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: {
+          in: ['source-player-1'],
+        },
+      },
+    })
+    expect(mockTx.users.delete).toHaveBeenCalledWith({
+      where: { id: 'guest-1' },
+    })
+  })
+})

--- a/__tests__/contexts/GuestContext.auth-transition.test.tsx
+++ b/__tests__/contexts/GuestContext.auth-transition.test.tsx
@@ -116,6 +116,18 @@ describe('GuestContext auth transitions', () => {
       expect(result.current.isGuest).toBe(false)
     })
 
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/user/upgrade-guest',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'X-Guest-Token': 'token-2',
+          },
+        })
+      )
+    })
+
     expect(result.current.guestId).toBeNull()
     expect(result.current.guestName).toBeNull()
     expect(result.current.guestToken).toBeNull()
@@ -124,4 +136,3 @@ describe('GuestContext auth transitions', () => {
     expect(window.localStorage.getItem(GUEST_TOKEN_KEY)).toBeNull()
   })
 })
-

--- a/app/api/user/upgrade-guest/route.ts
+++ b/app/api/user/upgrade-guest/route.ts
@@ -1,0 +1,280 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/next-auth'
+import { prisma } from '@/lib/db'
+import { getGuestClaimsFromRequest } from '@/lib/guest-auth'
+import { apiLogger } from '@/lib/logger'
+import { AuthenticationError, ValidationError, withErrorHandler } from '@/lib/error-handler'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const log = apiLogger('POST /api/user/upgrade-guest')
+
+type PlayerMigrationRow = {
+  id: string
+  gameId: string
+  score: number
+  finalScore: number | null
+  placement: number | null
+  isWinner: boolean
+  isReady: boolean
+  scorecard: string | null
+}
+
+type UpgradeGuestResult = {
+  migrated: boolean
+  alreadyMigrated: boolean
+  guestUserId: string
+  targetUserId: string
+  movedPlayers: number
+  mergedPlayerConflicts: number
+  movedLobbies: number
+  movedInvites: number
+  movedNotifications: number
+  mergedNotificationPreferences: boolean
+}
+
+function mergePlayerConflictData(
+  targetPlayer: PlayerMigrationRow,
+  sourcePlayer: PlayerMigrationRow
+) {
+  return {
+    score: Math.max(targetPlayer.score, sourcePlayer.score),
+    finalScore: targetPlayer.finalScore ?? sourcePlayer.finalScore,
+    placement: targetPlayer.placement ?? sourcePlayer.placement,
+    isWinner: targetPlayer.isWinner || sourcePlayer.isWinner,
+    isReady: targetPlayer.isReady || sourcePlayer.isReady,
+    scorecard: targetPlayer.scorecard ?? sourcePlayer.scorecard,
+  }
+}
+
+async function upgradeGuestInTransaction(
+  tx: Prisma.TransactionClient,
+  guestUserId: string,
+  targetUserId: string
+): Promise<UpgradeGuestResult> {
+  const sourceGuestUser = await tx.users.findUnique({
+    where: { id: guestUserId },
+    select: {
+      id: true,
+      isGuest: true,
+    },
+  })
+
+  if (!sourceGuestUser) {
+    return {
+      migrated: false,
+      alreadyMigrated: true,
+      guestUserId,
+      targetUserId,
+      movedPlayers: 0,
+      mergedPlayerConflicts: 0,
+      movedLobbies: 0,
+      movedInvites: 0,
+      movedNotifications: 0,
+      mergedNotificationPreferences: false,
+    }
+  }
+
+  if (!sourceGuestUser.isGuest) {
+    throw new ValidationError('Provided token does not belong to a guest account')
+  }
+
+  const sourcePlayers = await tx.players.findMany({
+    where: { userId: guestUserId },
+    select: {
+      id: true,
+      gameId: true,
+      score: true,
+      finalScore: true,
+      placement: true,
+      isWinner: true,
+      isReady: true,
+      scorecard: true,
+    },
+  })
+
+  const uniqueSourceGameIds = Array.from(new Set(sourcePlayers.map((player) => player.gameId)))
+  let mergedPlayerConflicts = 0
+
+  if (uniqueSourceGameIds.length > 0) {
+    const targetPlayers = await tx.players.findMany({
+      where: {
+        userId: targetUserId,
+        gameId: {
+          in: uniqueSourceGameIds,
+        },
+      },
+      select: {
+        id: true,
+        gameId: true,
+        score: true,
+        finalScore: true,
+        placement: true,
+        isWinner: true,
+        isReady: true,
+        scorecard: true,
+      },
+    })
+
+    const targetPlayersByGameId = new Map(targetPlayers.map((player) => [player.gameId, player]))
+    const conflictingSourcePlayerIds: string[] = []
+
+    for (const sourcePlayer of sourcePlayers) {
+      const targetPlayer = targetPlayersByGameId.get(sourcePlayer.gameId)
+      if (!targetPlayer) {
+        continue
+      }
+
+      conflictingSourcePlayerIds.push(sourcePlayer.id)
+      mergedPlayerConflicts += 1
+
+      await tx.players.update({
+        where: { id: targetPlayer.id },
+        data: mergePlayerConflictData(targetPlayer, sourcePlayer),
+      })
+    }
+
+    if (conflictingSourcePlayerIds.length > 0) {
+      await tx.players.deleteMany({
+        where: {
+          id: {
+            in: conflictingSourcePlayerIds,
+          },
+        },
+      })
+    }
+  }
+
+  const movedPlayersResult = await tx.players.updateMany({
+    where: { userId: guestUserId },
+    data: { userId: targetUserId },
+  })
+
+  const movedLobbiesResult = await tx.lobbies.updateMany({
+    where: { creatorId: guestUserId },
+    data: { creatorId: targetUserId },
+  })
+
+  const movedInvitesAsInviter = await tx.lobbyInvites.updateMany({
+    where: { inviterId: guestUserId },
+    data: { inviterId: targetUserId },
+  })
+  const movedInvitesAsInvitee = await tx.lobbyInvites.updateMany({
+    where: { inviteeId: guestUserId },
+    data: { inviteeId: targetUserId },
+  })
+
+  const movedNotificationsResult = await tx.notifications.updateMany({
+    where: { userId: guestUserId },
+    data: { userId: targetUserId },
+  })
+
+  let mergedNotificationPreferences = false
+  const sourceNotificationPreferences = await tx.notificationPreferences.findUnique({
+    where: { userId: guestUserId },
+  })
+
+  if (sourceNotificationPreferences) {
+    const targetNotificationPreferences = await tx.notificationPreferences.findUnique({
+      where: { userId: targetUserId },
+    })
+
+    if (targetNotificationPreferences) {
+      await tx.notificationPreferences.update({
+        where: { userId: targetUserId },
+        data: {
+          gameInvites: targetNotificationPreferences.gameInvites || sourceNotificationPreferences.gameInvites,
+          turnReminders: targetNotificationPreferences.turnReminders || sourceNotificationPreferences.turnReminders,
+          friendRequests: targetNotificationPreferences.friendRequests || sourceNotificationPreferences.friendRequests,
+          friendAccepted: targetNotificationPreferences.friendAccepted || sourceNotificationPreferences.friendAccepted,
+          unsubscribedAll:
+            targetNotificationPreferences.unsubscribedAll || sourceNotificationPreferences.unsubscribedAll,
+        },
+      })
+      await tx.notificationPreferences.delete({
+        where: { userId: guestUserId },
+      })
+      mergedNotificationPreferences = true
+    } else {
+      await tx.notificationPreferences.update({
+        where: { userId: guestUserId },
+        data: { userId: targetUserId },
+      })
+    }
+  }
+
+  await tx.users.delete({
+    where: { id: guestUserId },
+  })
+
+  return {
+    migrated: true,
+    alreadyMigrated: false,
+    guestUserId,
+    targetUserId,
+    movedPlayers: movedPlayersResult.count,
+    mergedPlayerConflicts,
+    movedLobbies: movedLobbiesResult.count,
+    movedInvites: movedInvitesAsInviter.count + movedInvitesAsInvitee.count,
+    movedNotifications: movedNotificationsResult.count,
+    mergedNotificationPreferences,
+  }
+}
+
+async function upgradeGuestHandler(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    throw new AuthenticationError('Unauthorized')
+  }
+
+  const guestClaims = getGuestClaimsFromRequest(request)
+  if (!guestClaims?.guestId) {
+    throw new ValidationError('Missing or invalid guest token')
+  }
+
+  const targetUserId = session.user.id
+  const guestUserId = guestClaims.guestId
+
+  if (guestUserId === targetUserId) {
+    return NextResponse.json({
+      success: true,
+      migrated: false,
+      alreadyMigrated: true,
+      guestUserId,
+      targetUserId,
+      movedPlayers: 0,
+      mergedPlayerConflicts: 0,
+      movedLobbies: 0,
+      movedInvites: 0,
+      movedNotifications: 0,
+      mergedNotificationPreferences: false,
+    })
+  }
+
+  const result = await prisma.$transaction((tx) =>
+    upgradeGuestInTransaction(tx, guestUserId, targetUserId)
+  )
+
+  log.info('Guest account upgrade processed', {
+    guestUserId,
+    targetUserId,
+    migrated: result.migrated,
+    alreadyMigrated: result.alreadyMigrated,
+    movedPlayers: result.movedPlayers,
+    mergedPlayerConflicts: result.mergedPlayerConflicts,
+    movedLobbies: result.movedLobbies,
+    movedInvites: result.movedInvites,
+    movedNotifications: result.movedNotifications,
+    mergedNotificationPreferences: result.mergedNotificationPreferences,
+  })
+
+  return NextResponse.json({
+    success: true,
+    ...result,
+  })
+}
+
+export const POST = withErrorHandler(upgradeGuestHandler)

--- a/contexts/GuestContext.tsx
+++ b/contexts/GuestContext.tsx
@@ -37,6 +37,7 @@ export function GuestProvider({ children }: { children: ReactNode }) {
     const [guestName, setGuestName] = useState<string | null>(null)
     const [guestToken, setGuestToken] = useState<string | null>(null)
     const guestStateGenerationRef = useRef(0)
+    const lastUpgradeAttemptTokenRef = useRef<string | null>(null)
 
     const applyGuestSession = useCallback((session: GuestSessionResponse, generation = guestStateGenerationRef.current) => {
         // Ignore stale async results from previous guest sessions.
@@ -137,22 +138,59 @@ export function GuestProvider({ children }: { children: ReactNode }) {
 
     // Never keep guest mode active when authenticated user session exists.
     useEffect(() => {
-        if (status !== 'authenticated') return
-
-        if (guestId || guestName || guestToken) {
-            clearGuestMode()
+        if (status !== 'authenticated') {
+            lastUpgradeAttemptTokenRef.current = null
             return
         }
 
-        if (typeof window !== 'undefined') {
-            const hasStoredGuest =
-                Boolean(localStorage.getItem(GUEST_ID_KEY)) ||
-                Boolean(localStorage.getItem(GUEST_NAME_KEY)) ||
-                Boolean(localStorage.getItem(GUEST_TOKEN_KEY))
+        if (typeof window === 'undefined') return
 
+        const storedGuestId = localStorage.getItem(GUEST_ID_KEY)
+        const storedGuestName = localStorage.getItem(GUEST_NAME_KEY)
+        const storedGuestToken = localStorage.getItem(GUEST_TOKEN_KEY)
+        const activeGuestToken = guestToken || storedGuestToken
+        const hasStoredGuest =
+            Boolean(storedGuestId) ||
+            Boolean(storedGuestName) ||
+            Boolean(storedGuestToken) ||
+            Boolean(guestId) ||
+            Boolean(guestName) ||
+            Boolean(guestToken)
+
+        if (!activeGuestToken) {
             if (hasStoredGuest) {
                 clearGuestMode()
             }
+            return
+        }
+
+        if (lastUpgradeAttemptTokenRef.current === activeGuestToken) {
+            return
+        }
+
+        lastUpgradeAttemptTokenRef.current = activeGuestToken
+        let cancelled = false
+
+        ;(async () => {
+            try {
+                await fetch('/api/user/upgrade-guest', {
+                    method: 'POST',
+                    headers: {
+                        'X-Guest-Token': activeGuestToken,
+                    },
+                })
+            } catch {
+                // Ignore migration failures in client state transition path.
+                // The backend migration is idempotent and can be retried safely.
+            } finally {
+                if (!cancelled) {
+                    clearGuestMode()
+                }
+            }
+        })()
+
+        return () => {
+            cancelled = true
         }
     }, [status, guestId, guestName, guestToken, clearGuestMode])
 


### PR DESCRIPTION
## Summary
- add `POST /api/user/upgrade-guest` endpoint to migrate guest progress into authenticated account
- make migration transaction idempotent (safe to retry if already migrated)
- add conflict-safe merge for `Players` rows when target account already has a row in the same game
- auto-trigger guest upgrade from `GuestContext` when session becomes authenticated (covers credentials and OAuth sign-ins)

## Migration behavior
- validates active authenticated session
- validates signed guest token from `X-Guest-Token`
- migrates shared gameplay/profile data currently tracked for guest+user:
  - `Players` (match history and stats source)
  - `Lobbies.creatorId`
  - `LobbyInvites` sender/receiver references
  - `Notifications`
  - `NotificationPreferences` (merged when both sides exist)
- deletes guest user in same transaction when migration completes

## Safety guarantees
- all DB mutations run in one transaction (rollback on failure)
- repeated calls are idempotent (`alreadyMigrated=true` when guest user no longer exists)
- player unique constraint conflicts (`gameId + userId`) are merged, not duplicated

## Tests
- added `__tests__/api/upgrade-guest-account.test.ts`:
  - 401 unauthorized
  - 400 invalid/missing guest token
  - idempotent already-migrated response
  - full migration + player conflict merge integrity
- updated `__tests__/contexts/GuestContext.auth-transition.test.tsx` to verify upgrade call on auth transition

## Verification
- `npm test -- __tests__/api/upgrade-guest-account.test.ts __tests__/contexts/GuestContext.test.tsx __tests__/contexts/GuestContext.auth-transition.test.tsx`
- `npm test -- __tests__/api/upgrade-guest-account.test.ts __tests__/api/guest-mode.test.ts __tests__/lib/request-auth.test.ts`
- `npm run ci:quick`
- pre-push hook suite passed

Closes #150