### PR TITLE
test: close critical coverage gaps

### DIFF
--- a/__tests__/api/admin-overview.test.ts
+++ b/__tests__/api/admin-overview.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+// @ts-nocheck
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    users: {
+      count: jest.fn(),
+    },
+    games: {
+      count: jest.fn(),
+    },
+    lobbies: {
+      count: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/admin-auth', () => ({
+  requireAdminApiUser: jest.fn(),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+  logger: {
+    error: jest.fn(),
+  },
+}))
+
+import { GET } from '@/app/api/admin/overview/route'
+import { prisma } from '@/lib/db'
+import { requireAdminApiUser } from '@/lib/admin-auth'
+import { AuthenticationError, AuthorizationError } from '@/lib/error-handler'
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockRequireAdminApiUser = requireAdminApiUser as jest.MockedFunction<typeof requireAdminApiUser>
+
+describe('GET /api/admin/overview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 for unauthenticated requests', async () => {
+    mockRequireAdminApiUser.mockRejectedValue(new AuthenticationError('Unauthorized'))
+
+    const response = await GET()
+    const payload = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(payload.error).toBe('Unauthorized')
+    expect(mockPrisma.users.count).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 for authenticated non-admin users', async () => {
+    mockRequireAdminApiUser.mockRejectedValue(new AuthorizationError('Admin access required'))
+
+    const response = await GET()
+    const payload = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(payload.error).toBe('Admin access required')
+    expect(mockPrisma.users.count).not.toHaveBeenCalled()
+  })
+
+  it('returns admin dashboard stats for authorized admins', async () => {
+    mockRequireAdminApiUser.mockResolvedValue({
+      id: 'admin-1',
+      role: 'admin',
+      suspended: false,
+      email: 'admin@example.com',
+      username: 'admin',
+    } as any)
+    mockPrisma.users.count
+      .mockResolvedValueOnce(100 as never)
+      .mockResolvedValueOnce(25 as never)
+      .mockResolvedValueOnce(3 as never)
+    mockPrisma.games.count
+      .mockResolvedValueOnce(45 as never)
+      .mockResolvedValueOnce(6 as never)
+    mockPrisma.lobbies.count
+      .mockResolvedValueOnce(12 as never)
+      .mockResolvedValueOnce(20 as never)
+
+    const response = await GET()
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.stats).toEqual({
+      totalUsers: 100,
+      activeUsers24h: 25,
+      suspendedUsers: 3,
+      totalGames: 45,
+      gamesInProgress: 6,
+      activeLobbies: 12,
+      totalLobbies: 20,
+    })
+    expect(typeof payload.generatedAt).toBe('string')
+  })
+})

