### PR TITLE
Fix DB schema persistence for game state storage

### DIFF
--- a/__tests__/lib/game-type-storage.test.ts
+++ b/__tests__/lib/game-type-storage.test.ts
@@ -1,0 +1,16 @@
+import { toPersistedGameType } from '@/lib/game-type-storage'
+
+describe('game type storage', () => {
+  it.each([
+    'telephone_doodle',
+    'sketch_and_guess',
+    'liars_party',
+    'fake_artist',
+  ] as const)('persists %s without downgrading to other', (gameType) => {
+    expect(toPersistedGameType(gameType)).toBe(gameType)
+  })
+
+  it('falls back to other for unknown runtime game types', () => {
+    expect(toPersistedGameType('unknown_runtime_game')).toBe('other')
+  })
+})

--- a/app/admin/games/[id]/page.tsx
+++ b/app/admin/games/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { prisma } from '@/lib/db'
 import { requireAdminSession } from '@/lib/admin-auth'
+import { stringifyPersistedGameState } from '@/lib/persisted-game-state'
 import AdminForceEndGameButton from '../../_components/AdminForceEndGameButton'
 import AdminDeleteGameButton from '../../_components/AdminDeleteGameButton'
 
@@ -63,7 +64,7 @@ export default async function AdminGameDetailPage({ params }: { params: Promise<
 
   if (!game) notFound()
 
-  let statePreview = game.state
+  let statePreview = stringifyPersistedGameState(game.state)
   if (statePreview.length > 5000) {
     statePreview = `${statePreview.slice(0, 5000)}\n... (truncated)`
   }

--- a/app/api/game/[gameId]/bot-turn/route.ts
+++ b/app/api/game/[gameId]/bot-turn/route.ts
@@ -9,6 +9,7 @@ import { apiLogger } from '@/lib/logger'
 import { advanceTurnPastDisconnectedPlayers } from '@/lib/disconnected-turn'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
 import { getRequestAuthUser } from '@/lib/request-auth'
+import { parsePersistedGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 export const maxDuration = 60 // Allow up to 60 seconds for bot execution
 
@@ -180,9 +181,9 @@ export async function POST(
     })
 
     // Parse game state with error handling
-    let gameState
+    let gameState: { players: unknown[] } & Record<string, unknown>
     try {
-      gameState = JSON.parse(game.state)
+      gameState = parsePersistedGameState(game.state) as { players: unknown[] } & Record<string, unknown>
       // Validate parsed state
       if (!gameState || typeof gameState !== 'object' || !Array.isArray(gameState.players)) {
         throw new Error('Invalid game state structure')
@@ -304,7 +305,7 @@ export async function POST(
             await prisma.games.update({
               where: { id: gameId },
               data: {
-                state: JSON.stringify(newState),
+                state: toPersistedGameStateInput(newState),
                 status: newState.status,
                 currentTurn: newState.currentPlayerIndex,
                 ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
@@ -317,7 +318,7 @@ export async function POST(
               return prisma.games.update({
                 where: { id: gameId },
                 data: {
-                  state: JSON.stringify(newState),
+                  state: toPersistedGameStateInput(newState),
                   status: newState.status,
                   currentTurn: newState.currentPlayerIndex,
                   ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),

--- a/app/api/game/[gameId]/fake-artist-action/route.ts
+++ b/app/api/game/[gameId]/fake-artist-action/route.ts
@@ -8,6 +8,7 @@ import { apiLogger } from '@/lib/logger'
 import { getRequestAuthUser } from '@/lib/request-auth'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
 import { fakeArtistActionRequestSchema } from '@/lib/validation/fake-artist'
+import { parsePersistedGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.game)
 
@@ -106,7 +107,7 @@ export async function POST(
 
     let parsedState: unknown
     try {
-      parsedState = JSON.parse(game.state)
+      parsedState = parsePersistedGameState(game.state)
     } catch {
       return NextResponse.json({ error: 'Corrupted game state' }, { status: 500 })
     }
@@ -133,7 +134,7 @@ export async function POST(
       await prisma.games.update({
         where: { id: gameId },
         data: {
-          state: JSON.stringify(nextState),
+          state: toPersistedGameStateInput(nextState),
           status: nextState.status,
           ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
           updatedAt: new Date(),

--- a/app/api/game/[gameId]/liars-party-action/route.ts
+++ b/app/api/game/[gameId]/liars-party-action/route.ts
@@ -8,6 +8,7 @@ import { apiLogger } from '@/lib/logger'
 import { getRequestAuthUser } from '@/lib/request-auth'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
 import { liarsPartyActionRequestSchema } from '@/lib/validation/liars-party'
+import { parsePersistedGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.game)
 
@@ -97,7 +98,7 @@ export async function POST(
 
     let parsedState: unknown
     try {
-      parsedState = JSON.parse(game.state)
+      parsedState = parsePersistedGameState(game.state)
     } catch {
       return NextResponse.json({ error: 'Corrupted game state' }, { status: 500 })
     }
@@ -124,7 +125,7 @@ export async function POST(
       await prisma.games.update({
         where: { id: gameId },
         data: {
-          state: JSON.stringify(nextState),
+          state: toPersistedGameStateInput(nextState),
           status: nextState.status,
           ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
           updatedAt: new Date(),

--- a/app/api/game/[gameId]/replay/route.ts
+++ b/app/api/game/[gameId]/replay/route.ts
@@ -3,14 +3,7 @@ import { prisma } from '@/lib/db'
 import { apiLogger } from '@/lib/logger'
 import { getRequestAuthUser } from '@/lib/request-auth'
 import { decodeGameReplaySnapshots } from '@/lib/game-replay'
-
-function parseSerializedState(state: string): unknown {
-  try {
-    return JSON.parse(state)
-  } catch {
-    return null
-  }
-}
+import { parsePersistedGameState } from '@/lib/persisted-game-state'
 
 function shouldDownloadReplay(value: string | null): boolean {
   if (!value) return false
@@ -94,7 +87,7 @@ export async function GET(
               playerId: null,
               actionType: 'game:final-state',
               actionPayload: null,
-              state: parseSerializedState(game.state),
+              state: parsePersistedGameState(game.state),
               createdAt: game.updatedAt.toISOString(),
             },
           ]

--- a/app/api/game/[gameId]/sketch-and-guess-action/route.ts
+++ b/app/api/game/[gameId]/sketch-and-guess-action/route.ts
@@ -8,6 +8,7 @@ import { apiLogger } from '@/lib/logger'
 import { getRequestAuthUser } from '@/lib/request-auth'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
 import { sketchAndGuessActionRequestSchema } from '@/lib/validation/sketch-and-guess'
+import { parsePersistedGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.game)
 
@@ -97,7 +98,7 @@ export async function POST(
 
     let parsedState: unknown
     try {
-      parsedState = JSON.parse(game.state)
+      parsedState = parsePersistedGameState(game.state)
     } catch {
       return NextResponse.json({ error: 'Corrupted game state' }, { status: 500 })
     }
@@ -125,7 +126,7 @@ export async function POST(
       await prisma.games.update({
         where: { id: gameId },
         data: {
-          state: JSON.stringify(nextState),
+          state: toPersistedGameStateInput(nextState),
           status: nextState.status,
           ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
           updatedAt: new Date(),

--- a/app/api/game/[gameId]/spy-action/route.ts
+++ b/app/api/game/[gameId]/spy-action/route.ts
@@ -6,6 +6,7 @@ import { notifySocket } from '@/lib/socket-url'
 import { apiLogger } from '@/lib/logger'
 import { getRequestAuthUser } from '@/lib/request-auth'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
+import { parsePersistedGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.game)
 
@@ -68,7 +69,7 @@ export async function POST(
 
     // Load game engine
     const spyGame = new SpyGame(gameId)
-    spyGame.loadState(JSON.parse(game.state))
+    spyGame.loadState(parsePersistedGameState(game.state))
 
     // Build move object
     const move = {
@@ -99,7 +100,7 @@ export async function POST(
     await prisma.games.update({
       where: { id: gameId },
       data: {
-        state: JSON.stringify(updatedState),
+        state: toPersistedGameStateInput(updatedState),
         status: updatedState.status, // Sync status from game engine
         updatedAt: new Date(),
         ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),

--- a/app/api/game/[gameId]/spy-init/route.ts
+++ b/app/api/game/[gameId]/spy-init/route.ts
@@ -7,6 +7,7 @@ import { apiLogger } from '@/lib/logger'
 import { getRequestAuthUser } from '@/lib/request-auth'
 import { getActiveSpyLocations } from '@/lib/spy-locations'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
+import { parsePersistedGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.game)
 
@@ -64,7 +65,7 @@ export async function POST(
 
     // Load game engine
     const spyGame = new SpyGame(gameId)
-    spyGame.loadState(JSON.parse(game.state))
+    spyGame.loadState(parsePersistedGameState(game.state))
     const state = spyGame.getState()
     const stateData = (state.data ?? {}) as {
       phase?: SpyGamePhase
@@ -139,7 +140,7 @@ export async function POST(
     await prisma.games.update({
       where: { id: gameId },
       data: {
-        state: JSON.stringify(updatedState),
+        state: toPersistedGameStateInput(updatedState),
         status: updatedState.status, // Sync status from game engine
         updatedAt: new Date(),
       },

--- a/app/api/game/[gameId]/spy-role/route.ts
+++ b/app/api/game/[gameId]/spy-role/route.ts
@@ -4,6 +4,7 @@ import { SpyGame } from '@/lib/games/spy-game'
 import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
 import { apiLogger } from '@/lib/logger'
 import { getRequestAuthUser } from '@/lib/request-auth'
+import { parsePersistedGameState } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.api)
 
@@ -62,7 +63,7 @@ export async function GET(
 
     // Load game engine
     const spyGame = new SpyGame(gameId)
-    spyGame.loadState(JSON.parse(game.state))
+    spyGame.loadState(parsePersistedGameState(game.state))
 
     // Get role info for this specific player
     const roleInfo = spyGame.getRoleInfoForPlayer(userId)

--- a/app/api/game/[gameId]/state/route.ts
+++ b/app/api/game/[gameId]/state/route.ts
@@ -8,6 +8,7 @@ import { advanceTurnPastDisconnectedPlayers } from '@/lib/disconnected-turn'
 import { notifySocket } from '@/lib/socket-url'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
 import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
+import { parsePersistedGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 interface AutoActionContext {
   source: 'turn-timeout'
@@ -306,7 +307,7 @@ export async function POST(
     // Recreate game engine from saved state
     let gameState: unknown
     try {
-      gameState = JSON.parse(game.state)
+      gameState = parsePersistedGameState(game.state)
 
       // Basic validation of state structure
       if (!gameState || typeof gameState !== 'object') {
@@ -491,7 +492,7 @@ export async function POST(
           updatedAt: game.updatedAt,
         },
         data: {
-          state: JSON.stringify(newState),
+          state: toPersistedGameStateInput(newState),
           status: newState.status,
           currentTurn: newState.currentPlayerIndex,
           ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),

--- a/app/api/game/[gameId]/telephone-doodle-action/route.ts
+++ b/app/api/game/[gameId]/telephone-doodle-action/route.ts
@@ -11,6 +11,7 @@ import {
   telephoneDoodleActionRequestSchema,
   TelephoneDoodleDrawingPayload,
 } from '@/lib/validation/telephone-doodle'
+import { parsePersistedGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.game)
 
@@ -110,7 +111,7 @@ export async function POST(
 
     let parsedState: unknown
     try {
-      parsedState = JSON.parse(game.state)
+      parsedState = parsePersistedGameState(game.state)
     } catch {
       return NextResponse.json({ error: 'Corrupted game state' }, { status: 500 })
     }
@@ -137,7 +138,7 @@ export async function POST(
       await prisma.games.update({
         where: { id: gameId },
         data: {
-          state: JSON.stringify(nextState),
+          state: toPersistedGameStateInput(nextState),
           status: nextState.status,
           ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
           updatedAt: new Date(),

--- a/app/api/game/create/route.ts
+++ b/app/api/game/create/route.ts
@@ -12,6 +12,7 @@ import { getBotDisplayName, normalizeBotDifficulty } from '@/lib/bot-profiles'
 import { getOrCreateBotUser, isPrismaUniqueConstraintError } from '@/lib/bot-helpers'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
 import { toPersistedGameType } from '@/lib/game-type-storage'
+import { toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.game)
 
@@ -185,7 +186,7 @@ export async function POST(request: NextRequest) {
             lobbyId: lobbyId,
             status: 'waiting',
             gameType: persistedGameType,
-            state: JSON.stringify(initialWaitingState),
+            state: toPersistedGameStateInput(initialWaitingState),
             players: {
               create: finishedGame.players.map((p, index) => ({
                 userId: p.userId,
@@ -389,7 +390,7 @@ export async function POST(request: NextRequest) {
     const game = await prisma.games.update({
       where: { id: waitingGame.id },
       data: {
-        state: JSON.stringify(gameEngine.getState()),
+        state: toPersistedGameStateInput(gameEngine.getState()),
         status: 'playing',
         gameType: persistedGameType,
         updatedAt: new Date(),

--- a/app/api/lobby/[code]/join-guest/route.ts
+++ b/app/api/lobby/[code]/join-guest/route.ts
@@ -18,6 +18,7 @@ import {
   verifyLobbyPassword,
 } from '@/lib/lobby-password'
 import { toPersistedGameType } from '@/lib/game-type-storage'
+import { toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const limiter = rateLimit(rateLimitPresets.game)
 const joinGuestSchema = z.object({
@@ -141,7 +142,7 @@ export async function POST(
           lobbyId: lobby.id,
           gameType: toPersistedGameType(runtimeGameType),
           status: 'waiting',
-          state: JSON.stringify(initialState),
+          state: toPersistedGameStateInput(initialState),
           players: {
             create: {
               userId: guestUser.id,

--- a/app/api/lobby/[code]/route.ts
+++ b/app/api/lobby/[code]/route.ts
@@ -20,6 +20,11 @@ import {
   verifyLobbyPassword,
 } from '@/lib/lobby-password'
 import { toPersistedGameType } from '@/lib/game-type-storage'
+import {
+  parsePersistedGameState,
+  stringifyPersistedGameState,
+  toPersistedGameStateInput,
+} from '@/lib/persisted-game-state'
 
 const apiLimiter = rateLimit(rateLimitPresets.api)
 const gameLimiter = rateLimit(rateLimitPresets.game)
@@ -138,7 +143,7 @@ export async function GET(
       const turnTimerSeconds = resolveTurnTimerSeconds(safeLobby.turnTimer)
       if (turnTimerSeconds > 0) {
         try {
-          const parsedState = JSON.parse(activeGame.state)
+          const parsedState = parsePersistedGameState(activeGame.state)
           const telephoneGame = new TelephoneDoodleGame(activeGame.id)
           telephoneGame.restoreState(parsedState as any)
 
@@ -153,7 +158,7 @@ export async function GET(
                 updatedAt: activeGame.updatedAt,
               },
               data: {
-                state: JSON.stringify(nextState),
+                state: toPersistedGameStateInput(nextState),
                 status: nextState.status,
                 ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
                 updatedAt: new Date(),
@@ -267,7 +272,7 @@ export async function GET(
       const turnTimerSeconds = resolveTurnTimerSeconds(safeLobby.turnTimer)
       if (turnTimerSeconds > 0) {
         try {
-          const parsedState = JSON.parse(activeGame.state)
+          const parsedState = parsePersistedGameState(activeGame.state)
           const liarsPartyGame = new LiarsPartyGame(activeGame.id)
           liarsPartyGame.restoreState(parsedState as any)
 
@@ -282,7 +287,7 @@ export async function GET(
                 updatedAt: activeGame.updatedAt,
               },
               data: {
-                state: JSON.stringify(nextState),
+                state: toPersistedGameStateInput(nextState),
                 status: nextState.status,
                 ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
                 updatedAt: new Date(),
@@ -398,7 +403,7 @@ export async function GET(
       const turnTimerSeconds = resolveTurnTimerSeconds(safeLobby.turnTimer)
       if (turnTimerSeconds > 0) {
         try {
-          const parsedState = JSON.parse(activeGame.state)
+          const parsedState = parsePersistedGameState(activeGame.state)
           const fakeArtistGame = new FakeArtistGame(activeGame.id)
           fakeArtistGame.restoreState(parsedState as any)
 
@@ -413,7 +418,7 @@ export async function GET(
                 updatedAt: activeGame.updatedAt,
               },
               data: {
-                state: JSON.stringify(nextState),
+                state: toPersistedGameStateInput(nextState),
                 status: nextState.status,
                 ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
                 updatedAt: new Date(),
@@ -524,6 +529,7 @@ export async function GET(
     const sanitizedActiveGame = activeGame
       ? {
           ...activeGame,
+          state: stringifyPersistedGameState(activeGame.state),
           players: Array.isArray(activeGame.players)
             ? activeGame.players.map((player: any) => {
                 const safeUser = sanitizeLobbyUserIdentity(player?.user)
@@ -638,7 +644,7 @@ export async function POST(
         data: {
           lobbyId: lobby.id,
           gameType: toPersistedGameType(runtimeGameType),
-          state: JSON.stringify(initialState),
+          state: toPersistedGameStateInput(initialState),
           status: 'waiting',
         },
       })

--- a/app/api/lobby/route.ts
+++ b/app/api/lobby/route.ts
@@ -10,6 +10,7 @@ import { pickRelevantLobbyGame } from '@/lib/lobby-snapshot'
 import { sanitizeLobbyCreatorIdentity } from '@/lib/lobby-response'
 import { hashLobbyPassword } from '@/lib/lobby-password'
 import { toPersistedGameType } from '@/lib/game-type-storage'
+import { toPersistedGameStateInput } from '@/lib/persisted-game-state'
 
 const log = apiLogger('/api/lobby')
 
@@ -169,7 +170,7 @@ export async function POST(request: NextRequest) {
               create: {
                 status: 'waiting',
                 gameType: persistedGameType,
-                state: JSON.stringify(initialState),
+                state: toPersistedGameStateInput(initialState),
                 players: {
                   create: {
                     userId: requestUser.id,

--- a/app/lobby/[code]/hooks/useLobbyActions.ts
+++ b/app/lobby/[code]/hooks/useLobbyActions.ts
@@ -121,7 +121,10 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
         setGame(activeGame)
         if (activeGame.state) {
           try {
-            const parsedState = JSON.parse(activeGame.state)
+            const parsedState =
+              typeof activeGame.state === 'string'
+                ? JSON.parse(activeGame.state)
+                : activeGame.state
 
             // Create the correct engine based on game type
             const gt = data.lobby.gameType || DEFAULT_GAME_TYPE

--- a/lib/game-type-storage.ts
+++ b/lib/game-type-storage.ts
@@ -7,26 +7,18 @@ const PERSISTED_GAME_TYPES = new Set<PrismaGameType>([
   'memory',
   'chess',
   'guess_the_spy',
+  'telephone_doodle',
+  'sketch_and_guess',
+  'liars_party',
+  'fake_artist',
   'uno',
   'other',
 ])
 
 /**
  * Maps runtime game type values to the current Prisma GameType enum.
- *
- * Experimental game types are intentionally persisted as `other` until DB
- * enum/schema is expanded in a dedicated migration.
  */
 export function toPersistedGameType(gameType: string): PrismaGameType {
-  if (
-    gameType === 'telephone_doodle' ||
-    gameType === 'sketch_and_guess' ||
-    gameType === 'liars_party' ||
-    gameType === 'fake_artist'
-  ) {
-    return 'other'
-  }
-
   if (PERSISTED_GAME_TYPES.has(gameType as PrismaGameType)) {
     return gameType as PrismaGameType
   }

--- a/lib/persisted-game-state.ts
+++ b/lib/persisted-game-state.ts
@@ -1,0 +1,23 @@
+import type { Prisma } from '@prisma/client'
+
+export type PersistedGameStateValue = Prisma.JsonValue | string | null | undefined
+
+export function parsePersistedGameState<T = unknown>(value: PersistedGameStateValue): T {
+  if (typeof value === 'string') {
+    return JSON.parse(value) as T
+  }
+
+  return JSON.parse(JSON.stringify(value ?? null)) as T
+}
+
+export function stringifyPersistedGameState(value: PersistedGameStateValue): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  return JSON.stringify(value ?? null)
+}
+
+export function toPersistedGameStateInput(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value ?? null)) as Prisma.InputJsonValue
+}

--- a/lib/socket/disconnect-sync.ts
+++ b/lib/socket/disconnect-sync.ts
@@ -6,6 +6,7 @@ import {
   setPlayerConnectionInState,
   TurnState,
 } from '../disconnected-turn'
+import { parsePersistedGameState, toPersistedGameStateInput, type PersistedGameStateValue } from '../persisted-game-state'
 
 type LogContext = Record<string, unknown>
 
@@ -34,7 +35,7 @@ interface ActiveGamePlayerRecord {
 
 interface ActiveLobbyGameRecord {
   id: string
-  state: string
+  state: PersistedGameStateValue
   currentTurn: number
   updatedAt: Date
   players: ActiveGamePlayerRecord[]
@@ -153,7 +154,7 @@ export function createDisconnectSyncManager({
 
       let parsedState: TurnState
       try {
-        parsedState = JSON.parse(activeGame.state) as TurnState
+        parsedState = parsePersistedGameState<TurnState>(activeGame.state)
       } catch (error) {
         logger.warn('Failed to parse game state during connection sync', {
           lobbyCode,
@@ -199,12 +200,12 @@ export function createDisconnectSyncManager({
           : activeGame.currentTurn
 
       const updateData: {
-        state: string
+        state: ReturnType<typeof toPersistedGameStateInput>
         currentTurn: number
         updatedAt: Date
         lastMoveAt?: Date
       } = {
-        state: JSON.stringify(parsedState),
+        state: toPersistedGameStateInput(parsedState),
         currentTurn: nextCurrentTurn,
         updatedAt: new Date(),
       }

--- a/prisma/migrations/20260309121500_harden_games_schema_and_expand_game_types/migration.sql
+++ b/prisma/migrations/20260309121500_harden_games_schema_and_expand_game_types/migration.sql
@@ -1,0 +1,27 @@
+-- Expand the persisted GameType enum so experimental game modes can be stored directly.
+ALTER TYPE "GameType" ADD VALUE IF NOT EXISTS 'telephone_doodle';
+ALTER TYPE "GameType" ADD VALUE IF NOT EXISTS 'sketch_and_guess';
+ALTER TYPE "GameType" ADD VALUE IF NOT EXISTS 'liars_party';
+ALTER TYPE "GameType" ADD VALUE IF NOT EXISTS 'fake_artist';
+
+-- Align delete semantics with application expectations for lobby/game cleanup.
+ALTER TABLE "Lobbies" DROP CONSTRAINT IF EXISTS "Lobbies_creatorId_fkey";
+ALTER TABLE "Lobbies"
+  ADD CONSTRAINT "Lobbies_creatorId_fkey"
+  FOREIGN KEY ("creatorId") REFERENCES "Users"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Games" DROP CONSTRAINT IF EXISTS "Games_lobbyId_fkey";
+ALTER TABLE "Games"
+  ADD CONSTRAINT "Games_lobbyId_fkey"
+  FOREIGN KEY ("lobbyId") REFERENCES "Lobbies"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Store authoritative game state as JSONB instead of TEXT.
+ALTER TABLE "Games"
+  ALTER COLUMN "state" TYPE JSONB
+  USING "state"::jsonb;
+
+-- Support per-game-type filtering without full scans.
+CREATE INDEX IF NOT EXISTS "Games_gameType_status_idx"
+  ON "Games"("gameType", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,7 +137,7 @@ model Lobbies {
   gameType        String         @default("yahtzee")
   createdAt       DateTime       @default(now()) @db.Timestamptz(3)
   creatorId       String
-  creator         Users          @relation("LobbyCreator", fields: [creatorId], references: [id])
+  creator         Users          @relation("LobbyCreator", fields: [creatorId], references: [id], onDelete: Cascade)
   games           Games[]
   invites         LobbyInvites[]
 
@@ -170,8 +170,8 @@ model LobbyInvites {
 model Games {
   id          String               @id @default(cuid())
   lobbyId     String
-  lobby       Lobbies              @relation(fields: [lobbyId], references: [id])
-  state       String               @db.Text // JSON string with game state
+  lobby       Lobbies              @relation(fields: [lobbyId], references: [id], onDelete: Cascade)
+  state       Json                 @db.JsonB
   status      GameStatus           @default(waiting)
   gameType    GameType             @default(yahtzee)
   abandonedAt DateTime?            @db.Timestamptz(3)
@@ -184,6 +184,7 @@ model Games {
 
   @@index([lobbyId])
   @@index([status])
+  @@index([gameType, status])
   @@index([createdAt])
 }
 
@@ -219,6 +220,10 @@ enum GameType {
   memory
   chess
   guess_the_spy
+  telephone_doodle
+  sketch_and_guess
+  liars_party
+  fake_artist
   uno
   other
 }

--- a/scripts/fix-game-statuses.ts
+++ b/scripts/fix-game-statuses.ts
@@ -14,6 +14,7 @@
  */
 
 import { prisma } from '../lib/db'
+import { parsePersistedGameState } from '../lib/persisted-game-state'
 
 interface GameStateMismatch {
     id: string
@@ -55,8 +56,7 @@ async function findStatusMismatches() {
 
     for (const game of games) {
         try {
-            // Parse game state JSON
-            const state = JSON.parse(game.state)
+            const state = parsePersistedGameState<{ status?: string; winner?: string }>(game.state)
 
             // Check if state has a status field and it differs from DB
             if (state.status && state.status !== game.status) {

--- a/scripts/run-operational-load.ts
+++ b/scripts/run-operational-load.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from 'node:fs'
 import { createGameEngine } from '../lib/game-registry'
 import { prisma } from '../lib/db'
+import { toPersistedGameStateInput } from '../lib/persisted-game-state'
 
 type LoadGameType = 'tic_tac_toe' | 'rock_paper_scissors' | 'yahtzee'
 
@@ -181,7 +182,7 @@ async function createLobbyFixture(params: {
             create: {
               status: 'waiting',
               gameType: params.gameType,
-              state: JSON.stringify(initialState),
+              state: toPersistedGameStateInput(initialState),
               players: {
                 create: {
                   userId: params.creatorId,


### PR DESCRIPTION
## Summary
- migrate `Games.state` from `TEXT` to `JSONB`, add missing cascade relations, and expand persisted `GameType` enum values
- route all game-state reads and writes through a shared helper so server logic remains compatible with persisted JSONB
- preserve the existing lobby snapshot client contract and add regression coverage for persisted game type mapping

## Testing
- `npm run db:validate`
- `npm run db:generate`
- `npm run check:db`
- `npm test -- --runInBand __tests__/lib/game-type-storage.test.ts __tests__/api/game-replay.test.ts __tests__/api/game-state.test.ts __tests__/socket/disconnect-sync.test.ts`
- `npm run ci:quick`
- `npm run hooks:pre-push`

Closes #168