### PR TITLE
Optimize user stats queries and replay compression

### DIFF
--- a/__tests__/api/user-stats.test.ts
+++ b/__tests__/api/user-stats.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment node
+ */
+// @ts-nocheck
+
+import { NextRequest } from 'next/server'
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    $queryRaw: jest.fn(),
+  },
+}))
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}))
+
+jest.mock('@/lib/next-auth', () => ({
+  authOptions: {},
+}))
+
+jest.mock('@/lib/admin-auth', () => ({
+  isAdminUser: jest.fn(),
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimit: jest.fn(() => jest.fn(async () => null)),
+  rateLimitPresets: {
+    api: {},
+  },
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}))
+
+import { GET } from '@/app/api/user/[id]/stats/route'
+import { prisma } from '@/lib/db'
+import { getServerSession } from 'next-auth'
+import { isAdminUser } from '@/lib/admin-auth'
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>
+const mockIsAdminUser = isAdminUser as jest.MockedFunction<typeof isAdminUser>
+
+describe('GET /api/user/[id]/stats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsAdminUser.mockResolvedValue(false)
+  })
+
+  it('returns 401 when the requester is not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/user/user-1/stats'),
+      { params: Promise.resolve({ id: 'user-1' }) }
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(payload.error).toBe('Unauthorized')
+    expect(mockPrisma.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when requesting another user without admin access', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'requester-1' },
+    } as any)
+    mockIsAdminUser.mockResolvedValue(false)
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/user/user-2/stats'),
+      { params: Promise.resolve({ id: 'user-2' }) }
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(payload.error).toBe('Forbidden')
+    expect(mockPrisma.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for an invalid date range', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as any)
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/user/user-1/stats?from=2026-02-10&to=2026-01-01'),
+      { params: Promise.resolve({ id: 'user-1' }) }
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('`from` must be less than or equal to `to`')
+    expect(mockPrisma.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it('returns aggregated stats without loading full game rows into memory', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as any)
+
+    mockPrisma.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          totalGames: 4,
+          wins: 1,
+          losses: 1,
+          draws: 1,
+          avgGameDurationMinutes: 15,
+        },
+      ] as any)
+      .mockResolvedValueOnce([
+        {
+          gameType: 'yahtzee',
+          gamesPlayed: 2,
+          wins: 1,
+          losses: 1,
+          draws: 0,
+          avgScore: 100,
+          bestScore: 120,
+          lastPlayed: new Date('2026-01-02T11:20:00.000Z'),
+        },
+        {
+          gameType: 'tic_tac_toe',
+          gamesPlayed: 1,
+          wins: 0,
+          losses: 0,
+          draws: 1,
+          avgScore: 0,
+          bestScore: 0,
+          lastPlayed: new Date('2026-01-03T12:05:00.000Z'),
+        },
+        {
+          gameType: 'guess_the_spy',
+          gamesPlayed: 1,
+          wins: 0,
+          losses: 0,
+          draws: 0,
+          avgScore: 0,
+          bestScore: 0,
+          lastPlayed: new Date('2026-01-04T13:25:00.000Z'),
+        },
+      ] as any)
+      .mockResolvedValueOnce([
+        { date: '2026-01-01', gamesPlayed: 1, wins: 1 },
+        { date: '2026-01-02', gamesPlayed: 1, wins: 0 },
+        { date: '2026-01-03', gamesPlayed: 1, wins: 0 },
+        { date: '2026-01-04', gamesPlayed: 1, wins: 0 },
+      ] as any)
+      .mockResolvedValueOnce([
+        { currentWinStreak: 0, longestWinStreak: 1 },
+      ] as any)
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/user/user-1/stats?from=2026-01-01&to=2026-01-31'),
+      { params: Promise.resolve({ id: 'user-1' }) }
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Stats-Cache')).toBe('bypass')
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(4)
+    expect(payload).toMatchObject({
+      userId: 'user-1',
+      overall: {
+        totalGames: 4,
+        wins: 1,
+        losses: 1,
+        draws: 1,
+        winRate: 33.3,
+        avgGameDurationMinutes: 15,
+        favoriteGame: 'yahtzee',
+        currentWinStreak: 0,
+        longestWinStreak: 1,
+      },
+      byGame: expect.arrayContaining([
+        expect.objectContaining({
+          gameType: 'yahtzee',
+          gamesPlayed: 2,
+          wins: 1,
+          losses: 1,
+          draws: 0,
+          winRate: 50,
+          avgScore: 100,
+          bestScore: 120,
+        }),
+      ]),
+      trends: expect.arrayContaining([
+        expect.objectContaining({ date: '2026-01-01', gamesPlayed: 1, wins: 1 }),
+        expect.objectContaining({ date: '2026-01-02', gamesPlayed: 1, wins: 0 }),
+      ]),
+      dateRange: {
+        from: '2026-01-01T00:00:00.000Z',
+        to: '2026-01-31T23:59:59.999Z',
+      },
+    })
+    expect(typeof payload.generatedAt).toBe('string')
+  })
+})

