### PR TITLE
fix(realtime): dispose disconnect timers during graceful shutdown

### DIFF
--- a/socket-server.ts
+++ b/socket-server.ts
@@ -832,6 +832,9 @@ const gracefulShutdown = async (signal: string) => {
   isShuttingDown = true
   logger.info(`${signal} received - starting graceful shutdown`)
 
+  // Cancel delayed disconnect timers before shutting down DB/socket resources.
+  disconnectSyncManager.dispose()
+
   // Stop accepting new connections
   server.close(() => {
     logger.info('HTTP server closed')


### PR DESCRIPTION
## Summary
Fixes graceful shutdown gap in `socket-server.ts` by disposing pending disconnect-grace timers before closing network/database resources.

- Calls `disconnectSyncManager.dispose()` at shutdown start
- Prevents delayed disconnect callbacks from firing while Prisma/socket resources are tearing down
- Keeps existing shutdown order and timeout behavior unchanged

## Files
- `socket-server.ts`

## Validation
- `npm test -- __tests__/socket/disconnect-sync.test.ts`
- `npm run ci:quick`
- pre-push hook suite passed

Closes #165