--- a/__tests__/api/auth-forgot-password.test.ts
+++ b/__tests__/api/auth-forgot-password.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+// @ts-nocheck
+
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/auth/forgot-password/route'
+import { prisma } from '@/lib/db'
+import { sendPasswordResetEmail } from '@/lib/email'
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    users: {
+      findFirst: jest.fn(),
+    },
+    passwordResetTokens: {
+      deleteMany: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/email', () => ({
+  sendPasswordResetEmail: jest.fn(),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}))
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockSendPasswordResetEmail = sendPasswordResetEmail as jest.MockedFunction<typeof sendPasswordResetEmail>
+
+function buildRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/auth/forgot-password', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+const genericSuccessMessage =
+  'If an account exists with that email, you will receive password reset instructions.'
+
+describe('POST /api/auth/forgot-password', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSendPasswordResetEmail.mockResolvedValue({ success: true })
+  })
+
+  it('returns validation error for invalid email input', async () => {
+    const response = await POST(buildRequest({ email: 'bad-email' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('Invalid email address')
+  })
+
+  it('returns generic success for non-existent users to prevent enumeration', async () => {
+    mockPrisma.users.findFirst.mockResolvedValue(null)
+
+    const response = await POST(buildRequest({ email: 'missing@example.com' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.message).toBe(genericSuccessMessage)
+    expect(mockPrisma.passwordResetTokens.create).not.toHaveBeenCalled()
+    expect(mockSendPasswordResetEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns generic success when the initial DB lookup fails', async () => {
+    mockPrisma.users.findFirst.mockRejectedValue(new Error('db offline'))
+
+    const response = await POST(buildRequest({ email: 'user@example.com' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.message).toBe(genericSuccessMessage)
+  })
+
+  it('creates a new reset token and sends email for existing users', async () => {
+    mockPrisma.users.findFirst.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+    } as any)
+
+    const response = await POST(buildRequest({ email: 'USER@example.com' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.message).toBe(genericSuccessMessage)
+    expect(mockPrisma.passwordResetTokens.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+    })
+    expect(mockPrisma.passwordResetTokens.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        token: expect.any(String),
+        expires: expect.any(Date),
+      },
+    })
+    expect(mockSendPasswordResetEmail).toHaveBeenCalledWith('user@example.com', expect.any(String))
+  })
+
+  it('still returns generic success when sending the reset email fails', async () => {
+    mockPrisma.users.findFirst.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+    } as any)
+    mockSendPasswordResetEmail.mockResolvedValue({
+      success: false,
+      error: 'provider unavailable',
+    })
+
+    const response = await POST(buildRequest({ email: 'user@example.com' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.message).toBe(genericSuccessMessage)
+  })
+})

--- a/__tests__/api/auth-login.test.ts
+++ b/__tests__/api/auth-login.test.ts
@@ -8,6 +8,8 @@ import { POST } from '@/app/api/auth/login/route'
 import { prisma } from '@/lib/db'
 import { comparePassword, createToken } from '@/lib/auth'
 
+let mockRateLimitResult: Response | null = null
+
 jest.mock('@/lib/db', () => ({
   prisma: {
     users: {
@@ -22,7 +24,7 @@ jest.mock('@/lib/auth', () => ({
 }))
 
 jest.mock('@/lib/rate-limit', () => ({
-  rateLimit: jest.fn(() => jest.fn(() => Promise.resolve(null))),
+  rateLimit: jest.fn(() => jest.fn(() => Promise.resolve(mockRateLimitResult))),
   rateLimitPresets: {
     auth: {},
   },
@@ -53,6 +55,7 @@ function buildRequest(body: unknown) {
 describe('POST /api/auth/login', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockRateLimitResult = null
   })
 
   it('returns 401 for suspended user with valid password', async () => {
@@ -76,6 +79,82 @@ describe('POST /api/auth/login', () => {
     expect(response.status).toBe(401)
     expect(payload.error).toBe('Account suspended')
     expect(mockCreateToken).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 for invalid password', async () => {
+    mockPrisma.users.findFirst.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      username: 'user',
+      passwordHash: 'hashed-password',
+      suspended: false,
+    } as any)
+    mockComparePassword.mockResolvedValue(false)
+
+    const response = await POST(
+      buildRequest({
+        email: 'user@example.com',
+        password: 'WrongPass123!',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(payload.error).toBe('Invalid credentials')
+    expect(mockCreateToken).not.toHaveBeenCalled()
+  })
+
+  it('normalizes email casing before querying and creating the token', async () => {
+    mockPrisma.users.findFirst.mockResolvedValue({
+      id: 'user-3',
+      email: 'mixed@example.com',
+      username: 'mixed-user',
+      passwordHash: 'hashed-password',
+      suspended: false,
+    } as any)
+    mockComparePassword.mockResolvedValue(true)
+
+    const response = await POST(
+      buildRequest({
+        email: 'MiXeD@Example.com',
+        password: 'ValidPass123!',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.user.email).toBe('mixed@example.com')
+    expect(mockPrisma.users.findFirst).toHaveBeenCalledWith({
+      where: {
+        email: {
+          equals: 'mixed@example.com',
+          mode: 'insensitive',
+        },
+      },
+    })
+    expect(mockCreateToken).toHaveBeenCalledWith({
+      userId: 'user-3',
+      email: 'mixed@example.com',
+    })
+  })
+
+  it('returns the limiter response when auth rate limiting triggers', async () => {
+    mockRateLimitResult = new Response(JSON.stringify({ error: 'Too many requests' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(
+      buildRequest({
+        email: 'user@example.com',
+        password: 'ValidPass123!',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(429)
+    expect(payload.error).toBe('Too many requests')
+    expect(mockPrisma.users.findFirst).not.toHaveBeenCalled()
   })
 
   it('returns 200 and token for active user with valid password', async () => {

--- a/__tests__/api/auth-register.test.ts
+++ b/__tests__/api/auth-register.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+// @ts-nocheck
+
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/auth/register/route'
+import { prisma } from '@/lib/db'
+import { hashPassword } from '@/lib/auth'
+import { sendVerificationEmail } from '@/lib/email'
+import { nanoid } from 'nanoid'
+
+let mockRateLimitResult: Response | null = null
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    users: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    emailVerificationTokens: {
+      create: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/auth', () => ({
+  hashPassword: jest.fn(),
+  createToken: jest.fn(),
+}))
+
+jest.mock('@/lib/email', () => ({
+  sendVerificationEmail: jest.fn(),
+}))
+
+jest.mock('nanoid', () => ({
+  nanoid: jest.fn(),
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimit: jest.fn(() => jest.fn(async () => mockRateLimitResult)),
+  rateLimitPresets: {
+    auth: {},
+  },
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}))
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockHashPassword = hashPassword as jest.MockedFunction<typeof hashPassword>
+const mockSendVerificationEmail = sendVerificationEmail as jest.MockedFunction<typeof sendVerificationEmail>
+const mockNanoid = nanoid as jest.MockedFunction<typeof nanoid>
+
+function buildRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/auth/register', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/auth/register', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRateLimitResult = null
+    mockHashPassword.mockResolvedValue('hashed-password')
+    mockSendVerificationEmail.mockResolvedValue({ success: true })
+    mockNanoid.mockReturnValue('verification-token')
+    mockPrisma.users.findFirst.mockResolvedValue(null)
+    mockPrisma.users.findUnique.mockResolvedValue(null)
+    mockPrisma.users.create.mockResolvedValue({
+      id: 'user-1',
+      email: 'new@example.com',
+      username: 'new_user',
+    } as any)
+  })
+
+  it('returns the limiter response when registration is rate limited', async () => {
+    mockRateLimitResult = new Response(JSON.stringify({ error: 'Too many requests' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(
+      buildRequest({
+        email: 'new@example.com',
+        username: 'new_user',
+        password: 'ValidPass123',
+      })
+    )
+
+    expect(response.status).toBe(429)
+    expect(mockPrisma.users.findFirst).not.toHaveBeenCalled()
+  })
+
+  it('rejects duplicate email or username during initial lookup', async () => {
+    mockPrisma.users.findFirst.mockResolvedValue({ id: 'existing-user' } as any)
+
+    const response = await POST(
+      buildRequest({
+        email: 'new@example.com',
+        username: 'new_user',
+        password: 'ValidPass123',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('Email or username already exists')
+    expect(mockPrisma.users.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects a username collision found before user creation', async () => {
+    mockPrisma.users.findUnique.mockResolvedValue({ id: 'taken-user' } as any)
+
+    const response = await POST(
+      buildRequest({
+        email: 'new@example.com',
+        username: 'new_user',
+        password: 'ValidPass123',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('Username already taken')
+    expect(mockPrisma.users.create).not.toHaveBeenCalled()
+  })
+
+  it('returns validation issues for invalid input', async () => {
+    const response = await POST(
+      buildRequest({
+        email: 'not-an-email',
+        username: 'ab',
+        password: 'short',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(Array.isArray(payload.error)).toBe(true)
+    expect(mockPrisma.users.findFirst).not.toHaveBeenCalled()
+  })
+
+  it('hashes the password, creates the user, and stores a verification token', async () => {
+    const response = await POST(
+      buildRequest({
+        email: 'NEW@Example.com',
+        username: 'new_user',
+        password: 'ValidPass123',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockHashPassword).toHaveBeenCalledWith('ValidPass123')
+    expect(mockPrisma.users.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          {
+            email: {
+              equals: 'new@example.com',
+              mode: 'insensitive',
+            },
+          },
+          { username: 'new_user' },
+        ],
+      },
+    })
+    expect(mockPrisma.users.create).toHaveBeenCalledWith({
+      data: {
+        email: 'new@example.com',
+        username: 'new_user',
+        passwordHash: 'hashed-password',
+      },
+    })
+    expect(mockPrisma.emailVerificationTokens.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        token: 'verification-token',
+        expires: expect.any(Date),
+      },
+    })
+    expect(mockSendVerificationEmail).toHaveBeenCalledWith('new@example.com', 'verification-token')
+    expect(payload.user).toEqual({
+      id: 'user-1',
+      email: 'new@example.com',
+      username: 'new_user',
+      emailVerified: false,
+    })
+  })
+
+  it('returns success even when verification email sending fails', async () => {
+    mockSendVerificationEmail.mockResolvedValue({
+      success: false,
+      error: 'provider unavailable',
+    })
+
+    const response = await POST(
+      buildRequest({
+        email: 'new@example.com',
+        username: 'new_user',
+        password: 'ValidPass123',
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockPrisma.emailVerificationTokens.create).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/api/auth-reset-password.test.ts
+++ b/__tests__/api/auth-reset-password.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+// @ts-nocheck
+
+import { NextRequest } from 'next/server'
+import bcrypt from 'bcrypt'
+import { POST } from '@/app/api/auth/reset-password/route'
+import { prisma } from '@/lib/db'
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    passwordResetTokens: {
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+    },
+    users: {
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    error: jest.fn(),
+  })),
+}))
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockHash = bcrypt.hash as jest.MockedFunction<typeof bcrypt.hash>
+
+function buildRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/auth/reset-password', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/auth/reset-password', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHash.mockResolvedValue('new-hash' as never)
+  })
+
+  it('returns validation issues for invalid password payload', async () => {
+    const response = await POST(
+      buildRequest({
+        token: '',
+        password: 'short',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(Array.isArray(payload.error)).toBe(true)
+  })
+
+  it('rejects invalid or missing reset tokens', async () => {
+    mockPrisma.passwordResetTokens.findUnique.mockResolvedValue(null)
+
+    const response = await POST(
+      buildRequest({
+        token: 'missing-token',
+        password: 'ValidPass123!',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('Invalid or expired reset token')
+    expect(mockPrisma.users.update).not.toHaveBeenCalled()
+  })
+
+  it('deletes expired tokens and rejects the reset attempt', async () => {
+    mockPrisma.passwordResetTokens.findUnique.mockResolvedValue({
+      id: 'token-1',
+      userId: 'user-1',
+      expires: new Date(Date.now() - 60_000),
+    } as any)
+
+    const response = await POST(
+      buildRequest({
+        token: 'expired-token',
+        password: 'ValidPass123!',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.error).toBe('Reset token has expired. Please request a new one.')
+    expect(mockPrisma.passwordResetTokens.delete).toHaveBeenCalledWith({
+      where: { id: 'token-1' },
+    })
+  })
+
+  it('updates the user password and consumes the token on success', async () => {
+    mockPrisma.passwordResetTokens.findUnique.mockResolvedValue({
+      id: 'token-2',
+      userId: 'user-2',
+      expires: new Date(Date.now() + 60_000),
+    } as any)
+
+    const response = await POST(
+      buildRequest({
+        token: 'valid-token',
+        password: 'ValidPass123!',
+      })
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.message).toBe('Password reset successfully')
+    expect(mockHash).toHaveBeenCalledWith('ValidPass123!', 10)
+    expect(mockPrisma.users.update).toHaveBeenCalledWith({
+      where: { id: 'user-2' },
+      data: { passwordHash: 'new-hash' },
+    })
+    expect(mockPrisma.passwordResetTokens.delete).toHaveBeenCalledWith({
+      where: { id: 'token-2' },
+    })
+  })
+})

--- a/__tests__/lib/guest-auth.test.ts
+++ b/__tests__/lib/guest-auth.test.ts
@@ -1,0 +1,121 @@
+import jwt from 'jsonwebtoken'
+import {
+  createGuestId,
+  createGuestToken,
+  getGuestClaimsFromRequest,
+  getGuestTokenFromRequest,
+  verifyGuestToken,
+} from '@/lib/guest-auth'
+
+describe('guest-auth', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    process.env = {
+      ...originalEnv,
+      NEXTAUTH_SECRET: 'test-nextauth-secret',
+    }
+    delete process.env.GUEST_JWT_SECRET
+    delete process.env.GUEST_JWT_EXPIRES_IN
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('creates guest ids with the expected prefix', () => {
+    expect(createGuestId()).toMatch(/^guest-[0-9a-f-]+$/i)
+  })
+
+  it('creates and verifies guest tokens using NEXTAUTH_SECRET fallback', () => {
+    const token = createGuestToken('guest-123', 'Alice')
+    const claims = verifyGuestToken(token)
+
+    expect(claims).toMatchObject({
+      guestId: 'guest-123',
+      guestName: 'Alice',
+    })
+    expect(typeof claims?.expiresAt).toBe('number')
+  })
+
+  it('prefers GUEST_JWT_SECRET when configured', () => {
+    process.env.GUEST_JWT_SECRET = 'guest-secret-only'
+
+    const token = createGuestToken('guest-456', 'Bob')
+    const claims = verifyGuestToken(token)
+
+    expect(claims).toMatchObject({
+      guestId: 'guest-456',
+      guestName: 'Bob',
+    })
+  })
+
+  it('returns null for expired guest tokens', async () => {
+    process.env.GUEST_JWT_EXPIRES_IN = '1ms'
+    const token = createGuestToken('guest-expired', 'Late Guest')
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(verifyGuestToken(token)).toBeNull()
+  })
+
+  it('returns null for tampered tokens', () => {
+    const token = createGuestToken('guest-789', 'Mallory')
+    const tampered = `${token.slice(0, -1)}x`
+
+    expect(verifyGuestToken(tampered)).toBeNull()
+  })
+
+  it('returns null for non-guest tokens', () => {
+    const token = jwt.sign(
+      { type: 'user', guestName: 'Charlie' },
+      process.env.NEXTAUTH_SECRET as string,
+      { issuer: 'boardly-guest', subject: 'guest-user' }
+    )
+
+    expect(verifyGuestToken(token)).toBeNull()
+  })
+
+  it('throws when no guest JWT secret is configured', () => {
+    delete process.env.NEXTAUTH_SECRET
+    delete process.env.GUEST_JWT_SECRET
+
+    expect(() => createGuestToken('guest-1', 'No Secret')).toThrow('Missing guest JWT secret')
+  })
+
+  it('extracts guest token from X-Guest-Token before Authorization', () => {
+    const request = new Request('http://localhost:3000', {
+      headers: {
+        'X-Guest-Token': 'header-token',
+        Authorization: 'Bearer bearer-token',
+      },
+    })
+
+    expect(getGuestTokenFromRequest(request)).toBe('header-token')
+  })
+
+  it('extracts guest token from Authorization bearer header when needed', () => {
+    const request = new Request('http://localhost:3000', {
+      headers: {
+        Authorization: 'Bearer bearer-token',
+      },
+    })
+
+    expect(getGuestTokenFromRequest(request)).toBe('bearer-token')
+  })
+
+  it('returns verified claims from a request', () => {
+    const token = createGuestToken('guest-claims', 'Claims User')
+    const request = new Request('http://localhost:3000', {
+      headers: {
+        'X-Guest-Token': token,
+      },
+    })
+
+    expect(getGuestClaimsFromRequest(request)).toMatchObject({
+      guestId: 'guest-claims',
+      guestName: 'Claims User',
+    })
+  })
+})

--- a/__tests__/socket/disconnect-sync.test.ts
+++ b/__tests__/socket/disconnect-sync.test.ts
@@ -62,6 +62,92 @@ describe('createDisconnectSyncManager', () => {
     expect(deps.prisma.games.updateMany).not.toHaveBeenCalled()
   })
 
+  it('updates persisted connection state and advances the turn past a disconnected current player', async () => {
+    const updatedAt = new Date('2026-03-09T12:00:00.000Z')
+    const prisma = {
+      games: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'game-active-1',
+          state: {
+            players: [
+              { id: user.id, isActive: true },
+              { id: 'user-2', isActive: true },
+            ],
+            currentPlayerIndex: 0,
+            data: {
+              held: [true, true, false],
+              rollsLeft: 1,
+            },
+          },
+          currentTurn: 0,
+          updatedAt,
+          players: [
+            {
+              userId: user.id,
+              position: 0,
+              user: { username: 'Alice', email: 'alice@example.com', bot: null },
+            },
+            {
+              userId: 'user-2',
+              position: 1,
+              user: { username: 'Bob', email: 'bob@example.com', bot: null },
+            },
+          ],
+        }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      players: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      lobbies: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    }
+
+    const deps = createDeps({
+      prisma: prisma as unknown as DisconnectSyncOptions['prisma'],
+    })
+    const manager = createDisconnectSyncManager(deps)
+
+    const result = await manager.syncPlayerConnectionStateInLobby('ABCD', user.id, false, {
+      advanceTurnIfCurrent: true,
+    })
+
+    expect(result.updated).toBe(true)
+    expect(result.turnAdvanced).toBe(true)
+    expect(result.skippedPlayerIds).toEqual([user.id])
+    expect(result.updatedState?.currentPlayerIndex).toBe(1)
+    expect(result.updatedState?.players?.[0]).toMatchObject({
+      id: user.id,
+      isActive: false,
+    })
+    expect(result.updatedState?.data).toMatchObject({
+      held: [false, false, false],
+      rollsLeft: 3,
+    })
+    expect(prisma.games.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: 'game-active-1',
+        currentTurn: 0,
+        updatedAt,
+      },
+      data: expect.objectContaining({
+        currentTurn: 1,
+        lastMoveAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        state: expect.objectContaining({
+          currentPlayerIndex: 1,
+          players: expect.arrayContaining([
+            expect.objectContaining({
+              id: user.id,
+              isActive: false,
+            }),
+          ]),
+        }),
+      }),
+    })
+  })
+
   it('cancels scheduled abrupt disconnect cleanup when cleared manually', async () => {
     jest.useFakeTimers()
     const deps = createDeps()
@@ -202,5 +288,102 @@ describe('createDisconnectSyncManager', () => {
     })
     expect(deps.emitWithMetadata).not.toHaveBeenCalled()
     expect(prisma.lobbies.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('removes the last human from a waiting lobby and deactivates the lobby when only bots remain', async () => {
+    jest.useFakeTimers()
+    const prisma = {
+      games: {
+        findFirst: jest.fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            id: 'waiting-game-1',
+            players: [
+              {
+                id: 'player-human',
+                userId: user.id,
+                user: {
+                  username: 'Alice',
+                  email: 'alice@example.com',
+                  bot: null,
+                },
+              },
+              {
+                id: 'player-bot',
+                userId: 'bot-1',
+                user: {
+                  username: 'Bot',
+                  email: null,
+                  bot: { difficulty: 'medium' },
+                },
+              },
+            ],
+          }),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      players: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      lobbies: {
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+    }
+
+    const io = {
+      to: jest.fn().mockReturnValue({
+        emit: jest.fn(),
+      }),
+    }
+    const emitWithMetadata = jest.fn()
+    const deps = createDeps({
+      disconnectGraceMs: 10,
+      io: io as DisconnectSyncOptions['io'],
+      prisma: prisma as unknown as DisconnectSyncOptions['prisma'],
+      emitWithMetadata,
+    })
+    const manager = createDisconnectSyncManager(deps)
+
+    manager.scheduleAbruptDisconnectForLobby('ABCD', user)
+
+    await jest.advanceTimersByTimeAsync(20)
+
+    expect(prisma.players.deleteMany).toHaveBeenCalledWith({
+      where: {
+        gameId: 'waiting-game-1',
+        userId: user.id,
+        game: {
+          status: 'waiting',
+        },
+      },
+    })
+    expect(prisma.lobbies.updateMany).toHaveBeenCalledWith({
+      where: {
+        code: 'ABCD',
+        isActive: true,
+      },
+      data: {
+        isActive: false,
+      },
+    })
+    expect(emitWithMetadata).toHaveBeenCalledWith(
+      'lobby:ABCD',
+      'player-left',
+      expect.objectContaining({
+        userId: user.id,
+        reason: 'disconnect',
+      })
+    )
+    expect(emitWithMetadata).toHaveBeenCalledWith(
+      'lobby:ABCD',
+      'lobby-update',
+      expect.objectContaining({
+        lobbyCode: 'ABCD',
+        data: expect.objectContaining({
+          disconnected: true,
+          gameId: 'waiting-game-1',
+        }),
+      })
+    )
+    expect(io.to).toHaveBeenCalledWith('lobby-list')
   })
 })

--- a/__tests__/socket/socket-rate-limit.test.ts
+++ b/__tests__/socket/socket-rate-limit.test.ts
@@ -1,0 +1,57 @@
+import { createSocketRateLimiter } from '@/lib/socket/socket-rate-limit'
+
+describe('socket-rate-limit', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('allows events up to the configured per-second limit and then blocks', () => {
+    const limiter = createSocketRateLimiter({ maxEventsPerSecond: 2 })
+
+    expect(limiter.checkRateLimit('socket-1')).toBe(true)
+    expect(limiter.checkRateLimit('socket-1')).toBe(true)
+    expect(limiter.checkRateLimit('socket-1')).toBe(false)
+  })
+
+  it('resets the rate window after one second', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-03-09T12:00:00.000Z'))
+
+    const limiter = createSocketRateLimiter({ maxEventsPerSecond: 1 })
+
+    expect(limiter.checkRateLimit('socket-2')).toBe(true)
+    expect(limiter.checkRateLimit('socket-2')).toBe(false)
+
+    jest.setSystemTime(new Date('2026-03-09T12:00:01.100Z'))
+
+    expect(limiter.checkRateLimit('socket-2')).toBe(true)
+  })
+
+  it('clears a socket entry explicitly', () => {
+    const limiter = createSocketRateLimiter({ maxEventsPerSecond: 1 })
+
+    expect(limiter.checkRateLimit('socket-3')).toBe(true)
+    expect(limiter.checkRateLimit('socket-3')).toBe(false)
+
+    limiter.clearSocket('socket-3')
+
+    expect(limiter.checkRateLimit('socket-3')).toBe(true)
+  })
+
+  it('cleans up stale socket entries', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-03-09T12:00:00.000Z'))
+
+    const limiter = createSocketRateLimiter({ staleThresholdMs: 5000 })
+
+    expect(limiter.checkRateLimit('socket-a')).toBe(true)
+    expect(limiter.checkRateLimit('socket-b')).toBe(true)
+
+    jest.setSystemTime(new Date('2026-03-09T12:00:07.000Z'))
+
+    expect(limiter.cleanupStaleLimits()).toEqual({
+      cleaned: 2,
+      remaining: 0,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add focused coverage for guest auth token helpers and socket rate limiting
- cover auth route happy/error paths for login, register, forgot-password, and reset-password
- add admin authorization coverage and deeper disconnect-sync regression tests

## Verification
- npm run typecheck
- npm test -- --runInBand __tests__/lib/guest-auth.test.ts __tests__/socket/socket-rate-limit.test.ts __tests__/api/auth-login.test.ts __tests__/api/auth-register.test.ts __tests__/api/auth-forgot-password.test.ts __tests__/api/auth-reset-password.test.ts __tests__/api/admin-overview.test.ts __tests__/socket/disconnect-sync.test.ts
- npm run ci:quick
- npm run hooks:pre-push

Closes #172