### PR TITLE
fix(lobby): eliminate join TOCTOU with serializable transaction

### DIFF
--- a/__tests__/api/lobby-code.test.ts
+++ b/__tests__/api/lobby-code.test.ts
@@ -13,6 +13,7 @@ import { notifySocket } from '@/lib/socket-url'
 // Mock dependencies
 jest.mock('@/lib/db', () => ({
   prisma: {
+    $transaction: jest.fn(),
     lobbies: {
       findUnique: jest.fn(),
       update: jest.fn(),
@@ -88,6 +89,7 @@ describe('GET /api/lobby/[code]', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPrisma.$transaction.mockImplementation(async (callback: any) => callback(mockPrisma as any))
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({}),
@@ -349,6 +351,39 @@ describe('POST /api/lobby/[code]', () => {
     const data = await response.json()
     expect(data.player).toBeDefined()
     expect(data.game).toBeDefined()
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1)
+    expect(mockPrisma.$transaction.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ isolationLevel: 'Serializable' })
+    )
+  })
+
+  it('should return 400 when lobby is full', async () => {
+    const gameWithPlayers = {
+      ...mockGame,
+      players: [],
+      state: JSON.stringify({ scores: [] }),
+    }
+
+    mockGetServerSession.mockResolvedValue(mockSession as any)
+    mockPrisma.users.findUnique.mockResolvedValue(mockUser as any)
+    mockPrisma.lobbies.findUnique.mockResolvedValue({
+      ...mockLobby,
+      maxPlayers: 2,
+      games: [gameWithPlayers],
+    } as any)
+    mockPrisma.players.findUnique.mockResolvedValue(null)
+    mockPrisma.players.count.mockResolvedValue(2)
+
+    const request = new NextRequest('http://localhost:3000/api/lobby/ABC123', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    })
+    const response = await POST(request, { params: { code: 'ABC123' } as any })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Lobby is full')
+    expect(mockPrisma.players.create).not.toHaveBeenCalled()
   })
 })
 

--- a/app/api/lobby/[code]/route.ts
+++ b/app/api/lobby/[code]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { notifySocket } from '@/lib/socket-url'
 import { apiLogger } from '@/lib/logger'
@@ -23,6 +24,15 @@ import { toPersistedGameType } from '@/lib/game-type-storage'
 const apiLimiter = rateLimit(rateLimitPresets.api)
 const gameLimiter = rateLimit(rateLimitPresets.game)
 const UNLIMITED_SPECTATORS_VALUE = 0
+const MAX_JOIN_SERIALIZABLE_RETRIES = 2
+
+class LobbyFullError extends Error {
+  constructor() {
+    super('Lobby is full')
+    this.name = 'LobbyFullError'
+  }
+}
+
 function resolveTurnTimerSeconds(turnTimer: unknown): number {
   if (typeof turnTimer !== 'number' || !Number.isFinite(turnTimer)) return 0
   return Math.max(0, Math.floor(turnTimer))
@@ -658,36 +668,62 @@ export async function POST(
       return NextResponse.json({ game, player: existingPlayer })
     }
 
-    // Count current players
-    const playerCount = await prisma.players.count({
-      where: { gameId: game.id },
-    })
+    let player: any
+    let attempt = 0
 
-    if (playerCount >= lobby.maxPlayers) {
-      return NextResponse.json(
-        { error: 'Lobby is full' },
-        { status: 400 }
-      )
-    }
+    while (true) {
+      try {
+        player = await prisma.$transaction(
+          async (tx) => {
+            const playerCount = await tx.players.count({
+              where: { gameId: game.id },
+            })
 
-    // Add player to game
-    const player = await prisma.players.create({
-      data: {
-        gameId: game.id,
-        userId: userId,
-        position: playerCount,
-        scorecard: JSON.stringify({}),
-      },
-      include: {
-        user: {
-          select: {
-            id: true,
-            username: true,
-            isGuest: true,
+            if (playerCount >= lobby.maxPlayers) {
+              throw new LobbyFullError()
+            }
+
+            return tx.players.create({
+              data: {
+                gameId: game.id,
+                userId: userId,
+                position: playerCount,
+                scorecard: JSON.stringify({}),
+              },
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    username: true,
+                    isGuest: true,
+                  },
+                },
+              },
+            })
           },
-        },
-      },
-    })
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+        )
+        break
+      } catch (error) {
+        if (error instanceof LobbyFullError) {
+          return NextResponse.json(
+            { error: 'Lobby is full' },
+            { status: 400 }
+          )
+        }
+
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2034' &&
+          attempt < MAX_JOIN_SERIALIZABLE_RETRIES
+        ) {
+          attempt += 1
+          continue
+        }
+
+        throw error
+      }
+    }
 
     // Notify all clients via WebSocket that a player joined
     await notifySocket(


### PR DESCRIPTION
## Summary
Fixes race condition in `POST /api/lobby/[code]` where concurrent joins could exceed `maxPlayers`.

- Moves `players.count` + `players.create` into a single serializable transaction
- Returns deterministic `400 Lobby is full` from within the transactional capacity check
- Retries transaction on serialization conflicts (`P2034`) with bounded attempts
- Keeps existing behavior for existing-player/idempotent join path
- Adds/updates route tests for transaction isolation and full-lobby handling

## Files
- `app/api/lobby/[code]/route.ts`
- `__tests__/api/lobby-code.test.ts`

## Validation
- `npm test -- __tests__/api/lobby-code.test.ts`
- `npm run ci:quick`
- pre-push hook suite passed

Closes #161