### PR TITLE
feat(lobby): support party invite flow directly from game hub create

### DIFF
--- a/app/lobby/create/page.tsx
+++ b/app/lobby/create/page.tsx
@@ -3,11 +3,13 @@
 import { useState, useEffect, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
+import dynamic from 'next/dynamic'
 import { useGuest } from '@/contexts/GuestContext'
 import { fetchWithGuest } from '@/lib/fetch-with-guest'
 import { clientLogger } from '@/lib/client-logger'
 import { useTranslation } from '@/lib/i18n-helpers'
 import type { RegisteredGameType } from '@/lib/game-catalog'
+import { showToast } from '@/lib/i18n-toast'
 import {
   trackLobbyCreateRequest,
   type AnalyticsGameType,
@@ -131,6 +133,8 @@ function isSelectableGameType(value: string | null | undefined): value is GameTy
 
 import { Disclosure } from '@headlessui/react'
 
+const FriendsListModal = dynamic(() => import('@/components/FriendsListModal'))
+
 function CreateLobbyPage() {
   const { t } = useTranslation()
   const router = useRouter()
@@ -160,6 +164,8 @@ function CreateLobbyPage() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [showPlayerWarning, setShowPlayerWarning] = useState(false)
+  const [showFriendsModal, setShowFriendsModal] = useState(false)
+  const [selectedFriendIds, setSelectedFriendIds] = useState<string[]>([])
 
   useEffect(() => {
     clientLogger.log('🎮 Game type selected:', selectedGameType)
@@ -182,6 +188,11 @@ function CreateLobbyPage() {
       router.push('/')
     }
   }, [status, isGuest, router])
+
+  const handlePartySelection = async (friendIds: string[]) => {
+    setSelectedFriendIds(friendIds)
+    showToast.success('toast.saved')
+  }
 
   if (!gameInfo) {
     return (
@@ -283,6 +294,43 @@ function CreateLobbyPage() {
         startedAt: createStartedAt,
         isGuest,
       })
+
+      if (!isGuest && selectedFriendIds.length > 0) {
+        try {
+          const inviteResponse = await fetch(`/api/lobby/${lobbyCode}/invite`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ friendIds: selectedFriendIds }),
+          })
+
+          const inviteResult = await inviteResponse.json().catch(() => null)
+          if (!inviteResponse.ok) {
+            clientLogger.warn('Lobby created but party invite request failed', {
+              lobbyCode,
+              status: inviteResponse.status,
+              error: inviteResult,
+            })
+          } else {
+            clientLogger.log('Party invite flow completed during lobby creation', {
+              lobbyCode,
+              invitedCount:
+                typeof inviteResult?.invitedCount === 'number'
+                  ? inviteResult.invitedCount
+                  : selectedFriendIds.length,
+              skippedCount: Array.isArray(inviteResult?.skippedFriendIds)
+                ? inviteResult.skippedFriendIds.length
+                : 0,
+            })
+          }
+        } catch (inviteError) {
+          clientLogger.warn('Lobby created but party invite request threw an error', {
+            lobbyCode,
+            error: inviteError,
+          })
+        }
+      }
 
       clientLogger.log('✅ Lobby created successfully, redirecting to:', lobbyCode)
       router.push(`/lobby/${lobbyCode}`)
@@ -642,6 +690,33 @@ function CreateLobbyPage() {
                 </p>
               </div>
 
+              {!isGuest && (
+                <div className="rounded-xl border border-white/20 bg-white/10 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-bold text-white">👥 {t('lobby.invite.title')}</p>
+                      <p className="text-xs text-white/70">
+                        {t('lobby.invite.description')}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setShowFriendsModal(true)}
+                      className="px-3 py-2 rounded-xl bg-white/20 hover:bg-white/30 text-white text-sm font-semibold transition-all"
+                    >
+                      {selectedFriendIds.length > 0
+                        ? t('lobby.invite.send', { count: selectedFriendIds.length })
+                        : t('lobby.invite.title')}
+                    </button>
+                  </div>
+                  {selectedFriendIds.length > 0 && (
+                    <p className="mt-3 text-xs text-emerald-200">
+                      {t('lobby.invite.send', { count: selectedFriendIds.length })}
+                    </p>
+                  )}
+                </div>
+              )}
+
               {/* Game Mode - Only for games that support it */}
               {gameInfo.settings.hasGameModes && (
                 <div>
@@ -769,6 +844,17 @@ function CreateLobbyPage() {
           </div>
         </div>
       </section>
+
+      {!isGuest && (
+        <FriendsListModal
+          isOpen={showFriendsModal}
+          onClose={() => setShowFriendsModal(false)}
+          onSelect={handlePartySelection}
+          initialSelectedFriendIds={selectedFriendIds}
+          confirmLabel={t('common.save')}
+          lobbyCode="pending-lobby"
+        />
+      )}
     </div>
   )
 }

--- a/components/FriendsListModal.tsx
+++ b/components/FriendsListModal.tsx
@@ -20,7 +20,10 @@ interface Friend {
 interface FriendsListModalProps {
   isOpen: boolean
   onClose: () => void
-  onInvite: (friendIds: string[]) => Promise<{ invitedCount: number; skippedCount: number }>
+  onInvite?: (friendIds: string[]) => Promise<{ invitedCount: number; skippedCount: number }>
+  onSelect?: (friendIds: string[]) => Promise<void> | void
+  initialSelectedFriendIds?: string[]
+  confirmLabel?: string
   lobbyCode: string
 }
 
@@ -28,6 +31,9 @@ export default function FriendsListModal({
   isOpen, 
   onClose, 
   onInvite,
+  onSelect,
+  initialSelectedFriendIds = [],
+  confirmLabel,
   lobbyCode 
 }: FriendsListModalProps) {
   const { t } = useTranslation()
@@ -91,8 +97,9 @@ export default function FriendsListModal({
   useEffect(() => {
     if (isOpen) {
       loadFriends()
+      setSelectedFriends(new Set(initialSelectedFriendIds))
     }
-  }, [isOpen])
+  }, [isOpen, initialSelectedFriendIds])
 
   const loadFriends = async () => {
     try {
@@ -129,6 +136,19 @@ export default function FriendsListModal({
 
     setInviting(true)
     try {
+      const selectedIds = Array.from(selectedFriends)
+
+      if (onSelect) {
+        await onSelect(selectedIds)
+        setSelectedFriends(new Set())
+        onClose()
+        return
+      }
+
+      if (!onInvite) {
+        throw new Error('Invite handler is not configured')
+      }
+
       const result = await onInvite(Array.from(selectedFriends))
       if (result.skippedCount > 0) {
         showToast.info('toast.inviteSkippedUsers', undefined, { count: result.skippedCount })
@@ -254,7 +274,7 @@ export default function FriendsListModal({
               >
                 {inviting
                   ? t('common.loading')
-                  : t('lobby.invite.send', { count: selectedFriends.size })}
+                  : confirmLabel || (onSelect ? t('common.save') : t('lobby.invite.send', { count: selectedFriends.size }))}
               </button>
               <button
                 onClick={onClose}


### PR DESCRIPTION
## Summary
- extend game-hub lobby creation flow to support party selection before lobby is created
- allow hosts to pick friends in `/lobby/create` and automatically send invites right after successful lobby creation
- reuse existing lobby invite backend (`POST /api/lobby/[code]/invite`) and invite telemetry source of truth (`LobbyInvites.sentAt/acceptedAt`)

## What changed
- `app/lobby/create/page.tsx`
  - add party selection UI block for authenticated users
  - integrate `FriendsListModal` in selection mode on create page
  - persist selected friend IDs in component state
  - after lobby create success, auto-send invite batch to selected friends
  - keep lobby creation resilient: invite failures do not block lobby creation redirect
- `components/FriendsListModal.tsx`
  - add optional selection-only mode (`onSelect`) for pre-lobby party picking
  - support initial selected IDs and configurable confirm label
  - preserve existing invite-now behavior for lobby waiting room

## Acceptance mapping
- Host can create and invite from game hub in one flow: ✅
- Invited users get actionable invite path (existing socket/email + join URL): ✅
- Host can start when invited players join (existing waiting room start flow): ✅
- Resilience to reconnect/stale invite handling remains backend-driven through existing invite model and join acceptance updates: ✅
- Invite telemetry:
  - sent tracked via `LobbyInvites.sentAt`
  - accepted tracked via `LobbyInvites.acceptedAt`
  - pending/stale derivable from invites with `acceptedAt = null`

## Verification
- `npm run ci:quick`
- `npm test -- __tests__/api/social-loop-api.test.ts`
- pre-push hook suite passed

Closes #147