### PR TITLE
Fix mobile lobby layouts, Tic-Tac-Toe finish redirect, and add local setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,13 @@
 NODE_ENV=development
 
 # ------------------------------------------------------------
-# DATABASE (Supabase PostgreSQL)
+# DATABASE (PostgreSQL: local or hosted)
 # ------------------------------------------------------------
+# Local example:
+# DATABASE_URL=postgresql://postgres:postgres@localhost:5432/boardly_local
+# DIRECT_URL=postgresql://postgres:postgres@localhost:5432/boardly_local
+#
+# Hosted Supabase example:
 # Get your connection string from: https://app.supabase.com/project/_/settings/database
 DATABASE_URL=postgresql://postgres:YOUR_PASSWORD@db.YOUR_PROJECT_ID.supabase.co:5432/postgres
 # Direct connection URL for migrations (avoid pooler/pgBouncer for prisma migrate)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ npm run db:rls:smoke
 ## Documentation map
 
 - Project docs index: `docs/README.md`
+- Full local-only setup: `docs/LOCAL_SETUP.md`
 - Product direction: `docs/PROJECT_VISION.md`
 - System design and data flows: `docs/ARCHITECTURE.md`
 - Local/prod operations and deployment: `docs/OPERATIONS.md`

--- a/__tests__/lib/lobby-lifecycle.test.ts
+++ b/__tests__/lib/lobby-lifecycle.test.ts
@@ -24,14 +24,7 @@ describe('lobby lifecycle helpers', () => {
     ).toBe('local-game-status:cancelled')
   })
 
