### PR TITLE
fix(game-engine): close defense-in-depth gaps in move/remove/restore paths

### DIFF
--- a/__tests__/lib/game-engine.test.ts
+++ b/__tests__/lib/game-engine.test.ts
@@ -85,13 +85,21 @@ describe('GameEngine', () => {
     it('should adjust current player index when removing', () => {
       game.addPlayer(player1)
       game.addPlayer(player2)
-      game.startGame()
       
       // Remove first player (current player)
       game.removePlayer('p1')
       
       const currentPlayer = game.getCurrentPlayer()
       expect(currentPlayer?.id).toBe('p2')
+    })
+
+    it('should not remove players while game is playing', () => {
+      game.addPlayer(player1)
+      game.addPlayer(player2)
+      game.startGame()
+
+      expect(game.removePlayer('p1')).toBe(false)
+      expect(game.getPlayers()).toHaveLength(2)
     })
   })
 
@@ -164,6 +172,38 @@ describe('GameEngine', () => {
       // Current player should not change
       const current = game.getCurrentPlayer()
       expect(current?.id).toBe('p1')
+    })
+
+    it('should reject moves when game status is not playing', () => {
+      const waitingMove: Move = {
+        playerId: 'p1',
+        type: 'valid',
+        data: {},
+        timestamp: new Date(),
+      }
+
+      expect(game.makeMove(waitingMove)).toBe(false)
+
+      game.startGame()
+      const playingMove: Move = {
+        playerId: 'p1',
+        type: 'valid',
+        data: {},
+        timestamp: new Date(),
+      }
+      expect(game.makeMove(playingMove)).toBe(true)
+
+      const finishedState = game.getState()
+      finishedState.status = 'finished'
+      game.restoreState(finishedState)
+
+      const afterFinishMove: Move = {
+        playerId: 'p2',
+        type: 'valid',
+        data: {},
+        timestamp: new Date(),
+      }
+      expect(game.makeMove(afterFinishMove)).toBe(false)
     })
 
     it('should detect win condition manually', () => {
@@ -249,8 +289,41 @@ describe('GameEngine', () => {
       }
       
       game.restoreState(corruptedState)
-      
+
       expect(game.getPlayers()).toEqual([])
+    })
+
+    it('should restore config from persisted state payload', () => {
+      const savedState = game.getState()
+      const restoredConfig = {
+        maxPlayers: 6,
+        minPlayers: 2,
+        timeLimit: 15,
+        rules: { speedMode: true },
+      }
+
+      game.restoreState({
+        ...savedState,
+        config: restoredConfig,
+      })
+
+      expect(game.getConfig()).toEqual(restoredConfig)
+    })
+
+    it('should deep clone restored nested state objects', () => {
+      game.addPlayer(player1)
+      game.addPlayer(player2)
+      game.startGame()
+
+      const externalState = game.getState()
+      game.restoreState(externalState)
+
+      ;(externalState.data as { value: number }).value = 999
+      externalState.players[0].name = 'Mutated outside'
+
+      const restored = game.getState()
+      expect((restored.data as { value: number }).value).not.toBe(999)
+      expect(restored.players[0].name).not.toBe('Mutated outside')
     })
   })
 

--- a/__tests__/lib/game-registry.test.ts
+++ b/__tests__/lib/game-registry.test.ts
@@ -112,6 +112,29 @@ describe('Game Registry', () => {
       expect(restored.getState().status).toBe('playing')
     })
 