--- a/__tests__/lib/game-replay.test.ts
+++ b/__tests__/lib/game-replay.test.ts
@@ -1,0 +1,87 @@
+// @ts-nocheck
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    $transaction: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    warn: jest.fn(),
+  })),
+}))
+
+import { prisma } from '@/lib/db'
+import { appendGameReplaySnapshot, decodeGameReplaySnapshots } from '@/lib/game-replay'
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+
+describe('game replay helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('compresses replay state asynchronously and keeps snapshots decodable', async () => {
+    const tx = {
+      gameStateSnapshots: {
+        findFirst: jest.fn().mockResolvedValue({ turnNumber: 2 }),
+        create: jest.fn().mockResolvedValue({ id: 'snapshot-3' }),
+        findMany: jest.fn().mockResolvedValue([{ id: 'snapshot-0' }]),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+    }
+
+    mockPrisma.$transaction.mockImplementation(async (callback: any) => callback(tx))
+
+    await appendGameReplaySnapshot({
+      gameId: 'game-1',
+      actionType: 'move:submit',
+      actionPayload: { cell: 4 },
+      state: {
+        gameType: 'tic_tac_toe',
+        board: ['X', null, 'O'],
+        currentPlayerIndex: 1,
+      },
+    })
+
+    expect(tx.gameStateSnapshots.create).toHaveBeenCalledTimes(1)
+    expect(tx.gameStateSnapshots.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: {
+          in: ['snapshot-0'],
+        },
+      },
+    })
+
+    const createArgs = tx.gameStateSnapshots.create.mock.calls[0][0]
+    expect(createArgs.data.turnNumber).toBe(3)
+    expect(createArgs.data.stateEncoding).toBe('gzip-base64')
+    expect(createArgs.data.stateSize).toBeGreaterThan(0)
+    expect(typeof createArgs.data.stateCompressed).toBe('string')
+    expect(createArgs.data.stateCompressed).not.toContain('"board"')
+
+    const decoded = decodeGameReplaySnapshots([
+      {
+        id: 'snapshot-3',
+        turnNumber: createArgs.data.turnNumber,
+        playerId: null,
+        actionType: 'move:submit',
+        actionPayload: { cell: 4 },
+        stateCompressed: createArgs.data.stateCompressed,
+        stateEncoding: createArgs.data.stateEncoding,
+        createdAt: new Date('2026-03-09T12:00:00.000Z'),
+      },
+    ])
+
+    expect(decoded[0]).toMatchObject({
+      id: 'snapshot-3',
+      actionType: 'move:submit',
+      state: {
+        gameType: 'tic_tac_toe',
+        board: ['X', null, 'O'],
+        currentPlayerIndex: 1,
+      },
+    })
+  })
+})

--- a/app/api/user/[id]/stats/route.ts
+++ b/app/api/user/[id]/stats/route.ts
@@ -1,24 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
-import { Prisma, GameStatus } from '@prisma/client'
 import { authOptions } from '@/lib/next-auth'
 import { prisma } from '@/lib/db'
 import { isAdminUser } from '@/lib/admin-auth'
 import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
 import { apiLogger } from '@/lib/logger'
