### PR TITLE
test(api): fix guest-mode mock for transactional join path

### DIFF
--- a/__tests__/api/guest-mode.test.ts
+++ b/__tests__/api/guest-mode.test.ts
@@ -14,6 +14,7 @@ import { getOrCreateBotUser } from '@/lib/bot-helpers'
 
 jest.mock('@/lib/db', () => ({
   prisma: {
+    $transaction: jest.fn(),
     lobbies: {
       findUnique: jest.fn(),
       create: jest.fn(),
@@ -112,6 +113,7 @@ describe('Guest mode API endpoints', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockPrisma.$transaction.mockImplementation(async (callback: any) => callback(mockPrisma as any))
     mockGetRequestAuthUser.mockResolvedValue(guestUser)
   })
 


### PR DESCRIPTION
## Summary
- update `guest-mode` API test mocks to include `prisma.$transaction`
- align the test harness with serializable join logic used in `POST /api/lobby/[code]`
- fix failing full gate (`ready:build-test`) where guest join returned 500 in test-only context

## Validation
- `npm test -- __tests__/api/guest-mode.test.ts --runInBand`
- `npm run ready:build-test`
