### PR TITLE
fix(171): harden API errors, guest names, and socket compatibility

### DIFF
--- a/__tests__/api/auth-guest-session.test.ts
+++ b/__tests__/api/auth-guest-session.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/auth/guest-session/route'
+import {
+  createGuestId,
+  createGuestToken,
+  getGuestTokenFromRequest,
+  verifyGuestToken,
+} from '@/lib/guest-auth'
+import { getOrCreateGuestUser } from '@/lib/guest-helpers'
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimit: jest.fn(() => jest.fn(async () => null)),
+  rateLimitPresets: {
+    auth: {},
+  },
+}))
+
+jest.mock('@/lib/guest-auth', () => ({
+  createGuestId: jest.fn(),
+  createGuestToken: jest.fn(),
+  getGuestTokenFromRequest: jest.fn(),
+  verifyGuestToken: jest.fn(),
+}))
+
+jest.mock('@/lib/guest-helpers', () => ({
+  getOrCreateGuestUser: jest.fn(),
+}))
+
+jest.mock('@/lib/error-handler', () => ({
+  handleApiError: jest.fn(() => {
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }),
+}))
+
+const mockCreateGuestId = createGuestId as jest.MockedFunction<typeof createGuestId>
+const mockCreateGuestToken = createGuestToken as jest.MockedFunction<typeof createGuestToken>
+const mockGetGuestTokenFromRequest =
+  getGuestTokenFromRequest as jest.MockedFunction<typeof getGuestTokenFromRequest>
+const mockVerifyGuestToken = verifyGuestToken as jest.MockedFunction<typeof verifyGuestToken>
+const mockGetOrCreateGuestUser = getOrCreateGuestUser as jest.MockedFunction<typeof getOrCreateGuestUser>
+
+function buildRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/auth/guest-session', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/auth/guest-session', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCreateGuestId.mockReturnValue('guest-id-1')
+    mockCreateGuestToken.mockReturnValue('guest-token-1')
+    mockGetGuestTokenFromRequest.mockReturnValue(null)
+    mockVerifyGuestToken.mockReturnValue(null)
+  })
+
+  it('rejects names containing disallowed Unicode control characters', async () => {
+    const response = await POST(
+      buildRequest({
+        guestName: 'bad\u202Ename',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload).toEqual({ error: 'Guest name must be 2-20 characters' })
+    expect(mockGetOrCreateGuestUser).not.toHaveBeenCalled()
+  })
+
+  it('accepts names with word characters, spaces, and hyphens', async () => {
+    mockGetOrCreateGuestUser.mockResolvedValue({
+      id: 'guest-user-1',
+      username: 'Guest_Name-2',
+    } as any)
+
+    const response = await POST(
+      buildRequest({
+        guestName: 'Guest_Name-2',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({
+      guestId: 'guest-user-1',
+      guestName: 'Guest_Name-2',
+      guestToken: 'guest-token-1',
+    })
+    expect(mockGetOrCreateGuestUser).toHaveBeenCalledWith('guest-id-1', 'Guest_Name-2')
+    expect(mockCreateGuestToken).toHaveBeenCalledWith('guest-user-1', 'Guest_Name-2')
+  })
+})

--- a/__tests__/api/game-bot-turn-auth.test.ts
+++ b/__tests__/api/game-bot-turn-auth.test.ts
@@ -4,6 +4,8 @@
 
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/game/[gameId]/bot-turn/route'
+import { prisma } from '@/lib/db'
+import { restoreGameEngine } from '@/lib/game-registry'
 import { getRequestAuthUser } from '@/lib/request-auth'
 
 jest.mock('@/lib/db', () => ({
@@ -57,6 +59,7 @@ jest.mock('@/lib/logger', () => ({
 }))
 
 const mockGetRequestAuthUser = getRequestAuthUser as jest.MockedFunction<typeof getRequestAuthUser>
+const mockRestoreGameEngine = restoreGameEngine as jest.MockedFunction<typeof restoreGameEngine>
 const originalSocketSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
 
 function buildRequest(body: unknown, headers: Record<string, string> = {}) {
@@ -132,5 +135,64 @@ describe('POST /api/game/[gameId]/bot-turn auth guard', () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({ error: 'Bot user ID required' })
     expect(mockGetRequestAuthUser).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns sanitized 500 response when bot turn execution fails unexpectedly', async () => {
+    mockGetRequestAuthUser.mockResolvedValue({
+      id: 'player-1',
+      username: 'Player 1',
+      suspended: false,
+      isGuest: false,
+    } as any)
+
+    ;(prisma.games.findUnique as jest.Mock).mockResolvedValue({
+      id: 'game-123',
+      state: JSON.stringify({
+        players: [
+          { id: 'player-1', score: 0 },
+          { id: 'bot-1', score: 0 },
+        ],
+      }),
+      status: 'playing',
+      currentTurn: 0,
+      players: [
+        {
+          id: 'db-player-1',
+          userId: 'player-1',
+          score: 0,
+          scorecard: null,
+          user: { id: 'player-1', bot: null },
+        },
+        {
+          id: 'db-player-bot',
+          userId: 'bot-1',
+          score: 0,
+          scorecard: null,
+          user: { id: 'bot-1', bot: { id: 'bot-meta-1' } },
+        },
+      ],
+      lobby: {
+        id: 'lobby-123',
+        code: 'ABCD12',
+        gameType: 'tic_tac_toe',
+      },
+    } as any)
+    mockRestoreGameEngine.mockImplementation(() => {
+      throw new Error('sensitive bot engine failure')
+    })
+
+    const response = await POST(
+      buildRequest({
+        botUserId: 'bot-1',
+        lobbyCode: 'ABCD12',
+      }),
+      { params: Promise.resolve({ gameId: 'game-123' }) }
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(payload.error).toBe('Internal server error')
+    expect(payload.code).toBe('BOT_TURN_FAILED')
+    expect(payload.details).toBeUndefined()
   })
 })

--- a/__tests__/api/game-create.test.ts
+++ b/__tests__/api/game-create.test.ts
@@ -635,6 +635,27 @@ describe('POST /api/game/create', () => {
     )
   })
 
+  it('returns generic 500 response without internal details on unexpected failures', async () => {
+    mockGetRequestAuthUser.mockResolvedValue(mockSession as any)
+    mockPrisma.lobbies.findUnique.mockRejectedValue(new Error('sensitive database failure'))
+
+    const request = new NextRequest('http://localhost:3000/api/game/create', {
+      method: 'POST',
+      body: JSON.stringify({
+        gameType: 'yahtzee',
+        lobbyId: 'lobby-123',
+        config: { maxPlayers: 4, minPlayers: 2 },
+      }),
+    })
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Internal server error')
+    expect(data.code).toBe('GAME_CREATE_FAILED')
+    expect(data.details).toBeUndefined()
+  })
+
   it('should initialize game state correctly', async () => {
     mockGetRequestAuthUser.mockResolvedValue(mockSession as any)
     mockPrisma.lobbies.findUnique.mockResolvedValue({

--- a/__tests__/api/lobby-code.test.ts
+++ b/__tests__/api/lobby-code.test.ts
@@ -216,6 +216,8 @@ describe('GET /api/lobby/[code]', () => {
 
     expect(response.status).toBe(500)
     expect(data.error).toBe('Internal server error')
+    expect(data.code).toBe('LOBBY_FETCH_FAILED')
+    expect(data.details).toBeUndefined()
   })
 })
 

--- a/__tests__/socket/handlers/send-chat-message.test.ts
+++ b/__tests__/socket/handlers/send-chat-message.test.ts
@@ -98,6 +98,7 @@ describe('createSendChatMessageHandler', () => {
       SocketRooms.lobby('ABCD'),
       SocketEvents.CHAT_MESSAGE,
       expect.objectContaining({
+        id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
         userId: 'user-1',
         username: 'Alice',
         message: 'hello world',

--- a/app/api/auth/guest-session/route.ts
+++ b/app/api/auth/guest-session/route.ts
@@ -15,7 +15,7 @@ import { Prisma } from '@prisma/client'
 const limiter = rateLimit(rateLimitPresets.auth)
 
 const guestSessionSchema = z.object({
-  guestName: z.string().trim().min(2).max(20),
+  guestName: z.string().trim().min(2).max(20).regex(/^[\w\s-]+$/u, 'Invalid characters'),
   guestToken: z.string().optional(),
 })
 

--- a/app/api/game/[gameId]/bot-turn/route.ts
+++ b/app/api/game/[gameId]/bot-turn/route.ts
@@ -177,7 +177,6 @@ export async function POST(
     log.info('Game found, processing bot turn', {
       gameId: game.id,
       gameType,
-      statePreview: game.state?.substring(0, 100)
     })
 
     // Parse game state with error handling
@@ -437,8 +436,8 @@ export async function POST(
     })
 
     return NextResponse.json({
-      error: 'Failed to execute bot turn',
-      details: error instanceof Error ? error.message : 'Unknown error'
+      error: 'Internal server error',
+      code: 'BOT_TURN_FAILED',
     }, { status: 500 })
   } finally {
     if (lockAcquired && lockKey) {

--- a/app/api/game/create/route.ts
+++ b/app/api/game/create/route.ts
@@ -361,7 +361,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(
           {
             error: 'Spy locations are not configured',
-            details: error instanceof Error ? error.message : 'Unable to resolve Spy locations',
+            code: 'SPY_LOCATIONS_UNAVAILABLE',
           },
           { status: 500 }
         )
@@ -533,7 +533,7 @@ export async function POST(request: NextRequest) {
     log.error('Create game error', error as Error)
     return NextResponse.json({
       error: 'Internal server error',
-      details: error instanceof Error ? error.message : 'Unknown error'
+      code: 'GAME_CREATE_FAILED'
     }, { status: 500 })
   }
 }

--- a/app/api/lobby/[code]/route.ts
+++ b/app/api/lobby/[code]/route.ts
@@ -555,7 +555,7 @@ export async function GET(
     })
     return NextResponse.json({
       error: 'Internal server error',
-      details: process.env.NODE_ENV === 'development' ? (error as Error).message : undefined
+      code: 'LOBBY_FETCH_FAILED',
     }, { status: 500 })
   }
 }

--- a/lib/games/rock-paper-scissors-game.ts
+++ b/lib/games/rock-paper-scissors-game.ts
@@ -157,12 +157,8 @@ export class RockPaperScissorsGame extends GameEngine {
         })
 
         // Update scores
-        if (!gameData.scores[player1.id]) {
-            gameData.scores[player1.id] = 0
-        }
-        if (!gameData.scores[player2.id]) {
-            gameData.scores[player2.id] = 0
-        }
+        gameData.scores[player1.id] ??= 0
+        gameData.scores[player2.id] ??= 0
 
         if (roundWinner === player1.id) {
             gameData.scores[player1.id] += 1

--- a/lib/socket/handlers/send-chat-message.ts
+++ b/lib/socket/handlers/send-chat-message.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { SocketEvents, SocketRooms } from '../../../types/socket-events'
 import { EmitSocketErrorFn, SendChatMessageSocket } from './types'
 
@@ -80,7 +81,7 @@ export function createSendChatMessageHandler({
       const senderUsername = getUserDisplayName(socket.data.user)
 
       emitWithMetadata(SocketRooms.lobby(normalizedLobbyCode), SocketEvents.CHAT_MESSAGE, {
-        id: Date.now().toString(),
+        id: randomUUID(),
         userId: senderUserId,
         username: senderUsername,
         message: normalizedMessage,

--- a/socket-server.ts
+++ b/socket-server.ts
@@ -99,7 +99,7 @@ const io = new SocketIOServer(server, {
   allowUpgrades: true, // Allow upgrade from polling to websocket after connection
   upgradeTimeout: 30000, // 30 seconds for upgrade
   maxHttpBufferSize: 1e6, // 1MB - sufficient for game data
-  allowEIO3: true, // Support older clients
+  allowEIO3: false,
 })
 
 const onlinePresence = createOnlinePresence(io, logger)


### PR DESCRIPTION
## Summary
- remove client-facing error-message leakage from 500 responses in bot-turn, game/create, and lobby/[code]
- switch chat message IDs from Date.now() to UUIDs to avoid collisions
- tighten guest session name validation to reject problematic Unicode control/special chars
- disable Engine.IO v3 compatibility (allowEIO3: false)
- use ??= for RPS score initialization
- remove bot-turn statePreview logging from game state logs

## Tests
- npm test -- __tests__/api/auth-guest-session.test.ts __tests__/api/game-bot-turn-auth.test.ts __tests__/api/game-create.test.ts __tests__/api/lobby-code.test.ts __tests__/socket/handlers/send-chat-message.test.ts __tests__/lib/games/rock-paper-scissors-game.test.ts
- npm run ci:quick

Closes #171
