### PR TITLE
fix(security): protect bot-turn endpoint with internal/auth guard

### DIFF
--- a/__tests__/api/game-bot-turn-auth.test.ts
+++ b/__tests__/api/game-bot-turn-auth.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/game/[gameId]/bot-turn/route'
+import { getRequestAuthUser } from '@/lib/request-auth'
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    games: {
+      findUnique: jest.fn(),
+    },
+    players: {
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/game-registry', () => ({
+  restoreGameEngine: jest.fn(),
+  hasBotSupport: jest.fn(() => true),
+}))
+
+jest.mock('@/lib/bots', () => ({
+  executeBotTurn: jest.fn(),
+  getBotDifficulty: jest.fn(() => 'medium'),
+}))
+
+jest.mock('@/lib/socket-url', () => ({
+  notifySocket: jest.fn(),
+}))
+
+jest.mock('@/lib/disconnected-turn', () => ({
+  advanceTurnPastDisconnectedPlayers: jest.fn((state: unknown) => ({
+    changed: false,
+    skippedPlayerIds: [],
+    currentPlayerId: (state as { currentPlayerId?: string })?.currentPlayerId ?? null,
+  })),
+}))
+
+jest.mock('@/lib/game-replay', () => ({
+  appendGameReplaySnapshot: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@/lib/request-auth', () => ({
+  getRequestAuthUser: jest.fn(),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}))
+
+const mockGetRequestAuthUser = getRequestAuthUser as jest.MockedFunction<typeof getRequestAuthUser>
+const originalSocketSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
+
+function buildRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost:3000/api/game/game-123/bot-turn', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/game/[gameId]/bot-turn auth guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.SOCKET_SERVER_INTERNAL_SECRET = 'test-internal-secret'
+  })
+
+  afterAll(() => {
+    process.env.SOCKET_SERVER_INTERNAL_SECRET = originalSocketSecret
+  })
+
+  it('returns 401 when request has no internal secret and no authenticated user', async () => {
+    mockGetRequestAuthUser.mockResolvedValue(null)
+
+    const response = await POST(
+      buildRequest({
+        botUserId: 'bot-1',
+        lobbyCode: 'ABCD12',
+      }),
+      { params: Promise.resolve({ gameId: 'game-123' }) }
+    )
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mockGetRequestAuthUser).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts valid internal secret and reaches payload validation without auth lookup', async () => {
+    const response = await POST(
+      buildRequest(
+        {
+          lobbyCode: 'ABCD12',
+        },
+        {
+          'X-Internal-Secret': 'test-internal-secret',
+        }
+      ),
+      { params: Promise.resolve({ gameId: 'game-123' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Bot user ID required' })
+    expect(mockGetRequestAuthUser).not.toHaveBeenCalled()
+  })
+
+  it('accepts authenticated external request and reaches payload validation', async () => {
+    mockGetRequestAuthUser.mockResolvedValue({
+      id: 'player-1',
+      username: 'Player 1',
+      suspended: false,
+      isGuest: false,
+    } as any)
+
+    const response = await POST(
+      buildRequest({
+        lobbyCode: 'ABCD12',
+      }),
+      { params: Promise.resolve({ gameId: 'game-123' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Bot user ID required' })
+    expect(mockGetRequestAuthUser).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/api/game-state.test.ts
+++ b/__tests__/api/game-state.test.ts
@@ -57,6 +57,7 @@ const mockAppendGameReplaySnapshot = appendGameReplaySnapshot as jest.MockedFunc
 >
 const originalFetch = global.fetch
 const mockFetch = jest.fn()
+const originalSocketSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
 
 describe('POST /api/game/[gameId]/state', () => {
   const mockAuthUser = {
@@ -112,6 +113,7 @@ describe('POST /api/game/[gameId]/state', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env.SOCKET_SERVER_INTERNAL_SECRET = 'test-internal-secret'
     mockNotifySocket.mockResolvedValue(true as any)
     mockAppendGameReplaySnapshot.mockResolvedValue(undefined)
     mockFetch.mockResolvedValue({
@@ -123,6 +125,7 @@ describe('POST /api/game/[gameId]/state', () => {
 
   afterAll(() => {
     global.fetch = originalFetch
+    process.env.SOCKET_SERVER_INTERNAL_SECRET = originalSocketSecret
   })
 
   const buildRequest = (body: unknown) =>
@@ -451,6 +454,10 @@ describe('POST /api/game/[gameId]/state', () => {
       'http://localhost:3000/api/game/game-123/bot-turn',
       expect.objectContaining({
         method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Internal-Secret': 'test-internal-secret',
+        }),
       }),
     )
     const [, requestInit] = mockFetch.mock.calls[0]
@@ -529,6 +536,10 @@ describe('POST /api/game/[gameId]/state', () => {
       'http://localhost:3000/api/game/game-123/bot-turn',
       expect.objectContaining({
         method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Internal-Secret': 'test-internal-secret',
+        }),
       }),
     )
     const [, requestInit] = mockFetch.mock.calls[0]
@@ -598,6 +609,10 @@ describe('POST /api/game/[gameId]/state', () => {
       'http://localhost:3000/api/game/game-123/bot-turn',
       expect.objectContaining({
         method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Internal-Secret': 'test-internal-secret',
+        }),
       }),
     )
     const [, requestInit] = mockFetch.mock.calls[0]

--- a/app/api/game/[gameId]/bot-turn/route.ts
+++ b/app/api/game/[gameId]/bot-turn/route.ts
@@ -8,6 +8,7 @@ import { notifySocket } from '@/lib/socket-url'
 import { apiLogger } from '@/lib/logger'
 import { advanceTurnPastDisconnectedPlayers } from '@/lib/disconnected-turn'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
+import { getRequestAuthUser } from '@/lib/request-auth'
 
 export const maxDuration = 60 // Allow up to 60 seconds for bot execution
 
@@ -26,6 +27,22 @@ export async function POST(
   try {
     const paramsData = await params
     gameId = paramsData.gameId
+    const configuredInternalSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
+    const providedInternalSecret = request.headers.get('X-Internal-Secret')
+    const hasConfiguredInternalSecret =
+      typeof configuredInternalSecret === 'string' && configuredInternalSecret.length > 0
+    const isAuthorizedInternalRequest =
+      hasConfiguredInternalSecret && providedInternalSecret === configuredInternalSecret
+    const requestUser = isAuthorizedInternalRequest ? null : await getRequestAuthUser(request)
+
+    if (!isAuthorizedInternalRequest && !requestUser?.id) {
+      log.warn('Unauthorized bot turn request', {
+        gameId: gameId,
+        hasInternalSecret: !!providedInternalSecret,
+      })
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
     const requestBody = await request.json()
     const { botUserId, lobbyCode, triggerSource, triggeredAt, turnEndToBotTriggerMs } = requestBody
     const resolvedTriggerSource =
@@ -117,6 +134,17 @@ export async function POST(
     if (!game) {
       log.error('Game not found', undefined, { gameId: gameId })
       return NextResponse.json({ error: 'Game not found' }, { status: 404 })
+    }
+
+    if (!isAuthorizedInternalRequest && requestUser?.id) {
+      const isParticipant = game.players.some((player) => player.userId === requestUser.id)
+      if (!isParticipant) {
+        log.warn('Forbidden bot turn request from non-participant', {
+          gameId: game.id,
+          requesterId: requestUser.id,
+        })
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+      }
     }
 
     const gameType = game.lobby.gameType

--- a/app/api/game/[gameId]/state/route.ts
+++ b/app/api/game/[gameId]/state/route.ts
@@ -108,6 +108,24 @@ function autoTriggerBotTurn(params: {
   const timeoutId = setTimeout(() => controller.abort(), BOT_TURN_TRIGGER_TIMEOUT_MS)
   const triggeredAt = Date.now()
   const turnEndToBotTriggerMs = resolveTurnEndToBotTriggerMs(authoritativeState, triggeredAt)
+  const internalSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
+  const forwardedAuthorization = request.headers.get('authorization')
+  const forwardedGuestToken = request.headers.get('X-Guest-Token')
+  const botTurnHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  if (internalSecret) {
+    botTurnHeaders['X-Internal-Secret'] = internalSecret
+  }
+
+  if (forwardedAuthorization) {
+    botTurnHeaders.authorization = forwardedAuthorization
+  }
+
+  if (forwardedGuestToken) {
+    botTurnHeaders['X-Guest-Token'] = forwardedGuestToken
+  }
 
   log.debug('Auto-triggering bot turn after player move', {
     gameId,
@@ -119,9 +137,7 @@ function autoTriggerBotTurn(params: {
 
   void fetch(botTurnApiUrl, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: botTurnHeaders,
     body: JSON.stringify({
       botUserId,
       lobbyCode,

--- a/app/api/game/create/route.ts
+++ b/app/api/game/create/route.ts
@@ -464,6 +464,24 @@ export async function POST(request: NextRequest) {
 
       // Trigger bot turn via separate HTTP request (fire and forget)
       const botApiUrl = `${request.nextUrl.origin}/api/game/${game.id}/bot-turn`
+      const internalSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
+      const forwardedAuthorization = request.headers.get('authorization')
+      const forwardedGuestToken = request.headers.get('X-Guest-Token')
+      const botTurnHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+      }
+
+      if (internalSecret) {
+        botTurnHeaders['X-Internal-Secret'] = internalSecret
+      }
+
+      if (forwardedAuthorization) {
+        botTurnHeaders.authorization = forwardedAuthorization
+      }
+
+      if (forwardedGuestToken) {
+        botTurnHeaders['X-Guest-Token'] = forwardedGuestToken
+      }
 
       // Add timeout to prevent hanging
       const controller = new AbortController()
@@ -471,9 +489,7 @@ export async function POST(request: NextRequest) {
 
       fetch(botApiUrl, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: botTurnHeaders,
         body: JSON.stringify({
           botUserId: dbCurrentPlayer.userId,
           lobbyCode: lobby.code,

--- a/app/lobby/[code]/hooks/useBotTurn.ts
+++ b/app/lobby/[code]/hooks/useBotTurn.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react'
 import { GameEngine } from '@/lib/game-engine'
 import { clientLogger } from '@/lib/client-logger'
 import { showToast } from '@/lib/i18n-toast'
+import { fetchWithGuest } from '@/lib/fetch-with-guest'
 
 interface GamePlayer {
   userId: string
@@ -59,7 +60,7 @@ export function useBotTurn({
     clientLogger.log('🤖 Triggering bot turn for:', botUserId)
 
     try {
-      const response = await fetch(`/api/game/${gameId}/bot-turn`, {
+      const response = await fetchWithGuest(`/api/game/${gameId}/bot-turn`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ botUserId, lobbyCode: code }),


### PR DESCRIPTION
## Summary
Fixes critical security gap in `POST /api/game/[gameId]/bot-turn`.

- Adds auth gate: allow requests that provide valid `X-Internal-Secret` **or** authenticated game participants
- Returns `401` for unauthenticated calls
- Returns `403` when authenticated caller is not a player in the game
- Propagates internal secret/auth context when auto-triggering bot turns from server routes
- Uses `fetchWithGuest` for client bot-turn trigger to preserve guest auth headers
- Adds focused auth-route tests

## Files
- `app/api/game/[gameId]/bot-turn/route.ts`
- `app/api/game/[gameId]/state/route.ts`
- `app/api/game/create/route.ts`
- `app/lobby/[code]/hooks/useBotTurn.ts`
- `__tests__/api/game-bot-turn-auth.test.ts`
- `__tests__/api/game-state.test.ts`

## Validation
- `npm test -- __tests__/api/game-bot-turn-auth.test.ts __tests__/api/game-state.test.ts`
- `npm run ci:quick`
- pre-push hook suite passed

Closes #160