-import { calculateUserStats } from '@/lib/stats-calculator'
+import { getUserStatsDashboard } from '@/lib/user-stats-dashboard'
 
 const limiter = rateLimit(rateLimitPresets.api)
 const log = apiLogger('GET /api/user/[id]/stats')
-const STATS_CACHE_TTL_MS = 60 * 1000
-
-interface StatsCacheEntry {
-  signature: string
-  expiresAt: number
-  payload: unknown
-}
-
-const statsCache = new Map<string, StatsCacheEntry>()
 
 function parseDateRangeParam(raw: string | null, { endOfDay }: { endOfDay: boolean }): Date | null {
   if (!raw) return null
@@ -86,91 +76,20 @@ export async function GET(
       )
     }
 
-    const where: Prisma.GamesWhereInput = {
-      players: {
-        some: {
-          userId: targetUserId,
-        },
-      },
-      status: {
-        in: [GameStatus.finished, GameStatus.abandoned, GameStatus.cancelled],
-      },
-    }
-
-    if (fromDate || toDate) {
-      where.createdAt = {}
-      if (fromDate) {
-        where.createdAt.gte = fromDate
-      }
-      if (toDate) {
-        where.createdAt.lte = toDate
-      }
-    }
-
-    const cacheKey = `${targetUserId}|${fromDate?.toISOString() ?? 'none'}|${toDate?.toISOString() ?? 'none'}`
-    const cacheSnapshot = await prisma.games.aggregate({
-      where,
-      _count: {
-        id: true,
-      },
-      _max: {
-        updatedAt: true,
-      },
-    })
-    const cacheSignature = `${cacheSnapshot._count.id}:${cacheSnapshot._max.updatedAt?.toISOString() ?? 'none'}`
-    const cachedEntry = statsCache.get(cacheKey)
-    if (cachedEntry && cachedEntry.signature === cacheSignature && Date.now() < cachedEntry.expiresAt) {
-      return NextResponse.json(cachedEntry.payload, {
-        headers: {
-          'Cache-Control': 'private, max-age=60',
-          'X-Stats-Cache': 'hit',
-        },
-      })
-    }
-
-    const games = await prisma.games.findMany({
-      where,
-      select: {
-        id: true,
-        gameType: true,
-        status: true,
-        createdAt: true,
-        updatedAt: true,
-        players: {
-          select: {
-            userId: true,
-            score: true,
-            finalScore: true,
-            isWinner: true,
-            placement: true,
-          },
-        },
-      },
-      orderBy: {
-        updatedAt: 'desc',
-      },
-    })
-
-    const stats = calculateUserStats(targetUserId, games, {
+    const payload = await getUserStatsDashboard(prisma, targetUserId, {
       from: fromDate,
       to: toDate,
     })
-    const payload = {
-      userId: targetUserId,
-      ...stats,
-    }
-    statsCache.set(cacheKey, {
-      signature: cacheSignature,
-      expiresAt: Date.now() + STATS_CACHE_TTL_MS,
-      payload,
-    })
 
     return NextResponse.json(
-      payload,
+      {
+        userId: targetUserId,
+        ...payload,
+      },
       {
         headers: {
           'Cache-Control': 'private, max-age=60',
-          'X-Stats-Cache': 'miss',
+          'X-Stats-Cache': 'bypass',
         },
       }
     )

--- a/lib/game-replay.ts
+++ b/lib/game-replay.ts
@@ -1,11 +1,13 @@
 import { Prisma } from '@prisma/client'
-import { gzipSync, gunzipSync } from 'node:zlib'
+import { promisify } from 'node:util'
+import { gunzipSync, gzip } from 'node:zlib'
 import { prisma } from '@/lib/db'
 import { apiLogger } from '@/lib/logger'
 
 const log = apiLogger('game-replay')
 const DEFAULT_STATE_ENCODING = 'gzip-base64'
 const MAX_SNAPSHOTS_PER_GAME = 500
+const gzipAsync = promisify(gzip)
 
 export interface ReplaySnapshotWriteInput {
   gameId: string
@@ -46,13 +48,13 @@ function toReplayActionPayload(value: unknown): Prisma.InputJsonValue | undefine
   }
 }
 
-function encodeState(state: unknown): {
+async function encodeState(state: unknown): Promise<{
   stateCompressed: string
   stateEncoding: string
   stateSize: number
-} {
+}> {
   const rawState = JSON.stringify(state ?? null)
-  const compressed = gzipSync(Buffer.from(rawState, 'utf-8')).toString('base64')
+  const compressed = (await gzipAsync(Buffer.from(rawState, 'utf-8'))).toString('base64')
 
   return {
     stateCompressed: compressed,
@@ -81,7 +83,7 @@ export async function appendGameReplaySnapshot(input: ReplaySnapshotWriteInput):
   if (!input.gameId || !input.actionType) return
 
   try {
-    const encodedState = encodeState(input.state)
+    const encodedState = await encodeState(input.state)
     const safeActionPayload = toReplayActionPayload(input.actionPayload)
 
     await prisma.$transaction(async (tx) => {

--- a/lib/user-stats-dashboard.ts
+++ b/lib/user-stats-dashboard.ts
@@ -1,0 +1,301 @@
+import { Prisma } from '@prisma/client'
+import type { PrismaClient } from '@prisma/client'
+import type {
+  UserByGameStats,
+  UserStatsDashboard,
+  UserTrendPoint,
+} from '@/lib/stats-calculator'
+
+interface GetUserStatsDashboardOptions {
+  from?: Date | null
+  to?: Date | null
+}
+
+type UserStatsQueryClient = Pick<PrismaClient, '$queryRaw'>
+
+interface OverallRow {
+  totalGames: number
+  wins: number
+  losses: number
+  draws: number
+  avgGameDurationMinutes: number
+}
+
+interface ByGameRow {
+  gameType: string
+  gamesPlayed: number
+  wins: number
+  losses: number
+  draws: number
+  avgScore: number | null
+  bestScore: number | null
+  lastPlayed: Date | null
+}
+
+interface TrendRow {
+  date: string
+  gamesPlayed: number
+  wins: number
+}
+
+interface StreakRow {
+  currentWinStreak: number
+  longestWinStreak: number
+}
+
+function roundToOneDecimal(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+function toFiniteNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'bigint') {
+    return Number(value)
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return fallback
+}
+
+function buildCreatedAtFilter(from?: Date | null, to?: Date | null): Prisma.Sql {
+  const filters: Prisma.Sql[] = []
+
+  if (from) {
+    filters.push(Prisma.sql`g."createdAt" >= ${from}`)
+  }
+
+  if (to) {
+    filters.push(Prisma.sql`g."createdAt" <= ${to}`)
+  }
+
+  if (filters.length === 0) {
+    return Prisma.empty
+  }
+
+  return Prisma.sql`AND ${Prisma.join(filters, ' AND ')}`
+}
+
+function buildUserGamesCte(userId: string, options: GetUserStatsDashboardOptions): Prisma.Sql {
+  const createdAtFilter = buildCreatedAtFilter(options.from, options.to)
+
+  return Prisma.sql`
+    WITH user_games AS (
+      SELECT
+        g.id,
+        g."gameType",
+        g."createdAt",
+        g."updatedAt",
+        p.score,
+        p."finalScore",
+        p."isWinner",
+        CASE
+          WHEN g.status <> 'finished' THEN NULL
+          WHEN winners."winnerCount" = 0 THEN 'draw'
+          WHEN p."isWinner" = true AND winners."winnerCount" > 1 THEN 'draw'
+          WHEN p."isWinner" = true THEN 'win'
+          ELSE 'loss'
+        END AS outcome
+      FROM "Games" g
+      JOIN "Players" p
+        ON p."gameId" = g.id
+       AND p."userId" = ${userId}
+      JOIN LATERAL (
+        SELECT COUNT(*) FILTER (WHERE winners."isWinner" = true)::int AS "winnerCount"
+        FROM "Players" winners
+        WHERE winners."gameId" = g.id
+      ) winners ON TRUE
+      WHERE g.status IN ('finished', 'abandoned', 'cancelled')
+      ${createdAtFilter}
+    )
+  `
+}
+
+function normalizeOverallRow(row: OverallRow | undefined) {
+  return {
+    totalGames: toFiniteNumber(row?.totalGames),
+    wins: toFiniteNumber(row?.wins),
+    losses: toFiniteNumber(row?.losses),
+    draws: toFiniteNumber(row?.draws),
+    avgGameDurationMinutes: roundToOneDecimal(toFiniteNumber(row?.avgGameDurationMinutes)),
+  }
+}
+
+function normalizeByGameRows(rows: ByGameRow[]): UserByGameStats[] {
+  return rows.map((row) => {
+    const gamesPlayed = toFiniteNumber(row.gamesPlayed)
+    const wins = toFiniteNumber(row.wins)
+    const losses = toFiniteNumber(row.losses)
+    const draws = toFiniteNumber(row.draws)
+    const denominator = wins + losses + draws
+
+    return {
+      gameType: row.gameType,
+      gamesPlayed,
+      wins,
+      losses,
+      draws,
+      winRate: denominator > 0 ? roundToOneDecimal((wins / denominator) * 100) : 0,
+      avgScore:
+        row.avgScore === null || row.avgScore === undefined
+          ? null
+          : roundToOneDecimal(toFiniteNumber(row.avgScore)),
+      bestScore:
+        row.bestScore === null || row.bestScore === undefined
+          ? null
+          : toFiniteNumber(row.bestScore),
+      lastPlayed: row.lastPlayed ? row.lastPlayed.toISOString() : null,
+    }
+  })
+}
+
+function normalizeTrendRows(rows: TrendRow[]): UserTrendPoint[] {
+  return rows.map((row) => ({
+    date: row.date,
+    gamesPlayed: toFiniteNumber(row.gamesPlayed),
+    wins: toFiniteNumber(row.wins),
+  }))
+}
+
+export async function getUserStatsDashboard(
+  client: UserStatsQueryClient,
+  userId: string,
+  options: GetUserStatsDashboardOptions = {}
+): Promise<UserStatsDashboard> {
+  const userGamesCte = buildUserGamesCte(userId, options)
+
+  const [overallRows, byGameRows, trendRows, streakRows] = await Promise.all([
+    client.$queryRaw<OverallRow[]>(Prisma.sql`
+      ${userGamesCte}
+      SELECT
+        COUNT(*)::int AS "totalGames",
+        COUNT(*) FILTER (WHERE outcome = 'win')::int AS wins,
+        COUNT(*) FILTER (WHERE outcome = 'loss')::int AS losses,
+        COUNT(*) FILTER (WHERE outcome = 'draw')::int AS draws,
+        COALESCE(
+          ROUND(
+            AVG(GREATEST(EXTRACT(EPOCH FROM ("updatedAt" - "createdAt")), 0))::numeric / 60,
+            1
+          )::double precision,
+          0
+        ) AS "avgGameDurationMinutes"
+      FROM user_games
+    `),
+    client.$queryRaw<ByGameRow[]>(Prisma.sql`
+      ${userGamesCte}
+      SELECT
+        "gameType",
+        COUNT(*)::int AS "gamesPlayed",
+        COUNT(*) FILTER (WHERE outcome = 'win')::int AS wins,
+        COUNT(*) FILTER (WHERE outcome = 'loss')::int AS losses,
+        COUNT(*) FILTER (WHERE outcome = 'draw')::int AS draws,
+        ROUND(AVG(COALESCE("finalScore", score))::numeric, 1)::double precision AS "avgScore",
+        MAX(COALESCE("finalScore", score))::int AS "bestScore",
+        MAX("updatedAt") AS "lastPlayed"
+      FROM user_games
+      GROUP BY "gameType"
+      ORDER BY COUNT(*) DESC, "gameType" ASC
+    `),
+    client.$queryRaw<TrendRow[]>(Prisma.sql`
+      ${userGamesCte}
+      SELECT
+        TO_CHAR(DATE("updatedAt" AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS date,
+        COUNT(*)::int AS "gamesPlayed",
+        COUNT(*) FILTER (WHERE outcome = 'win')::int AS wins
+      FROM user_games
+      GROUP BY DATE("updatedAt" AT TIME ZONE 'UTC')
+      ORDER BY DATE("updatedAt" AT TIME ZONE 'UTC') ASC
+    `),
+    client.$queryRaw<StreakRow[]>(Prisma.sql`
+      ${userGamesCte}
+      , finished_games AS (
+        SELECT
+          id,
+          "updatedAt",
+          outcome,
+          ROW_NUMBER() OVER (ORDER BY "updatedAt" ASC, id ASC) AS seq,
+          ROW_NUMBER() OVER (
+            PARTITION BY CASE WHEN outcome = 'win' THEN 1 ELSE 0 END
+            ORDER BY "updatedAt" ASC, id ASC
+          ) AS seq_by_group,
+          ROW_NUMBER() OVER (ORDER BY "updatedAt" DESC, id DESC) AS rev_seq,
+          ROW_NUMBER() OVER (
+            PARTITION BY CASE WHEN outcome = 'win' THEN 1 ELSE 0 END
+            ORDER BY "updatedAt" DESC, id DESC
+          ) AS rev_seq_by_group
+        FROM user_games
+        WHERE outcome IS NOT NULL
+      ),
+      longest_streak AS (
+        SELECT COALESCE(MAX(streak_length), 0)::int AS value
+        FROM (
+          SELECT COUNT(*)::int AS streak_length
+          FROM finished_games
+          WHERE outcome = 'win'
+          GROUP BY seq - seq_by_group
+        ) grouped
+      ),
+      current_streak AS (
+        SELECT
+          CASE
+            WHEN EXISTS (
+              SELECT 1
+              FROM finished_games
+              WHERE rev_seq = 1 AND outcome = 'win'
+            )
+            THEN COALESCE((
+              SELECT COUNT(*)::int
+              FROM finished_games
+              WHERE outcome = 'win'
+                AND rev_seq - rev_seq_by_group = 0
+            ), 0)
+            ELSE 0
+          END AS value
+      )
+      SELECT
+        current_streak.value::int AS "currentWinStreak",
+        longest_streak.value::int AS "longestWinStreak"
+      FROM current_streak
+      CROSS JOIN longest_streak
+    `),
+  ])
+
+  const normalizedOverall = normalizeOverallRow(overallRows[0])
+  const byGame = normalizeByGameRows(byGameRows)
+  const trends = normalizeTrendRows(trendRows)
+  const streaks = streakRows[0] ?? { currentWinStreak: 0, longestWinStreak: 0 }
+  const outcomeDenominator =
+    normalizedOverall.wins + normalizedOverall.losses + normalizedOverall.draws
+
+  return {
+    overall: {
+      totalGames: normalizedOverall.totalGames,
+      wins: normalizedOverall.wins,
+      losses: normalizedOverall.losses,
+      draws: normalizedOverall.draws,
+      winRate:
+        outcomeDenominator > 0
+          ? roundToOneDecimal((normalizedOverall.wins / outcomeDenominator) * 100)
+          : 0,
+      avgGameDurationMinutes: normalizedOverall.avgGameDurationMinutes,
+      favoriteGame: byGame[0]?.gameType ?? null,
+      currentWinStreak: toFiniteNumber(streaks.currentWinStreak),
+      longestWinStreak: toFiniteNumber(streaks.longestWinStreak),
+    },
+    byGame,
+    trends,
+    dateRange: {
+      from: options.from?.toISOString() ?? null,
+      to: options.to?.toISOString() ?? null,
+    },
+    generatedAt: new Date().toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary
- replace the user stats endpoint's full-game hydration path with PostgreSQL aggregations and streak calculations via raw SQL
- remove the ineffective in-memory stats cache and keep the dashboard response shape intact for date-range filters
- switch replay snapshot compression from synchronous `gzipSync` to async `gzip`, with regression coverage for stats and replay helpers

## Testing
- `npm run typecheck`
- `npm test -- --runInBand __tests__/api/user-stats.test.ts __tests__/lib/game-replay.test.ts __tests__/lib/stats-calculator.test.ts __tests__/api/game-replay.test.ts`
- `npm run ci:quick`
- `npm run hooks:pre-push`

Closes #170