-  it('returns local inactive redirect reason when lobby is inactive and game is not active', () => {
-    expect(
-      resolveLifecycleRedirectReason({
-        gameStatus: 'finished',
-        lobbyIsActive: false,
-      })
-    ).toBe('local-lobby-inactive')
-
+  it('returns local inactive redirect reason when lobby is inactive and there is no settled game to show', () => {
     expect(
       resolveLifecycleRedirectReason({
         gameStatus: null,
@@ -40,7 +33,7 @@ describe('lobby lifecycle helpers', () => {
     ).toBe('local-lobby-inactive')
   })
 
-  it('does not redirect while game is active even if lobby flag is false', () => {
+  it('does not redirect while game is active or finished even if lobby flag is false', () => {
     expect(
       resolveLifecycleRedirectReason({
         gameStatus: 'playing',
@@ -51,6 +44,13 @@ describe('lobby lifecycle helpers', () => {
     expect(
       resolveLifecycleRedirectReason({
         gameStatus: 'waiting',
+        lobbyIsActive: false,
+      })
+    ).toBeNull()
+
+    expect(
+      resolveLifecycleRedirectReason({
+        gameStatus: 'finished',
         lobbyIsActive: false,
       })
     ).toBeNull()

--- a/app/globals.css
+++ b/app/globals.css
@@ -135,12 +135,19 @@
   --secondary-600: 124, 58, 237;
   --success-500: 34, 197, 94;
   --error-500: 239, 68, 68;
+  --mobile-tabs-offset: 5.75rem;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --foreground-rgb: 255, 255, 255;
     --background-rgb: 18, 18, 18;
+  }
+}
+
+@supports (padding-bottom: env(safe-area-inset-bottom)) {
+  :root {
+    --mobile-tabs-offset: calc(5.75rem + env(safe-area-inset-bottom));
   }
 }
 

--- a/app/lobby/[code]/components/MobileTabPanel.tsx
+++ b/app/lobby/[code]/components/MobileTabPanel.tsx
@@ -10,23 +10,24 @@ interface MobileTabPanelProps {
 
 export default function MobileTabPanel({ id, activeTab, children }: MobileTabPanelProps) {
   const isActive = activeTab === id
-  
+
   return (
     <div
       className={`md:hidden absolute inset-0 w-full max-w-full transition-all duration-300 ease-in-out ${
-        isActive 
-          ? 'opacity-100 pointer-events-auto z-10' 
+        isActive
+          ? 'opacity-100 pointer-events-auto z-10'
           : 'opacity-0 pointer-events-none z-0'
       }`}
-      style={{ 
+      style={{
         transform: isActive ? 'translate3d(0, 0, 0)' : 'translate3d(100%, 0, 0)',
         height: '100%',
         overflowY: 'auto',
         overflowX: 'hidden',
         WebkitOverflowScrolling: 'touch',
+        paddingBottom: 'var(--mobile-tabs-offset)',
       }}
     >
-      <div className="h-full pb-20">
+      <div className="min-h-full">
         {children}
       </div>
     </div>

--- a/app/lobby/[code]/page.tsx
+++ b/app/lobby/[code]/page.tsx
@@ -1793,7 +1793,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
                 >
                   {/* Game Tab */}
                   <MobileTabPanel id="game" activeTab={mobileActiveTab}>
-                    <div className="p-4 space-y-4">
+                    <div className="min-h-full p-4 space-y-4">
                       <GameBoard
                         gameEngine={gameEngine}
                         game={game}
@@ -1817,7 +1817,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
 
                   {/* Scorecard Tab */}
                   <MobileTabPanel id="scorecard" activeTab={mobileActiveTab}>
-                    <div className="p-4">
+                    <div className="min-h-full p-4">
                       {(() => {
                         const currentUserId = getCurrentUserId()
                         const viewingPlayerId = selectedPlayerId || gameEngine.getCurrentPlayer()?.id
@@ -1855,7 +1855,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
 
                   {/* Players Tab */}
                   <MobileTabPanel id="players" activeTab={mobileActiveTab}>
-                    <div className="p-4 space-y-4">
+                    <div className="min-h-full p-4 space-y-4">
                       <PlayerList
                         players={playersForLeaderboard}
                         currentTurn={gameEngine.getState().currentPlayerIndex}
@@ -1879,7 +1879,12 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
 
                   {/* Chat Tab */}
                   <MobileTabPanel id="chat" activeTab={mobileActiveTab}>
-                    <div className="h-full">
+                    <div
+                      className="min-h-full"
+                      style={{
+                        height: 'calc(100% - var(--mobile-tabs-offset))',
+                      }}
+                    >
                       <Chat
                         messages={chatMessages}
                         onSendMessage={(message) => {

--- a/app/lobby/create/page.tsx
+++ b/app/lobby/create/page.tsx
@@ -365,14 +365,14 @@ function CreateLobbyPage() {
   }
 
   return (
-    <div className={`bg-gradient-to-br ${gameInfo.gradient} flex flex-col`}>
+    <div className={`min-h-[calc(100dvh-64px)] bg-gradient-to-br ${gameInfo.gradient} flex flex-col`}>
       <section
         className="flex flex-col w-full px-4 py-4 md:py-0 md:h-[calc(100vh-64px)] md:items-center md:justify-center flex-shrink-0"
       >
         <div className="w-full max-w-4xl flex flex-col items-center justify-center">
-          <div className="bg-white/10 backdrop-blur-md rounded-2xl shadow-2xl border-2 border-white/20 flex flex-col md:flex-row md:gap-0 gap-4 overflow-hidden w-full md:h-[80vh] md:max-h-[800px]">
+          <div className="bg-white/10 backdrop-blur-md rounded-2xl shadow-2xl border-2 border-white/20 flex flex-col md:flex-row md:gap-0 gap-4 overflow-visible md:overflow-hidden w-full md:h-[80vh] md:max-h-[800px]">
             {/* 1. Game Type Selector - clean scrollable list */}
-            <div className="md:w-1/4 w-full flex flex-col overflow-y-auto bg-white/5 border-b-2 md:border-b-0 md:border-r-2 border-white/10 order-1">
+            <div className="md:w-1/4 w-full flex flex-col overflow-visible md:overflow-y-auto bg-white/5 border-b-2 md:border-b-0 md:border-r-2 border-white/10 order-1">
               {Object.entries(GAME_INFO)
                 .filter(([key]) => !TEMPORARILY_UNAVAILABLE_GAME_TYPES.has(key as GameType))
                 .sort(([, a], [, b]) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
@@ -393,10 +393,10 @@ function CreateLobbyPage() {
               ))}
             </div>
             {/* 2. Form */}
-            <form onSubmit={handleSubmit} className="md:w-2/4 w-full p-4 md:p-6 space-y-2.5 md:space-y-3 flex flex-col order-3 md:order-2 overflow-y-auto max-h-[70vh] md:max-h-none">
+            <form onSubmit={handleSubmit} className="md:w-2/4 w-full p-4 md:p-6 space-y-2.5 md:space-y-3 flex flex-col order-3 md:order-2 overflow-visible md:overflow-y-auto max-h-none">
               <div>
                 <label className="block text-xs md:text-sm font-bold text-white mb-1.5 md:mb-2">
-                  🎮 {t('lobby.create.lobbyName')}
+                  🎮 {t('lobby.create.lobbyName')} <span className="font-medium text-white/70">({t('common.optional')})</span>
                 </label>
                 <input
                   type="text"

--- a/components/PlayerList.tsx
+++ b/components/PlayerList.tsx
@@ -116,7 +116,7 @@ const PlayerList = React.memo(function PlayerList({ players, currentTurn, curren
 
   return (
     <>
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-4 border border-gray-200 dark:border-gray-700 animate-fade-in h-full flex flex-col">
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-4 border border-gray-200 dark:border-gray-700 animate-fade-in h-auto md:h-full flex flex-col">
         <button
           onClick={() => {
             soundManager.play('click', { force: true })
@@ -132,7 +132,7 @@ const PlayerList = React.memo(function PlayerList({ players, currentTurn, curren
             </span>
           )}
         </button>
-        <div className="space-y-1.5 overflow-y-auto pr-1 flex-1 custom-scrollbar snap-y snap-mandatory">
+        <div className="space-y-1.5 overflow-visible md:overflow-y-auto pr-1 flex-1 custom-scrollbar snap-y snap-mandatory">
           {sortedPlayers.map((player, index) => {
             // Use player.position (actual game index) instead of sorted index
             const isCurrentTurn = player.position === currentTurn

--- a/components/Scorecard.tsx
+++ b/components/Scorecard.tsx
@@ -206,12 +206,12 @@ const Scorecard = React.memo(function Scorecard({
   const total = upperTotal + bonus + lowerTotal
 
   return (
-    <div className={`h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl border border-gray-200 dark:border-gray-700 overflow-x-hidden ${
+    <div className={`min-h-full sm:h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl border border-gray-200 dark:border-gray-700 overflow-x-hidden sm:overflow-hidden ${
       !isCurrentPlayer ? 'opacity-90' : ''
     }`} style={{ borderRadius: 'clamp(12px, 1.2vw, 24px)' }}>
       {/* TWO COLUMN LAYOUT - ADAPTIVE WITH SCROLL - Single column on mobile */}
-      <div className="flex-1 overflow-hidden" style={{ padding: 'clamp(10px, 1vw, 20px)' }}>
-        <div className="h-full grid grid-cols-1 sm:grid-cols-2 scorecard-columns" style={{ gap: 'clamp(8px, 0.8vw, 20px)' }}>
+      <div className="flex-1 overflow-visible sm:overflow-hidden" style={{ padding: 'clamp(10px, 1vw, 20px)' }}>
+        <div className="min-h-full sm:h-full grid grid-cols-1 sm:grid-cols-2 scorecard-columns" style={{ gap: 'clamp(8px, 0.8vw, 20px)' }}>
           {/* LEFT COLUMN: Upper Section */}
           <div className="flex flex-col min-h-0">
             <div className="flex items-center justify-between flex-shrink-0" style={{ marginBottom: 'clamp(6px, 0.6vh, 10px)', gap: 'clamp(6px, 0.6vw, 12px)' }}>
@@ -233,7 +233,7 @@ const Scorecard = React.memo(function Scorecard({
             
             <div className="flex-1 flex flex-col min-h-0">
               {/* Categories - full height */}
-              <div className="flex-1 overflow-y-auto overflow-x-hidden pr-1 min-h-0 flex flex-col justify-evenly" style={{ gap: 'clamp(4px, 0.4vh, 8px)' }}>
+              <div className="flex-1 overflow-visible sm:overflow-y-auto overflow-x-hidden pr-1 min-h-0 flex flex-col justify-start sm:justify-evenly" style={{ gap: 'clamp(4px, 0.4vh, 8px)' }}>
                 {upperSection.map(renderCategory)}
               </div>
             </div>
@@ -278,7 +278,7 @@ const Scorecard = React.memo(function Scorecard({
             
             <div className="flex-1 flex flex-col min-h-0">
               {/* Categories - full height */}
-              <div className="flex-1 overflow-y-auto overflow-x-hidden pr-1 min-h-0 flex flex-col justify-evenly" style={{ gap: 'clamp(4px, 0.4vh, 8px)' }}>
+              <div className="flex-1 overflow-visible sm:overflow-y-auto overflow-x-hidden pr-1 min-h-0 flex flex-col justify-start sm:justify-evenly" style={{ gap: 'clamp(4px, 0.4vh, 8px)' }}>
                 {lowerSection.map(renderCategory)}
               </div>
             </div>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 ## Development setup
 
+For the full local-only workflow, see `docs/LOCAL_SETUP.md`.
+
 ```bash
 npm install
 cp .env.example .env.local

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -1,0 +1,222 @@
+# Local Setup
+
+This guide explains how to run Boardly fully locally without Supabase, Vercel, Render, Resend, or other hosted services.
+
+## Goal
+
+At the end of this setup you should have:
+
+- PostgreSQL running on your machine
+- Next.js app running on `http://localhost:3000`
+- Socket.IO server running on `http://localhost:3001`
+- Prisma schema pushed to a local database
+
+## Prerequisites
+
+- Node.js 18+
+- npm
+- PostgreSQL 14+ running locally
+
+Optional:
+
+- Docker, if you prefer to run PostgreSQL in a local container
+
+## 1. Clone and install
+
+```bash
+git clone <repo-url>
+cd Boardly
+npm install
+```
+
+## 2. Start PostgreSQL locally
+
+Use whichever local-only option you prefer.
+
+### Option A: local PostgreSQL service
+
+Create a database:
+
+```bash
+createdb boardly_local
+```
+
+If your local PostgreSQL user is not `postgres`, replace the username in the `.env.local` example below.
+
+### Option B: Docker
+
+```bash
+docker run --name boardly-postgres \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=boardly_local \
+  -p 5432:5432 \
+  -d postgres:16
+```
+
+## 3. Create `.env.local`
+
+Copy the template:
+
+```bash
+cp .env.example .env.local
+```
+
+For a local-only stack, this minimal config is enough:
+
+```env
+NODE_ENV=development
+
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/boardly_local
+DIRECT_URL=postgresql://postgres:postgres@localhost:5432/boardly_local
+
+NEXTAUTH_SECRET=replace-with-a-long-random-string-at-least-32-chars
+NEXTAUTH_URL=http://localhost:3000
+
+CORS_ORIGIN=http://localhost:3000,http://127.0.0.1:3000
+
+CRON_SECRET=replace-with-another-long-random-string-at-least-32-chars
+
+# Optional locally. Leave unset unless you need explicit overrides.
+# NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
+# SOCKET_SERVER_URL=http://localhost:3001
+# SOCKET_SERVER_INTERNAL_SECRET=replace-with-at-least-16-chars
+```
+
+Generate local secrets:
+
+```bash
+openssl rand -base64 32
+```
+
+## 4. Leave hosted integrations disabled
+
+For normal local development you do not need:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`
+- `RESEND_API_KEY`
+- Google / GitHub / Discord OAuth env vars
+- Sentry env vars
+- Upstash env vars
+
+Without these values:
+
+- email sending is skipped
+- OAuth providers are unavailable
+- Sentry is disabled
+- local DB still works normally through Prisma
+
+## 5. Prepare the database
+
+Generate Prisma client and push schema:
+
+```bash
+npm run db:generate
+npm run db:push
+```
+
+Recommended checks:
+
+```bash
+npm run check:env:quiet
+npm run check:db
+```
+
+## 6. Start the app and socket server
+
+Preferred:
+
+```bash
+npm run dev:all
+```
+
+Or in separate terminals:
+
+```bash
+npm run dev
+npm run socket:dev
+```
+
+Open:
+
+- app: `http://localhost:3000`
+- socket server: `http://localhost:3001`
+
+## 7. Local smoke test
+
+Recommended quick smoke path:
+
+1. Open `http://localhost:3000`
+2. Create a guest session or sign in with a local account if you already have one
+3. Create a lobby
+4. Start a game
+5. Verify moves update in the UI
+
+## Local architecture notes
+
+- The browser connects to Socket.IO on port `3001`.
+- The Next.js server stays on port `3000`.
+- Prisma talks directly to your local PostgreSQL instance.
+- In development, protected internal socket endpoints are allowed without `SOCKET_SERVER_INTERNAL_SECRET`.
+
+## Common local-only problems
+
+### `DATABASE_URL` is set but Prisma cannot connect
+
+Check:
+
+- PostgreSQL is actually running
+- the database exists
+- username/password in `.env.local` match your local PostgreSQL setup
+
+Useful commands:
+
+```bash
+npm run check:db
+npm run db:validate
+```
+
+### App loads but socket does not connect
+
+Check:
+
+- `npm run socket:dev` is running
+- `CORS_ORIGIN` includes `http://localhost:3000`
+- `NEXT_PUBLIC_SOCKET_URL` is unset or points to `http://localhost:3001`
+
+### Lobby/game pages behave strangely after schema changes
+
+Refresh Prisma artifacts and schema:
+
+```bash
+npm run db:generate
+npm run db:push
+```
+
+Then restart `npm run dev:all`.
+
+### Email or OAuth flows fail locally
+
+That is expected if you intentionally left those env vars unset. They are not required for a fully local gameplay/dev loop.
+
+## Recommended pre-change check
+
+Before larger changes:
+
+```bash
+bash scripts/codex-quick-check.sh --skip-db
+```
+
+Or, if local DB is running:
+
+```bash
+bash scripts/codex-quick-check.sh
+```
+
+## Related docs
+
+- `README.md`
+- `docs/OPERATIONS.md`
+- `docs/CONTRIBUTING.md`
+- `docs/ARCHITECTURE.md`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2,6 +2,8 @@
 
 ## Local development
 
+For a full local-only walkthrough without hosted services, start with `docs/LOCAL_SETUP.md`.
+
 ### Prerequisites
 
 - Node.js 18+

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This folder contains the canonical project documentation.
 ## Core docs
 
 - `docs/PROJECT_VISION.md` - product goals, long-term direction, and decision principles
+- `docs/LOCAL_SETUP.md` - full local-only setup with local PostgreSQL and local app/socket services
 - `docs/ARCHITECTURE.md` - technical architecture, data model, websocket flow, game engine patterns
 - `docs/OPERATIONS.md` - environment setup, local runbook, deployment, troubleshooting
 - `docs/ROADMAP.md` - active priorities and near-term milestones

--- a/lib/lobby-lifecycle.ts
+++ b/lib/lobby-lifecycle.ts
@@ -1,5 +1,6 @@
 const TERMINAL_GAME_STATUSES = ['abandoned', 'cancelled'] as const
 const NON_TERMINAL_ACTIVE_STATUSES = new Set(['waiting', 'playing'])
+const NON_TERMINAL_SETTLED_STATUSES = new Set(['finished'])
 
 export type TerminalGameStatus = (typeof TERMINAL_GAME_STATUSES)[number]
 
@@ -19,7 +20,11 @@ export function resolveLifecycleRedirectReason(params: {
     return `local-game-status:${normalizedGameStatus}`
   }
 
-  if (lobbyIsActive === false && !NON_TERMINAL_ACTIVE_STATUSES.has(normalizedGameStatus || '')) {
+  if (
+    lobbyIsActive === false &&
+    !NON_TERMINAL_ACTIVE_STATUSES.has(normalizedGameStatus || '') &&
+    !NON_TERMINAL_SETTLED_STATUSES.has(normalizedGameStatus || '')
+  ) {
     return 'local-lobby-inactive'
   }
 


### PR DESCRIPTION
## Summary
- remove nested mobile scroll behavior from the create lobby form and mark lobby name as optional
- reserve mobile bottom-tab safe space for Yahtzee mobile panels and relax nested scrolling in scorecard/players layouts
- stop treating `finished` games in inactive lobbies as terminal redirects, which fixes the Tic-Tac-Toe vs bot post-round redirect
- add a dedicated `docs/LOCAL_SETUP.md` guide for a fully local stack and cross-link it from canonical docs

## Verification
- `npm test -- --runInBand __tests__/lib/lobby-lifecycle.test.ts`
- `npm run typecheck`
- `npm run lint`
- pre-push hook: `npm run db:generate`
- pre-push hook: `npm run check:locales`
- pre-push hook: `npm run ci:quick`
- pre-push hook: `npm test -- --runTestsByPath __tests__/lib/socket-url.test.ts __tests__/lib/guest-helpers.test.ts __tests__/lib/game-registry.test.ts __tests__/lib/lobby-player-requirements.test.ts`

## Issues
Closes #187
Closes #188
Closes #189
Closes #190
