### PR TITLE
fix(security): enforce CSRF for token-based unsafe API requests

### DIFF
--- a/__tests__/middleware-csrf.test.ts
+++ b/__tests__/middleware-csrf.test.ts
@@ -15,11 +15,20 @@ jest.mock('@/lib/socket-url', () => ({
 }))
 
 const mockGetToken = getToken as jest.MockedFunction<typeof getToken>
+const originalInternalSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
+const originalCronSecret = process.env.CRON_SECRET
 
 describe('middleware CSRF enforcement', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetToken.mockResolvedValue(null as any)
+    process.env.SOCKET_SERVER_INTERNAL_SECRET = 'test-internal-secret'
+    process.env.CRON_SECRET = 'test-cron-secret'
+  })
+
+  afterAll(() => {
+    process.env.SOCKET_SERVER_INTERNAL_SECRET = originalInternalSecret
+    process.env.CRON_SECRET = originalCronSecret
   })
 
   it('allows same-origin authenticated unsafe API requests', async () => {
@@ -52,11 +61,38 @@ describe('middleware CSRF enforcement', () => {
     expect(payload.error).toBe('Invalid origin. Possible CSRF attack.')
   })
 
-  it('does not enforce CSRF when no authenticated session cookie is present', async () => {
+  it('rejects cross-origin unsafe API requests without trusted server credentials', async () => {
     const request = new NextRequest('http://localhost:3000/api/friends/request', {
       method: 'POST',
       headers: {
         origin: 'https://evil.example',
+      },
+    })
+
+    const response = await middleware(request)
+
+    expect(response.status).toBe(403)
+  })
+
+  it('allows cross-origin internal requests with valid internal secret header', async () => {
+    const request = new NextRequest('http://localhost:3000/api/game/game-123/state', {
+      method: 'POST',
+      headers: {
+        origin: 'https://evil.example',
+        'X-Internal-Secret': 'test-internal-secret',
+      },
+    })
+
+    const response = await middleware(request)
+
+    expect(response.status).not.toBe(403)
+  })
+
+  it('allows machine requests with valid cron bearer token even without origin header', async () => {
+    const request = new NextRequest('http://localhost:3000/api/cron/maintenance', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-cron-secret',
       },
     })
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -41,12 +41,6 @@ const ALLOWED_CORS_ORIGIN_SET = new Set(
     .filter((origin): origin is string => origin !== null)
 )
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
-const AUTH_SESSION_COOKIE_NAMES = [
-  'next-auth.session-token',
-  '__Secure-next-auth.session-token',
-  'authjs.session-token',
-  '__Secure-authjs.session-token',
-]
 
 function isLocalDevelopmentOrigin(origin: string): boolean {
   try {
@@ -72,8 +66,20 @@ function resolveAllowedCorsOrigin(origin: string | null): string | null {
   return null
 }
 
-function hasAuthenticatedSessionCookie(request: NextRequest): boolean {
-  return AUTH_SESSION_COOKIE_NAMES.some((name) => request.cookies.has(name))
+function hasValidInternalSecret(request: NextRequest): boolean {
+  const configuredSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
+  if (!configuredSecret) return false
+  return request.headers.get('X-Internal-Secret') === configuredSecret
+}
+
+function hasValidCronAuthorization(request: NextRequest): boolean {
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) return false
+  return request.headers.get('authorization') === `Bearer ${cronSecret}`
+}
+
+function isTrustedServerRequest(request: NextRequest): boolean {
+  return hasValidInternalSecret(request) || hasValidCronAuthorization(request)
 }
 
 function buildCspHeaderValue() {
@@ -191,7 +197,7 @@ export async function middleware(request: NextRequest) {
     }
 
     const isUnsafeMethod = !SAFE_METHODS.has(request.method.toUpperCase())
-    if (isUnsafeMethod && hasAuthenticatedSessionCookie(request) && !verifyCsrfToken(request)) {
+    if (isUnsafeMethod && !isTrustedServerRequest(request) && !verifyCsrfToken(request)) {
       return NextResponse.json(
         { error: 'Invalid origin. Possible CSRF attack.' },
         { status: 403 }


### PR DESCRIPTION
## Summary
Fixes CSRF gap in middleware where unsafe requests were only protected when session cookies were present.

- Enforces CSRF origin validation for all unsafe API methods by default
- Keeps trusted machine-to-machine paths working via explicit bypasses:
  - valid `X-Internal-Secret` (internal server calls)
  - valid `Authorization: Bearer <CRON_SECRET>` (cron endpoints)
- Preserves same-origin request behavior for regular browser clients
- Expands middleware CSRF test coverage for token-based/cross-origin and trusted bypass cases

## Files
- `middleware.ts`
- `__tests__/middleware-csrf.test.ts`

## Validation
- `npm test -- __tests__/middleware-csrf.test.ts`
- `npm run ci:quick`
- pre-push hook suite passed

Closes #166