### PR TITLE
docs: add dependency upgrade plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ npm run db:rls:smoke
 - Contribution workflow: `docs/CONTRIBUTING.md`
 - Security model details: `docs/SECURITY_MODEL.md`
 - Realtime telemetry baseline: `docs/REALTIME_TELEMETRY.md`
+- Dependency maintenance plan: `docs/DEPENDENCY_UPGRADE_PLAN.md`
 - Bot developer guide: `lib/bots/README.md`
 - Migrations and RLS notes: `prisma/migrations/README.md`
 - AI agent instructions: `.github/copilot-instructions.md`

--- a/docs/DEPENDENCY_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_UPGRADE_PLAN.md
@@ -1,0 +1,174 @@
+# Dependency Upgrade Plan
+
+Last verified: 2026-03-09
+
+This document is the canonical dependency maintenance plan for Boardly. It separates low-risk patch waves from major framework and ORM migrations that need dedicated branches and manual smoke coverage.
+
+Version checks in this document were verified against:
+
+- current installed versions in this repository
+- `npm view <package> version`
+- `npm audit`
+- official upgrade guides from Prisma, Next.js, React, Tailwind CSS, and ESLint
+
+## Current snapshot
+
+| Package group | Current | Latest verified | Track | Notes |
+| --- | --- | --- | --- | --- |
+| `@prisma/client` + `prisma` | `5.22.0` | `7.4.2` | major | Blocked by Prisma 7 migration work in [`lib/db.ts`](../lib/db.ts) and CLI config changes |
+| `next` | `15.5.12` | `16.1.6` | major | Deferred; must be upgraded together with React |
+| `react` + `react-dom` | `18.3.1` | `19.2.4` | major | Deferred with Next 16 |
+| `socket.io` + `socket.io-client` | `4.8.1` | `4.8.3` | patch | Upgrade both together |
+| `@sentry/nextjs` | `10.27.0` | `10.42.0` | minor | Low-risk observability bump |
+| `react-i18next` | `16.3.5` | `16.5.6` | minor | Low-risk |
+| `i18next` | `25.6.3` | `25.8.15` | minor | Low-risk |
+| `resend` | `6.1.3` | `6.9.3` | minor | Low-risk |
+| `dotenv` | `17.2.3` | `17.3.1` | patch | Low-risk |
+| `tailwindcss` | `3.4.14` | `4.2.1` | major | Separate migration; config and CSS pipeline change |
+| `zod` | `3.23.8` | `4.3.6` | major | Wide validation surface across auth, env, and lobby APIs |
+| `eslint` | `8.57.1` | `10.0.3` | major | Repo still uses legacy `.eslintrc.json` |
+| `lefthook` | `1.13.6` | `2.1.3` | major | Separate hook config migration |
+
+## Audit status
+
+`npm audit` on 2026-03-09 is not clean.
+
+Current findings are in local development and MCP tooling, not in the shipped Next.js or Socket.IO runtime:
+
+- `@modelcontextprotocol/server-filesystem` pulls `@modelcontextprotocol/sdk@1.26.0`, `express-rate-limit@8.2.1`, `hono@4.11.7`, and `@hono/node-server@1.19.9`
+- `@modelcontextprotocol/server-github` and `@modelcontextprotocol/server-postgres` still resolve `@modelcontextprotocol/sdk@1.0.1`
+- `markdownlint-cli@0.47.0` resolves a vulnerable `minimatch`
+
+This means the dependency plan now has two separate goals:
+
+1. keep application runtime dependencies current
+2. clear local tooling audit findings without destabilizing the app stack
+
+## Repo-specific blockers
+
+### Prisma 7
+
+- [`lib/db.ts`](../lib/db.ts) still uses `prisma.$use(...)` middleware for retry and timeout handling. Prisma 6 deprecated middleware in favor of Client extensions and query extensions, and Prisma 7 removes more legacy paths.
+- Package scripts still hardcode `--schema prisma/schema.prisma`. Prisma 7 uses `prisma.config.ts` as the CLI configuration entry point.
+- Prisma 7 requires an explicit generator `output` path instead of relying on the old default location.
+- CI already runs Node 20, but [`docs/LOCAL_SETUP.md`](./LOCAL_SETUP.md) and [`docs/OPERATIONS.md`](./OPERATIONS.md) still state `Node.js 18+`. Those docs must be updated when the Prisma/Next upgrade actually lands.
+
+### Next 16 + React 19
+
+- [`next.config.js`](../next.config.js) contains a custom `webpack` hook. Next 16 uses Turbopack by default for `next build`, and the official upgrade guide says builds fail when a custom webpack config is still present unless the project explicitly stays on `--webpack` or migrates the config.
+- The repo still uses [`middleware.ts`](../middleware.ts). Next 16 deprecates the `middleware` convention in favor of `proxy`, and the codemod will try to rename it.
+- The async request API migration is mostly in good shape already:
+  - `params` and `searchParams` are already typed as `Promise<...>` in many App Router files
+  - `cookies()` usage in [`lib/next-auth.ts`](../lib/next-auth.ts) is already awaited
+- There are no App Router parallel route slots (`app/@...`) in the current tree, so the new `default.js` requirement is not a blocker here.
+
+### Tailwind 4
+
+- The repo currently uses [`tailwind.config.ts`](../tailwind.config.ts), [`postcss.config.js`](../postcss.config.js), and `@tailwind base/components/utilities` in [`app/globals.css`](../app/globals.css).
+- Tailwind 4 changes the configuration and PostCSS integration model, so this should stay isolated from the Next 16 migration.
+
+### Zod 4
+
+- `zod` is used in auth, env validation, lobby routes, and multiple game validators.
+- The repo also relies on `ZodError` formatting and helper mapping in [`lib/validation/auth.ts`](../lib/validation/auth.ts) and [`lib/error-handler.ts`](../lib/error-handler.ts).
+- Recommended path: move to the latest `3.25.x` first, then evaluate `4.x` in a separate PR.
+
+### ESLint 10 and Lefthook 2
+
+- The repo still uses legacy ESLint config in [`.eslintrc.json`](../.eslintrc.json).
+- Next 16 docs now point projects toward flat config, and ESLint 10 drops more legacy assumptions.
+- Lefthook 2 should be treated as a separate hook-config migration, not bundled into app-runtime changes.
+
+## Recommended execution order
+
+### Wave 0: development tooling audit cleanup
+
+Scope:
+
+- update MCP server packages that still pull old `@modelcontextprotocol/sdk`
+- update `markdownlint-cli`
+- re-run `npm audit`
+
+Reason:
+
+- this clears current local tooling advisories without touching app runtime behavior
+
+### Wave 1: low-risk runtime patch and minor upgrades
+
+Scope:
+
+- `socket.io` + `socket.io-client` `4.8.1 -> 4.8.3`
+- `@sentry/nextjs` `10.27.0 -> 10.42.0`
+- `react-i18next` `16.3.5 -> 16.5.6`
+- `i18next` `25.6.3 -> 25.8.15`
+- `resend` `6.1.3 -> 6.9.3`
+- `dotenv` `17.2.3 -> 17.3.1`
+
+Reason:
+
+- these are the safest updates and should happen before any major migration
+
+### Wave 2: Prisma 5 -> 7 preparation and upgrade
+
+Scope:
+
+- replace `prisma.$use(...)` middleware in [`lib/db.ts`](../lib/db.ts) with Prisma Client extensions / query extensions
+- add `prisma.config.ts`
+- add explicit client generator `output`
+- upgrade `prisma` and `@prisma/client`
+- update local docs from Node 18+ to the actual required minimum once the upgrade is confirmed
+
+Reason:
+
+- Prisma touches the entire persistence layer and must be isolated from framework upgrades
+
+### Wave 3: Next 16 + React 19
+
+Scope:
+
+- run the official Next 16 codemod
+- decide whether to keep `next build --webpack` temporarily or migrate the custom webpack logic in [`next.config.js`](../next.config.js)
+- evaluate `middleware.ts -> proxy.ts` migration carefully instead of blindly renaming it
+- upgrade `next`, `react`, `react-dom`, `@types/react`, and `@types/react-dom`
+
+Reason:
+
+- Next 16 and React 19 should move together; the official guide treats them as one upgrade step
+
+### Wave 4: isolated major migrations
+
+Scope:
+
+- `tailwindcss` 3 -> 4
+- `zod` 3 -> 4
+- `eslint` 8 -> 10
+- `lefthook` 1 -> 2
+
+Reason:
+
+- each of these changes a different part of the toolchain and should not be bundled into the ORM or framework waves
+
+## Verification gate for every wave
+
+Run the smallest gate that still matches the risk level. For Prisma and Next waves, do the full gate.
+
+- `npm install`
+- `npm audit`
+- `npm run ci:quick`
+- `npm test`
+- `npm run ready:build-test`
+- manual smoke: register, login, guest join, create lobby, start game, reconnect once, finish game
+
+For the Next 16 wave, add:
+
+- `npm run dev:all`
+- browser smoke of key routes in a real browser
+- focused check of admin pages, auth pages, and lobby/game flow
+
+## Official references
+
+- Prisma ORM 7 upgrade guide: <https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-7>
+- Next.js 16 upgrade guide: <https://nextjs.org/docs/app/guides/upgrading/version-16>
+- React 19 release post: <https://react.dev/blog/2024/12/05/react-19>
+- Tailwind CSS v4 upgrade guide: <https://tailwindcss.com/docs/upgrade-guide>
+- ESLint migration guide: <https://eslint.org/docs/latest/use/configure/migration-guide>

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This folder contains the canonical project documentation.
 - `docs/CONTRIBUTING.md` - workflow and engineering standards
 - `docs/SECURITY_MODEL.md` - auth boundaries, RLS posture, secrets policy
 - `docs/REALTIME_TELEMETRY.md` - reconnect telemetry events, dashboards, SLOs, alerts
+- `docs/DEPENDENCY_UPGRADE_PLAN.md` - staged dependency maintenance plan and migration sequencing
 
 ## Specialized docs
 


### PR DESCRIPTION
## Summary
- add a canonical dependency upgrade plan with verified versions, repo-specific blockers, and staged execution waves
- document the current `npm audit` findings and separate runtime upgrades from local MCP/dev-tooling cleanup
- create follow-up execution issues #196, #197, #198, and #199

## Verification
- npm audit --audit-level=low
- npm run ci:quick
- npm run hooks:pre-push

Closes #173