### PR TITLE
fix: resolve socket reliability issues from #167

### DIFF
--- a/__tests__/socket/disconnect-sync.test.ts
+++ b/__tests__/socket/disconnect-sync.test.ts
@@ -151,4 +151,56 @@ describe('createDisconnectSyncManager', () => {
       })
     )
   })
+
+  it('does not remove players from games that already left waiting state', async () => {
+    const prisma = {
+      games: {
+        findFirst: jest.fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            id: 'game-1',
+            players: [
+              {
+                id: 'player-1',
+                userId: user.id,
+                user: {
+                  username: 'Alice',
+                  email: 'alice@example.com',
+                  bot: null,
+                },
+              },
+            ],
+          }),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      players: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      lobbies: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    }
+
+    const deps = createDeps({
+      disconnectGraceMs: 10,
+      prisma: prisma as unknown as DisconnectSyncOptions['prisma'],
+    })
+    const manager = createDisconnectSyncManager(deps)
+
+    manager.scheduleAbruptDisconnectForLobby('ABCD', user)
+
+    await new Promise((resolve) => setTimeout(resolve, 40))
+
+    expect(prisma.players.deleteMany).toHaveBeenCalledWith({
+      where: {
+        gameId: 'game-1',
+        userId: user.id,
+        game: {
+          status: 'waiting',
+        },
+      },
+    })
+    expect(deps.emitWithMetadata).not.toHaveBeenCalled()
+    expect(prisma.lobbies.updateMany).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/socket/handlers/player-typing.test.ts
+++ b/__tests__/socket/handlers/player-typing.test.ts
@@ -9,19 +9,20 @@ describe('createPlayerTypingHandler', () => {
     const checkRateLimit = jest.fn().mockReturnValue(true)
     const isSocketAuthorizedForLobby = jest.fn().mockReturnValue(true)
     const getUserDisplayName = jest.fn().mockReturnValue('Alice')
+    const emitWithMetadata = jest.fn()
 
     return {
       socketMonitor,
       checkRateLimit,
       isSocketAuthorizedForLobby,
       getUserDisplayName,
+      emitWithMetadata,
       ...overrides,
     }
   }
 
   function createSocket() {
-    const emit = jest.fn()
-    const to = jest.fn().mockReturnValue({ emit })
+    const to = jest.fn()
     const socket = {
       id: 'socket-1',
       data: {
@@ -33,13 +34,13 @@ describe('createPlayerTypingHandler', () => {
       rooms: new Set<string>(['socket-1', 'lobby:LOBBY1']),
       to,
     }
-    return { socket, to, emit }
+    return { socket }
   }
 
   it('broadcasts typing event to lobby peers when request is valid', () => {
     const deps = createDeps()
     const handler = createPlayerTypingHandler(deps)
-    const { socket, to, emit } = createSocket()
+    const { socket } = createSocket()
 
     handler(socket, {
       lobbyCode: ' LOBBY1 ',
@@ -50,8 +51,34 @@ describe('createPlayerTypingHandler', () => {
     expect(deps.socketMonitor.trackEvent).toHaveBeenCalledWith('player-typing')
     expect(deps.checkRateLimit).toHaveBeenCalledWith('socket-1')
     expect(deps.isSocketAuthorizedForLobby).toHaveBeenCalledWith(socket, 'LOBBY1')
-    expect(to).toHaveBeenCalledWith(SocketRooms.lobby('LOBBY1'))
-    expect(emit).toHaveBeenCalledWith(SocketEvents.PLAYER_TYPING, {
+    expect(deps.emitWithMetadata).toHaveBeenCalledWith(
+      SocketRooms.lobby('LOBBY1'),
+      SocketEvents.PLAYER_TYPING,
+      {
+        userId: 'user-1',
+        username: 'Alice',
+      }
+    )
+  })
+
+  it('throttles typing events per user and lobby to one event every 2 seconds', () => {
+    let now = 1000
+    const deps = createDeps({
+      now: () => now,
+    })
+    const handler = createPlayerTypingHandler(deps)
+    const { socket } = createSocket()
+
+    handler(socket, { lobbyCode: 'LOBBY1', userId: 'u', username: 'n' })
+    handler(socket, { lobbyCode: 'LOBBY1', userId: 'u', username: 'n' })
+
+    expect(deps.emitWithMetadata).toHaveBeenCalledTimes(1)
+
+    now += 2000
+    handler(socket, { lobbyCode: 'LOBBY1', userId: 'u', username: 'n' })
+
+    expect(deps.emitWithMetadata).toHaveBeenCalledTimes(2)
+    expect(deps.emitWithMetadata).toHaveBeenNthCalledWith(2, SocketRooms.lobby('LOBBY1'), SocketEvents.PLAYER_TYPING, {
       userId: 'user-1',
       username: 'Alice',
     })
@@ -62,12 +89,12 @@ describe('createPlayerTypingHandler', () => {
       checkRateLimit: jest.fn().mockReturnValue(false),
     })
     const handler = createPlayerTypingHandler(deps)
-    const { socket, to } = createSocket()
+    const { socket } = createSocket()
 
     handler(socket, { lobbyCode: 'LOBBY1', userId: 'u', username: 'n' })
 
     expect(deps.socketMonitor.trackEvent).toHaveBeenCalledWith('player-typing')
-    expect(to).not.toHaveBeenCalled()
+    expect(deps.emitWithMetadata).not.toHaveBeenCalled()
   })
 
   it('stops when lobby code is missing or not authorized', () => {
@@ -75,23 +102,23 @@ describe('createPlayerTypingHandler', () => {
       isSocketAuthorizedForLobby: jest.fn().mockReturnValue(false),
     })
     const handler = createPlayerTypingHandler(deps)
-    const { socket, to } = createSocket()
+    const { socket } = createSocket()
 
     handler(socket, { lobbyCode: '   ', userId: 'u', username: 'n' })
     handler(socket, { lobbyCode: 'LOBBY1', userId: 'u', username: 'n' })
 
     expect(deps.isSocketAuthorizedForLobby).toHaveBeenCalledTimes(1)
-    expect(to).not.toHaveBeenCalled()
+    expect(deps.emitWithMetadata).not.toHaveBeenCalled()
   })
 
   it('ignores malformed payload before auth checks', () => {
     const deps = createDeps()
     const handler = createPlayerTypingHandler(deps)
-    const { socket, to } = createSocket()
+    const { socket } = createSocket()
 
     handler(socket, { userId: 'u', username: 'n' } as any)
 
     expect(deps.isSocketAuthorizedForLobby).not.toHaveBeenCalled()
-    expect(to).not.toHaveBeenCalled()
+    expect(deps.emitWithMetadata).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/socket/socket-events.test.ts
+++ b/__tests__/socket/socket-events.test.ts
@@ -157,6 +157,7 @@ function createDependencies(overrides?: Record<string, unknown>) {
     checkRateLimit: deps.checkRateLimit,
     isSocketAuthorizedForLobby,
     getUserDisplayName: deps.getUserDisplayName,
+    emitWithMetadata: deps.emitWithMetadata,
   })
 
   const leaveLobby = createLeaveLobbyHandler({
@@ -269,11 +270,12 @@ describe('Socket event critical flow', () => {
       username: socket.data.user.username,
     })
 
-    expect(socket.roomEmits).toContainEqual({
-      room: SocketRooms.lobby('ABCD'),
-      event: SocketEvents.PLAYER_TYPING,
-      payload: { userId: 'user-1', username: 'Alice' },
-    })
+    expect(deps.emitWithMetadata).toHaveBeenNthCalledWith(
+      2,
+      SocketRooms.lobby('ABCD'),
+      SocketEvents.PLAYER_TYPING,
+      { userId: 'user-1', username: 'Alice' }
+    )
 
     deps.leaveLobby(socket, 'ABCD')
 

--- a/__tests__/socket/useSocketConnection.test.ts
+++ b/__tests__/socket/useSocketConnection.test.ts
@@ -536,6 +536,37 @@ describe('useSocketConnection', () => {
 
       expect(onGameUpdate).toHaveBeenCalledTimes(2)
     })
+
+    it('does not drop lower sequence events from different event types', async () => {
+      const onGameUpdate = jest.fn()
+      const onChatMessage = jest.fn()
+      renderHook(() =>
+        useSocketConnection({
+          ...defaultProps,
+          onGameUpdate,
+          onChatMessage,
+        })
+      )
+
+      await waitForSocketInit()
+      await flushAsync(10)
+
+      const gameUpdateHandler = getHandler<(data: any) => void>('game-update')
+      const chatMessageHandler = getHandler<(data: any) => void>('chat-message')
+
+      await act(async () => {
+        chatMessageHandler?.({ sequenceId: 50, id: 'c1', message: 'hello' })
+        await new Promise(resolve => setTimeout(resolve, 10))
+      })
+
+      await act(async () => {
+        gameUpdateHandler?.({ sequenceId: 49, payload: { state: { id: 's1' } } })
+        await new Promise(resolve => setTimeout(resolve, 10))
+      })
+
+      expect(onChatMessage).toHaveBeenCalledTimes(1)
+      expect(onGameUpdate).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('Cleanup', () => {

--- a/app/lobby/[code]/hooks/useSocketConnection.ts
+++ b/app/lobby/[code]/hooks/useSocketConnection.ts
@@ -73,7 +73,7 @@ export function useSocketConnection({
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const joinRetryTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const joinAckTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const lastProcessedSequenceRef = useRef(0)
+  const lastProcessedSequenceByEventRef = useRef<Map<string, number>>(new Map())
   const isRejoiningRef = useRef(false)
   const hasJoinedLobbyRef = useRef(false)
   const shouldSyncAfterJoinRef = useRef(false)
@@ -550,9 +550,9 @@ export function useSocketConnection({
           code
         )
 
-        // Reset dedup cursor on each fresh transport session.
+        // Reset dedup cursors on each fresh transport session.
         // Server sequence counters are in-memory and can reset on restart/redeploy.
-        lastProcessedSequenceRef.current = 0
+        lastProcessedSequenceByEventRef.current.clear()
 
         setIsConnected(true)
         setIsReconnecting(false)
@@ -800,15 +800,18 @@ export function useSocketConnection({
         handler: (payload: any) => void
       ) => {
         try {
-          if (data?.sequenceId !== undefined) {
-            if (data.sequenceId <= lastProcessedSequenceRef.current) {
+          if (typeof data?.sequenceId === 'number' && Number.isFinite(data.sequenceId)) {
+            const lastProcessedSequence = lastProcessedSequenceByEventRef.current.get(eventName) ?? 0
+
+            if (data.sequenceId <= lastProcessedSequence) {
               clientLogger.warn(`⚠️ Dropped duplicate ${eventName} event`, {
                 sequenceId: data.sequenceId,
-                lastProcessed: lastProcessedSequenceRef.current,
+                lastProcessed: lastProcessedSequence,
               })
               return
             }
-            lastProcessedSequenceRef.current = data.sequenceId
+
+            lastProcessedSequenceByEventRef.current.set(eventName, data.sequenceId)
           }
 
           handler(data)
@@ -823,7 +826,9 @@ export function useSocketConnection({
       newSocket.on(SocketEvents.CHAT_MESSAGE, (data) =>
         handleEventWithDeduplication('chat-message', data, onChatMessageRef.current)
       )
-      newSocket.on(SocketEvents.PLAYER_TYPING, (data) => onPlayerTypingRef.current(data))
+      newSocket.on(SocketEvents.PLAYER_TYPING, (data) =>
+        handleEventWithDeduplication('player-typing', data, onPlayerTypingRef.current)
+      )
       newSocket.on(SocketEvents.LOBBY_UPDATE, (data) =>
         handleEventWithDeduplication('lobby-update', data, onLobbyUpdateRef.current)
       )

--- a/lib/socket/disconnect-sync.ts
+++ b/lib/socket/disconnect-sync.ts
@@ -297,12 +297,19 @@ export function createDisconnectSyncManager({
       return { handled: false, gameId: waitingGame.id }
     }
 
-    await prisma.players.deleteMany({
+    const deleteResult = await prisma.players.deleteMany({
       where: {
         gameId: waitingGame.id,
         userId: user.id,
+        game: {
+          status: 'waiting',
+        },
       },
     })
+
+    if (deleteResult.count === 0) {
+      return { handled: false, gameId: waitingGame.id }
+    }
 
     const remainingPlayers = waitingGame.players.filter((player) => player.userId !== user.id)
     const remainingHumanPlayers = remainingPlayers.filter((player) => !player.user.bot).length

--- a/lib/socket/handlers/player-typing.ts
+++ b/lib/socket/handlers/player-typing.ts
@@ -5,6 +5,9 @@ interface SocketMonitorLike {
   trackEvent: (event: string) => void
 }
 
+const DEFAULT_TYPING_THROTTLE_MS = 2000
+const DEFAULT_TYPING_THROTTLE_STALE_MS = 60000
+
 interface PlayerTypingPayload {
   lobbyCode: string
   userId: string
@@ -16,6 +19,10 @@ interface PlayerTypingDependencies {
   checkRateLimit: (socketId: string) => boolean
   isSocketAuthorizedForLobby: (socket: PlayerTypingSocket, lobbyCode: string) => boolean
   getUserDisplayName: (user: { username?: string | null; email?: string | null } | undefined) => string
+  emitWithMetadata: (room: string, event: string, data: unknown) => void
+  now?: () => number
+  typingThrottleMs?: number
+  typingThrottleStaleMs?: number
 }
 
 export function createPlayerTypingHandler({
@@ -23,7 +30,31 @@ export function createPlayerTypingHandler({
   checkRateLimit,
   isSocketAuthorizedForLobby,
   getUserDisplayName,
+  emitWithMetadata,
+  now = () => Date.now(),
+  typingThrottleMs = DEFAULT_TYPING_THROTTLE_MS,
+  typingThrottleStaleMs = DEFAULT_TYPING_THROTTLE_STALE_MS,
 }: PlayerTypingDependencies) {
+  const lastTypingEventAtByMember = new Map<string, number>()
+  let lastCleanupAt = 0
+
+  const throttleMs = Math.max(0, typingThrottleMs)
+  const throttleStaleMs = Math.max(throttleMs, typingThrottleStaleMs)
+
+  function cleanupStaleThrottleEntries(timestamp: number) {
+    if (timestamp - lastCleanupAt < throttleStaleMs) {
+      return
+    }
+
+    lastCleanupAt = timestamp
+
+    for (const [key, lastTimestamp] of lastTypingEventAtByMember.entries()) {
+      if (timestamp - lastTimestamp >= throttleStaleMs) {
+        lastTypingEventAtByMember.delete(key)
+      }
+    }
+  }
+
   return (socket: PlayerTypingSocket, data: PlayerTypingPayload) => {
     socketMonitor.trackEvent('player-typing')
 
@@ -40,8 +71,23 @@ export function createPlayerTypingHandler({
       return
     }
 
-    socket.to(SocketRooms.lobby(normalizedLobbyCode)).emit(SocketEvents.PLAYER_TYPING, {
-      userId: socket.data.user.id,
+    const userId = socket.data.user.id
+    const nowTimestamp = now()
+    const throttledMemberKey = `${normalizedLobbyCode}:${userId}`
+    const lastTypingTimestamp = lastTypingEventAtByMember.get(throttledMemberKey)
+
+    if (
+      typeof lastTypingTimestamp === 'number' &&
+      nowTimestamp - lastTypingTimestamp < throttleMs
+    ) {
+      return
+    }
+
+    lastTypingEventAtByMember.set(throttledMemberKey, nowTimestamp)
+    cleanupStaleThrottleEntries(nowTimestamp)
+
+    emitWithMetadata(SocketRooms.lobby(normalizedLobbyCode), SocketEvents.PLAYER_TYPING, {
+      userId,
       username: getUserDisplayName(socket.data.user),
     })
   }

--- a/socket-server.ts
+++ b/socket-server.ts
@@ -162,6 +162,7 @@ const socketRateLimiter = createSocketRateLimiter({
   staleThresholdMs: 60000,
 })
 const RATE_LIMIT_CLEANUP_INTERVAL = 60000 // Clean up every 60 seconds
+const SPECTATOR_MEMBERS_SWEEP_INTERVAL = 120000 // Purge stale spectator cache every 2 minutes
 
 function checkRateLimit(socketId: string): boolean {
   return socketRateLimiter.checkRateLimit(socketId)
@@ -382,6 +383,65 @@ function getSpectatorSnapshot(lobbyCode: string) {
   return { count: spectators.length, spectators }
 }
 
+async function sweepStaleSpectatorLobbyMemberships() {
+  const trackedLobbyCodes = Array.from(spectatorMembersByLobby.keys())
+  if (trackedLobbyCodes.length === 0) {
+    return
+  }
+
+  try {
+    const activeLobbies = await prisma.lobbies.findMany({
+      where: {
+        code: {
+          in: trackedLobbyCodes,
+        },
+        isActive: true,
+      },
+      select: {
+        code: true,
+      },
+    })
+
+    const activeLobbyCodeSet = new Set(activeLobbies.map((lobby) => lobby.code))
+    const staleLobbyCodes = trackedLobbyCodes.filter((lobbyCode) => !activeLobbyCodeSet.has(lobbyCode))
+
+    if (staleLobbyCodes.length === 0) {
+      return
+    }
+
+    for (const lobbyCode of staleLobbyCodes) {
+      spectatorMembersByLobby.delete(lobbyCode)
+    }
+
+    await Promise.all(
+      staleLobbyCodes.map((lobbyCode) =>
+        prisma.lobbies.updateMany({
+          where: {
+            code: lobbyCode,
+            spectatorCount: {
+              gt: 0,
+            },
+          },
+          data: {
+            spectatorCount: 0,
+          },
+        })
+      )
+    )
+
+    io.to(SocketRooms.lobbyList()).emit(SocketEvents.LOBBY_LIST_UPDATE)
+
+    logger.info('Purged stale spectator membership cache entries', {
+      purgedCount: staleLobbyCodes.length,
+      lobbyCodes: staleLobbyCodes,
+    })
+  } catch (error) {
+    logger.error('Failed to sweep stale spectator membership cache', error as Error, {
+      trackedLobbies: trackedLobbyCodes.length,
+    })
+  }
+}
+
 async function handleSpectatorJoin(socket: SpectatorMembershipSocket, lobbyCode: string) {
   socketMonitor.trackEvent('join-spectators')
   try {
@@ -583,6 +643,10 @@ setInterval(() => {
   }
 }, RATE_LIMIT_CLEANUP_INTERVAL)
 
+setInterval(() => {
+  void sweepStaleSpectatorLobbyMemberships()
+}, SPECTATOR_MEMBERS_SWEEP_INTERVAL)
+
 // Authentication middleware
 io.use(
   createSocketAuthMiddleware({
@@ -650,6 +714,9 @@ const handlePlayerTyping = createPlayerTypingHandler({
   checkRateLimit,
   isSocketAuthorizedForLobby,
   getUserDisplayName,
+  emitWithMetadata: (room, event, data) => {
+    emitWithMetadata(io, room, event, data)
+  },
 })
 
 const { handleDisconnecting, handleDisconnect } = createConnectionLifecycleHandlers({

--- a/types/socket-events.ts
+++ b/types/socket-events.ts
@@ -181,7 +181,7 @@ export interface PlayerReadyPayload extends BaseEventPayload {
   isReady: boolean
 }
 
-export interface PlayerTypingPayload {
+export interface PlayerTypingPayload extends BaseEventPayload {
   lobbyCode: string
   userId: string
   username: string


### PR DESCRIPTION
## Summary
- guard waiting-lobby disconnect cleanup with `game.status = 'waiting'` and skip cleanup when no rows are deleted
- switch client sequence deduplication to per-event counters to prevent cross-event stale drops
- add periodic sweep for stale `spectatorMembersByLobby` entries and reset lobby spectator counts
- add per-user per-lobby typing throttle (1 event / 2s) and emit typing through metadata pipeline
- add/update tests for disconnect guard, per-event dedup, typing throttle/metadata, and socket flow expectations

## Validation
- `npm run ci:quick`
- `npm test -- __tests__/socket/useSocketConnection.test.ts __tests__/socket/handlers/player-typing.test.ts __tests__/socket/socket-events.test.ts __tests__/socket/disconnect-sync.test.ts`

Closes #167