+    it('should preserve custom game config when restoring from saved state', () => {
+      const original = createGameEngine('yahtzee', 'restore-cfg', {
+        maxPlayers: 6,
+        minPlayers: 2,
+        timeLimit: 12,
+        rules: { targetRounds: 5, hardMode: true },
+      })
+      original.addPlayer({ id: 'p1', name: 'Player 1' })
+      original.addPlayer({ id: 'p2', name: 'Player 2' })
+
+      const savedState = original.getState()
+      const restored = restoreGameEngine('yahtzee', 'restore-cfg', savedState)
+
+      expect(restored.getConfig()).toEqual(original.getConfig())
+      expect(restored.getConfig().maxPlayers).toBe(6)
+      expect(restored.getConfig().rules).toEqual(
+        expect.objectContaining({
+          targetRounds: 5,
+          hardMode: true,
+        })
+      )
+    })
+
     it('should throw error for unknown game types', () => {
       expect(() => restoreGameEngine('unknown', 'id', {}))
         .toThrow('Unknown game type')

--- a/lib/game-engine.ts
+++ b/lib/game-engine.ts
@@ -26,11 +26,36 @@ export interface GameState<TGameData = unknown> {
   updatedAt: Date;
 }
 
+export interface RestorableGameState<TGameData = unknown> extends GameState<TGameData> {
+  config?: GameConfig;
+}
+
 export interface GameConfig {
   maxPlayers: number;
   minPlayers: number;
   timeLimit?: number; // in minutes
   rules?: Record<string, any>;
+}
+
+function cloneDeep<T>(value: T): T {
+  if (value === null || value === undefined || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneDeep(item)) as T;
+  }
+
+  const cloned: Record<string, unknown> = {};
+  for (const [key, itemValue] of Object.entries(value as Record<string, unknown>)) {
+    cloned[key] = cloneDeep(itemValue);
+  }
+
+  return cloned as T;
 }
 
 /**
@@ -87,6 +112,10 @@ export abstract class GameEngine {
   }
 
   removePlayer(playerId: string): boolean {
+    if (this.state.status === 'playing') {
+      return false;
+    }
+
     const index = this.state.players.findIndex(p => p.id === playerId);
     if (index === -1) return false;
 
@@ -119,6 +148,10 @@ export abstract class GameEngine {
   }
 
   makeMove(move: Move): boolean {
+    if (this.state.status !== 'playing' && !this.canProcessMoveWhenNotPlaying(move)) {
+      return false;
+    }
+
     if (!this.validateMove(move)) {
       return false;
     }
@@ -147,13 +180,22 @@ export abstract class GameEngine {
     return true;
   }
 
+  // Override in rare cases where a move must be allowed outside "playing" status.
+  // Default remains deny-by-default for defense in depth.
+  protected canProcessMoveWhenNotPlaying(_move: Move): boolean {
+    return false;
+  }
+
   private nextPlayer(): void {
     this.state.currentPlayerIndex = (this.state.currentPlayerIndex + 1) % this.state.players.length;
     this.state.lastMoveAt = Date.now(); // Track when turn changed
   }
 
-  getState(): GameState {
-    return { ...this.state };
+  getState(): RestorableGameState {
+    return {
+      ...this.state,
+      config: cloneDeep(this.config),
+    };
   }
 
   getCurrentPlayer(): Player | null {
@@ -177,12 +219,19 @@ export abstract class GameEngine {
   }
 
   // Method to restore state from saved data
-  restoreState(savedState: GameState): void {
+  restoreState(savedState: RestorableGameState): void {
     // Ensure players is an array when restoring state
     if (savedState && typeof savedState === 'object') {
+      const { config, ...stateWithoutConfig } = savedState;
       this.state = {
-        ...savedState,
-        players: Array.isArray(savedState.players) ? savedState.players : [],
+        ...cloneDeep(stateWithoutConfig),
+        players: Array.isArray(savedState.players)
+          ? cloneDeep(savedState.players)
+          : [],
+      };
+
+      if (config && typeof config === 'object') {
+        this.config = cloneDeep(config);
       }
     }
   }

--- a/lib/game-registry.ts
+++ b/lib/game-registry.ts
@@ -243,7 +243,8 @@ export function restoreGameEngine(
   gameId: string,
   savedState: any,
 ): GameEngine {
-  const engine = createGameEngine(gameType, gameId)
+  const savedConfig = extractSavedGameConfig(savedState)
+  const engine = createGameEngine(gameType, gameId, savedConfig)
   engine.restoreState(savedState)
   return engine
 }
@@ -305,4 +306,44 @@ export function isSupportedGameType(value: string): value is SupportedGameType {
     (value === 'liars_party' && isLiarsPartyEnabled()) ||
     (value === 'fake_artist' && isFakeArtistEnabled())
   )
+}
+
+function extractSavedGameConfig(savedState: unknown): Partial<GameConfig> | undefined {
+  if (!savedState || typeof savedState !== 'object') {
+    return undefined
+  }
+
+  const maybeConfig = (savedState as { config?: unknown }).config
+  if (!maybeConfig || typeof maybeConfig !== 'object') {
+    return undefined
+  }
+
+  const rawConfig = maybeConfig as Partial<GameConfig>
+  const normalized: Partial<GameConfig> = {}
+
+  if (
+    typeof rawConfig.minPlayers === 'number' &&
+    Number.isFinite(rawConfig.minPlayers) &&
+    rawConfig.minPlayers > 0
+  ) {
+    normalized.minPlayers = Math.floor(rawConfig.minPlayers)
+  }
+
+  if (
+    typeof rawConfig.maxPlayers === 'number' &&
+    Number.isFinite(rawConfig.maxPlayers) &&
+    rawConfig.maxPlayers > 0
+  ) {
+    normalized.maxPlayers = Math.floor(rawConfig.maxPlayers)
+  }
+
+  if (typeof rawConfig.timeLimit === 'number' && Number.isFinite(rawConfig.timeLimit)) {
+    normalized.timeLimit = rawConfig.timeLimit
+  }
+
+  if (rawConfig.rules && typeof rawConfig.rules === 'object' && !Array.isArray(rawConfig.rules)) {
+    normalized.rules = { ...(rawConfig.rules as Record<string, unknown>) }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined
 }

--- a/lib/games/tic-tac-toe-game.ts
+++ b/lib/games/tic-tac-toe-game.ts
@@ -172,6 +172,10 @@ export class TicTacToeGame extends GameEngine {
     ]
   }
 
+  protected canProcessMoveWhenNotPlaying(move: Move): boolean {
+    return move.type === 'next-round' && this.state.status === 'finished'
+  }
+
   protected shouldAdvanceTurn(move: Move): boolean {
     if (move.type === 'next-round') {
       return false


### PR DESCRIPTION
## Summary
- enforce deny-by-default status guard in base `GameEngine.makeMove`, with an explicit opt-in hook for valid non-playing transitions
- block `removePlayer` while game status is `playing` to avoid index/data corruption from array splicing
- persist engine config in game state payload and restore config when rebuilding engines from saved state
- deep-clone restored state/config in `restoreState` to prevent external reference mutation after restore
- allow TicTacToe's `next-round` move explicitly while status is `finished` to preserve match progression behavior
- add regression tests for all of the above (`game-engine` and `game-registry`)

## Validation
- `npm run ci:quick`
- `npm test -- __tests__/lib/game-engine.test.ts __tests__/lib/game-registry.test.ts __tests__/lib/games/tic-tac-toe-game.test.ts __tests__/lib/games/all-games-integration.test.ts`
- `npm test -- __tests__/lib/games`

Closes #169
