### PR TITLE
chore: clean MCP audit findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,8 +84,10 @@ REPLAY_RETENTION_DAYS=90
 # Used by AI tooling (VSCode Copilot) for repository automation
 # GITHUB_TOKEN=ghp_your_github_personal_access_token_here
 
-# Database connection is shared from DATABASE_URL above
-# No additional config needed for PostgreSQL MCP server
+# Database connection is shared from DATABASE_URL above.
+# Optional only for hosted/TLS PostgreSQL when MCP scripts must enforce verify-full.
+# Not needed for a local PostgreSQL instance on localhost.
+# MCP_POSTGRES_CA_CERT_PATH=./certs/postgres-ca.pem
 
 # ------------------------------------------------------------
 # SOCKET.IO SERVER

--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ backup_*.sql
 *.sh
 !scripts/mcp-*.sh
 !scripts/codex-*.sh
+!scripts/export-postgres-mcp-ca.sh
 !scripts/test-mcp-postgres-driver.sh
 setup-*.*
 # .env-template.*

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -74,6 +74,7 @@ Recommended:
 - `GUEST_JWT_SECRET` (guest token signing isolation)
 - `CRON_SECRET` (required in production; recommended locally to test `/api/cron/*`)
 - `NEXT_PUBLIC_SOCKET_URL` (explicit socket endpoint in non-local envs)
+- `MCP_POSTGRES_CA_CERT_PATH` (optional for hosted/TLS PostgreSQL used by MCP scripts; not needed for local localhost PostgreSQL)
 - `BOT_UX_DELAY_MS` or `BOT_UX_DELAY_SCALE` + `BOT_UX_DELAY_MIN_MS` + `BOT_UX_DELAY_MAX_MS` (optional bot UX timing controls)
 - `ANALYTICS_ALLOWED_USER_IDS` / `ANALYTICS_ALLOWED_EMAILS` (restrict analytics endpoints)
 - `OPS_ALERT_WEBHOOK_URL` (alerts channel webhook)
@@ -155,6 +156,26 @@ Recommended verification after each phase:
 - one realtime gameplay flow (create/join/play/reconnect) if gameplay timestamps changed
 
 ## Common troubleshooting
+
+### MCP Postgres health check fails with `self-signed certificate in certificate chain`
+
+For hosted PostgreSQL with a custom CA chain, export the CA bundle once and write `MCP_POSTGRES_CA_CERT_PATH` into your env file:
+
+```bash
+bash scripts/export-postgres-mcp-ca.sh
+```
+
+Windows PowerShell equivalent:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/export-postgres-mcp-ca.ps1
+```
+
+Then rerun:
+
+```bash
+bash scripts/codex-mcp-health-check.sh
+```
 
 ### Render build hangs after Prisma datasource log
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "jest-environment-jsdom": "^30.2.0",
         "lefthook": "^1.13.6",
         "markdownlint": "^0.40.0",
-        "markdownlint-cli": "^0.47.0",
+        "markdownlint-cli": "^0.48.0",
         "node-fetch": "^2.7.0",
         "prisma": "^5.22.0",
         "supertest": "^7.1.4",
@@ -1575,9 +1575,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1601,6 +1601,30 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -2089,29 +2113,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2886,10 +2887,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+    "node_modules/@modelcontextprotocol/server-filesystem": {
+      "version": "2026.1.14",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-filesystem/-/server-filesystem-2026.1.14.tgz",
+      "integrity": "sha512-bGAfu3fWRVeF10NxvPhFBDlRen6ExSx6YkKJzoVgQMNrbdVVV4okfGGQ3KBRu9ygXYfw5/N9ermHAJXA0uys+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "diff": "^5.1.0",
+        "glob": "^10.5.0",
+        "minimatch": "^10.0.1",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "bin": {
+        "mcp-server-filesystem": "dist/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-filesystem/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2927,7 +2945,7 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+    "node_modules/@modelcontextprotocol/server-filesystem/node_modules/ajv-formats": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
@@ -2945,51 +2963,27 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+    "node_modules/@modelcontextprotocol/server-filesystem/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
-      }
-    },
-    "node_modules/@modelcontextprotocol/server-filesystem": {
-      "version": "2026.1.14",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-filesystem/-/server-filesystem-2026.1.14.tgz",
-      "integrity": "sha512-bGAfu3fWRVeF10NxvPhFBDlRen6ExSx6YkKJzoVgQMNrbdVVV4okfGGQ3KBRu9ygXYfw5/N9ermHAJXA0uys+g==",
+    "node_modules/@modelcontextprotocol/server-filesystem/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2",
-        "diff": "^5.1.0",
-        "glob": "^10.5.0",
-        "minimatch": "^10.0.1",
-        "zod-to-json-schema": "^3.23.5"
+        "balanced-match": "^4.0.2"
       },
-      "bin": {
-        "mcp-server-filesystem": "dist/index.js"
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@modelcontextprotocol/server-filesystem/node_modules/glob": {
@@ -3014,33 +3008,27 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@modelcontextprotocol/server-filesystem/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+    "node_modules/@modelcontextprotocol/server-filesystem/node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
+      "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@modelcontextprotocol/server-filesystem/node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3052,7 +3040,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3088,15 +3075,72 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-github/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.1.tgz",
-      "integrity": "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-github/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-github/node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@modelcontextprotocol/server-github/node_modules/node-fetch": {
@@ -3151,6 +3195,95 @@
         "mcp-server-memory": "dist/index.js"
       }
     },
+    "node_modules/@modelcontextprotocol/server-memory/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-memory/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-memory/node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-memory/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-memory/node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
     "node_modules/@modelcontextprotocol/server-postgres": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-postgres/-/server-postgres-0.6.2.tgz",
@@ -3167,15 +3300,92 @@
       }
     },
     "node_modules/@modelcontextprotocol/server-postgres/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.1.tgz",
-      "integrity": "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-postgres/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-postgres/node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-postgres/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-postgres/node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -7627,6 +7837,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concurrently": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
@@ -8867,6 +9084,17 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -8888,6 +9116,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
@@ -8930,12 +9171,36 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
@@ -8983,6 +9248,17 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -8994,6 +9270,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -9095,6 +9384,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -9135,6 +9435,19 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -9340,13 +9653,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -9992,6 +10305,30 @@
       "license": "BSD-2-Clause",
       "peer": true
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -10168,9 +10505,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10498,9 +10835,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12947,9 +13284,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13002,23 +13339,23 @@
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.47.0.tgz",
-      "integrity": "sha512-HOcxeKFAdDoldvoYDofd85vI8LgNWy8vmYpCwnlLV46PJcodmGzD7COSSBlhHwsfT4o9KrAStGodImVBus31Bg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+      "integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "~14.0.2",
+        "commander": "~14.0.3",
         "deep-extend": "~0.6.0",
         "ignore": "~7.0.5",
         "js-yaml": "~4.1.1",
         "jsonc-parser": "~3.3.1",
         "jsonpointer": "~5.0.1",
-        "markdown-it": "~14.1.0",
+        "markdown-it": "~14.1.1",
         "markdownlint": "~0.40.0",
-        "minimatch": "~10.1.1",
+        "minimatch": "~10.2.4",
         "run-con": "~1.3.2",
-        "smol-toml": "~1.5.2",
+        "smol-toml": "~1.6.0",
         "tinyglobby": "~0.2.15"
       },
       "bin": {
@@ -13026,6 +13363,29 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/markdownlint-cli/node_modules/commander": {
@@ -13049,16 +13409,16 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -16121,9 +16481,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -16931,6 +17291,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "lefthook": "^1.13.6",
     "markdownlint": "^0.40.0",
-    "markdownlint-cli": "^0.47.0",
+    "markdownlint-cli": "^0.48.0",
     "node-fetch": "^2.7.0",
     "prisma": "^5.22.0",
     "supertest": "^7.1.4",
@@ -121,7 +121,22 @@
   },
   "overrides": {
     "rollup": "^4.59.0",
-    "minimatch": "^9.0.7",
+    "@modelcontextprotocol/server-filesystem": {
+      "@modelcontextprotocol/sdk": "^1.27.1",
+      "minimatch": "^10.2.4"
+    },
+    "@modelcontextprotocol/server-github": {
+      "@modelcontextprotocol/sdk": "^1.27.1"
+    },
+    "@modelcontextprotocol/server-memory": {
+      "@modelcontextprotocol/sdk": "^1.27.1"
+    },
+    "@modelcontextprotocol/server-postgres": {
+      "@modelcontextprotocol/sdk": "^1.27.1"
+    },
+    "@hono/node-server": "^1.19.10",
+    "express-rate-limit": "^8.2.2",
+    "hono": "^4.12.4",
     "serialize-javascript": "^7.0.3",
     "schema-utils": {
       "ajv": "^8.18.0"

--- a/scripts/export-postgres-mcp-ca.sh
+++ b/scripts/export-postgres-mcp-ca.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_relative_path="${1:-.codex-local/certs/postgres-mcp-ca.pem}"
+env_file_name="${2:-.env}"
+
+workspace_dir="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "${workspace_dir}/scripts/mcp-common.sh"
+
+load_workspace_env "$workspace_dir"
+
+require_command "node" "Install Node.js and ensure it is available in your PATH."
+require_env_var "DATABASE_URL" "DATABASE_URL is not set in .env/.env.local."
+
+env_file_path="${workspace_dir}/${env_file_name}"
+if [[ ! -f "$env_file_path" ]]; then
+  echo "Env file not found: ${env_file_path}" >&2
+  exit 1
+fi
+
+node - "$workspace_dir" "$output_relative_path" "$env_file_name" <<'NODE'
+const fs = require('fs')
+const net = require('net')
+const path = require('path')
+const tls = require('tls')
+const { URL } = require('url')
+const { createHash } = require('crypto')
+
+const [workspaceDir, outputRelativePath, envFileName] = process.argv.slice(2)
+const databaseUrl = process.env.DATABASE_URL
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is not set in .env/.env.local.')
+}
+
+const endpoint = new URL(databaseUrl)
+const host = endpoint.hostname
+const port = endpoint.port ? Number.parseInt(endpoint.port, 10) : 5432
+
+function toPem(raw) {
+  const body = raw.toString('base64').match(/.{1,64}/g)?.join('\n') ?? ''
+  return `-----BEGIN CERTIFICATE-----\n${body}\n-----END CERTIFICATE-----`
+}
+
+function setOrAddEnvVar(filePath, name, value) {
+  const line = `${name}=${value}`
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(`^\\s*${escaped}\\s*=.*$`, 'm')
+  let content = fs.readFileSync(filePath, 'utf8')
+
+  if (pattern.test(content)) {
+    content = content.replace(pattern, line)
+  } else {
+    if (content.length > 0 && !content.endsWith('\n')) {
+      content += '\n'
+    }
+    content += `${line}\n`
+  }
+
+  fs.writeFileSync(filePath, content)
+}
+
+function collectChain(peerCertificate) {
+  const result = []
+  const seen = new Set()
+  let current = peerCertificate
+
+  while (current && current.raw) {
+    const fingerprint = current.fingerprint256 || createHash('sha256').update(current.raw).digest('hex')
+    if (seen.has(fingerprint)) {
+      break
+    }
+
+    seen.add(fingerprint)
+    result.push(current)
+
+    if (!current.issuerCertificate || current.issuerCertificate === current) {
+      break
+    }
+
+    current = current.issuerCertificate
+  }
+
+  return result
+}
+
+function connectRaw(hostname, portNumber) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: hostname, port: portNumber })
+
+    const onError = (error) => {
+      cleanup()
+      reject(error)
+    }
+
+    const onConnect = () => {
+      cleanup()
+      resolve(socket)
+    }
+
+    const cleanup = () => {
+      socket.off('error', onError)
+      socket.off('connect', onConnect)
+      socket.off('timeout', onTimeout)
+    }
+
+    const onTimeout = () => {
+      cleanup()
+      socket.destroy()
+      reject(new Error('Timed out while connecting to Postgres server.'))
+    }
+
+    socket.setTimeout(10_000)
+    socket.once('error', onError)
+    socket.once('connect', onConnect)
+    socket.once('timeout', onTimeout)
+  })
+}
+
+function readSingleByte(socket) {
+  return new Promise((resolve, reject) => {
+    const onData = (chunk) => {
+      cleanup()
+      resolve(chunk[0])
+    }
+
+    const onError = (error) => {
+      cleanup()
+      reject(error)
+    }
+
+    const onTimeout = () => {
+      cleanup()
+      reject(new Error('Timed out while waiting for Postgres SSL negotiation response.'))
+    }
+
+    const cleanup = () => {
+      socket.off('data', onData)
+      socket.off('error', onError)
+      socket.off('timeout', onTimeout)
+    }
+
+    socket.once('data', onData)
+    socket.once('error', onError)
+    socket.once('timeout', onTimeout)
+  })
+}
+
+function connectTls(socket, hostname) {
+  return new Promise((resolve, reject) => {
+    const tlsSocket = tls.connect({
+      socket,
+      rejectUnauthorized: false,
+      servername: hostname,
+    })
+
+    const onError = (error) => {
+      cleanup()
+      tlsSocket.destroy()
+      reject(error)
+    }
+
+    const onSecureConnect = () => {
+      cleanup()
+      resolve(tlsSocket)
+    }
+
+    const onTimeout = () => {
+      cleanup()
+      tlsSocket.destroy()
+      reject(new Error('Timed out while negotiating Postgres TLS session.'))
+    }
+
+    const cleanup = () => {
+      tlsSocket.off('error', onError)
+      tlsSocket.off('secureConnect', onSecureConnect)
+      tlsSocket.off('timeout', onTimeout)
+    }
+
+    tlsSocket.setTimeout(10_000)
+    tlsSocket.once('error', onError)
+    tlsSocket.once('secureConnect', onSecureConnect)
+    tlsSocket.once('timeout', onTimeout)
+  })
+}
+
+async function main() {
+  const socket = await connectRaw(host, port)
+
+  try {
+    // PostgreSQL SSLRequest: length=8, code=80877103
+    socket.write(Buffer.from([0, 0, 0, 8, 4, 210, 22, 47]))
+
+    const response = await readSingleByte(socket)
+    if (response !== 'S'.charCodeAt(0)) {
+      throw new Error(`Postgres server rejected SSL negotiation (response '${String.fromCharCode(response)}').`)
+    }
+
+    const tlsSocket = await connectTls(socket, host)
+    try {
+      const peerCertificate = tlsSocket.getPeerCertificate(true)
+      if (!peerCertificate || !peerCertificate.raw) {
+        throw new Error('Could not capture remote TLS certificate from Postgres connection.')
+      }
+
+      const chain = collectChain(peerCertificate)
+      const caCertificates = (chain.length > 1 ? chain.slice(1) : chain).map((certificate) => certificate.raw)
+
+      if (caCertificates.length === 0) {
+        throw new Error('No CA certificates found in captured TLS chain.')
+      }
+
+      const outputPath = path.isAbsolute(outputRelativePath)
+        ? outputRelativePath
+        : path.join(workspaceDir, outputRelativePath)
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+      fs.writeFileSync(outputPath, `${caCertificates.map(toPem).join('\n')}\n`)
+
+      const envFilePath = path.join(workspaceDir, envFileName)
+      const relativeForEnv = path.isAbsolute(outputRelativePath)
+        ? outputRelativePath
+        : outputRelativePath.replace(/\\/g, '/')
+      setOrAddEnvVar(envFilePath, 'MCP_POSTGRES_CA_CERT_PATH', relativeForEnv)
+
+      console.log('Exporting Postgres MCP CA bundle')
+      console.log(`Host: ${host}`)
+      console.log(`Port: ${port}`)
+      console.log('')
+      console.log('CA bundle exported:')
+      console.log(`  ${outputPath}`)
+      console.log(`Included CA certificates: ${caCertificates.length}`)
+      console.log('')
+      console.log('Updated env file:')
+      console.log(`  ${envFilePath}`)
+      console.log(`  MCP_POSTGRES_CA_CERT_PATH=${relativeForEnv}`)
+    } finally {
+      tlsSocket.end()
+      tlsSocket.destroy()
+    }
+  } finally {
+    socket.end()
+    socket.destroy()
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})
+NODE

--- a/scripts/test-mcp-postgres-driver.ps1
+++ b/scripts/test-mcp-postgres-driver.ps1
@@ -12,20 +12,10 @@ Import-WorkspaceEnv -WorkspaceDir $workspaceDir
 
 Assert-Command -CommandName "node" -InstallHint "Install Node.js and ensure it is available in your PATH."
 Require-EnvVar -Name "DATABASE_URL" -Message "DATABASE_URL is not set in .env/.env.local."
-Require-EnvVar -Name "MCP_POSTGRES_CA_CERT_PATH" -Message "MCP_POSTGRES_CA_CERT_PATH is not set in .env/.env.local."
 
 $dbUrl = [Environment]::GetEnvironmentVariable("DATABASE_URL", "Process")
 $caPath = [Environment]::GetEnvironmentVariable("MCP_POSTGRES_CA_CERT_PATH", "Process")
 
-if (-not [System.IO.Path]::IsPathRooted($caPath)) {
-  $caPath = Join-Path $workspaceDir $caPath
-}
-
-if (-not (Test-Path -LiteralPath $caPath)) {
-  throw "CA file not found: $caPath"
-}
-
-$caPath = (Resolve-Path -LiteralPath $caPath).Path
 $pgCandidates = @(
   (Join-Path $workspaceDir "node_modules\@modelcontextprotocol\server-postgres\node_modules\pg"),
   (Join-Path $workspaceDir "node_modules\pg")
@@ -36,30 +26,43 @@ if (-not $pgModulePath) {
   throw "Cannot find pg driver (checked: $($pgCandidates -join ', '))"
 }
 
-[Environment]::SetEnvironmentVariable("NODE_EXTRA_CA_CERTS", $caPath, "Process")
-[Environment]::SetEnvironmentVariable("PGSSLROOTCERT", $caPath, "Process")
+$dbUrlForSmoke = $dbUrl
+if (-not [string]::IsNullOrWhiteSpace($caPath)) {
+  if (-not [System.IO.Path]::IsPathRooted($caPath)) {
+    $caPath = Join-Path $workspaceDir $caPath
+  }
 
-$caPathForUrl = ($caPath -replace '\\', '/')
-$caPathEncoded = [System.Uri]::EscapeDataString($caPathForUrl)
-$dbUrlWithCa = $dbUrl
-if ($dbUrlWithCa -notmatch '([?&])sslrootcert=') {
-  $separator = if ($dbUrlWithCa.Contains("?")) { "&" } else { "?" }
-  $dbUrlWithCa = $dbUrlWithCa + $separator + "sslrootcert=" + $caPathEncoded
-}
-if ($dbUrlWithCa -match '([?&])sslmode=') {
-  $sslModeRegex = New-Object System.Text.RegularExpressions.Regex("(?i)([?&]sslmode=)[^&]*")
-  $dbUrlWithCa = $sslModeRegex.Replace($dbUrlWithCa, '$1verify-full', 1)
-}
-else {
-  $separator = if ($dbUrlWithCa.Contains("?")) { "&" } else { "?" }
-  $dbUrlWithCa = $dbUrlWithCa + $separator + "sslmode=verify-full"
+  if (-not (Test-Path -LiteralPath $caPath)) {
+    throw "CA file not found: $caPath"
+  }
+
+  $caPath = (Resolve-Path -LiteralPath $caPath).Path
+  [Environment]::SetEnvironmentVariable("NODE_EXTRA_CA_CERTS", $caPath, "Process")
+  [Environment]::SetEnvironmentVariable("PGSSLROOTCERT", $caPath, "Process")
+
+  $caPathForUrl = ($caPath -replace '\\', '/')
+  $caPathEncoded = [System.Uri]::EscapeDataString($caPathForUrl)
+  if ($dbUrlForSmoke -notmatch '([?&])sslrootcert=') {
+    $separator = if ($dbUrlForSmoke.Contains("?")) { "&" } else { "?" }
+    $dbUrlForSmoke = $dbUrlForSmoke + $separator + "sslrootcert=" + $caPathEncoded
+  }
+  if ($dbUrlForSmoke -match '([?&])sslmode=') {
+    $sslModeRegex = New-Object System.Text.RegularExpressions.Regex("(?i)([?&]sslmode=)[^&]*")
+    $dbUrlForSmoke = $sslModeRegex.Replace($dbUrlForSmoke, '$1verify-full', 1)
+  }
+  else {
+    $separator = if ($dbUrlForSmoke.Contains("?")) { "&" } else { "?" }
+    $dbUrlForSmoke = $dbUrlForSmoke + $separator + "sslmode=verify-full"
+  }
 }
 
-[Environment]::SetEnvironmentVariable("DATABASE_URL", $dbUrlWithCa, "Process")
+[Environment]::SetEnvironmentVariable("DATABASE_URL", $dbUrlForSmoke, "Process")
 
-$env:NODE_EXTRA_CA_CERTS = $caPath
-$env:PGSSLROOTCERT = $caPath
-$env:DATABASE_URL = $dbUrlWithCa
+if (-not [string]::IsNullOrWhiteSpace($caPath)) {
+  $env:NODE_EXTRA_CA_CERTS = $caPath
+  $env:PGSSLROOTCERT = $caPath
+}
+$env:DATABASE_URL = $dbUrlForSmoke
 $env:PG_MCP_SMOKE_SQL = $Sql
 $env:PG_MCP_SMOKE_PG_MODULE_PATH = $pgModulePath
 

--- a/scripts/test-mcp-postgres-driver.sh
+++ b/scripts/test-mcp-postgres-driver.sh
@@ -11,30 +11,9 @@ load_workspace_env "$workspace_dir"
 
 require_command "node" "Install Node.js and ensure it is available in your PATH."
 require_env_var "DATABASE_URL" "DATABASE_URL is not set in .env/.env.local."
-require_env_var "MCP_POSTGRES_CA_CERT_PATH" "MCP_POSTGRES_CA_CERT_PATH is not set in .env/.env.local."
 
 db_url="${DATABASE_URL}"
-ca_path="${MCP_POSTGRES_CA_CERT_PATH}"
-
-resolved_ca_path="$(node - "$ca_path" "$workspace_dir" <<'NODE'
-const fs = require('fs');
-const path = require('path');
-
-const [rawPath, workspaceDir] = process.argv.slice(2);
-let fullPath = rawPath;
-
-if (!path.isAbsolute(fullPath)) {
-  fullPath = path.join(workspaceDir, fullPath);
-}
-
-if (!fs.existsSync(fullPath)) {
-  console.error(`CA file not found: ${fullPath}`);
-  process.exit(1);
-}
-
-process.stdout.write(fs.realpathSync(fullPath));
-NODE
-)"
+ca_path="${MCP_POSTGRES_CA_CERT_PATH:-}"
 
 pg_module_path=""
 pg_candidates=(
@@ -54,10 +33,31 @@ if [[ -z "$pg_module_path" ]]; then
   exit 1
 fi
 
-export NODE_EXTRA_CA_CERTS="$resolved_ca_path"
-export PGSSLROOTCERT="$resolved_ca_path"
+if [[ -n "$ca_path" ]]; then
+  resolved_ca_path="$(node - "$ca_path" "$workspace_dir" <<'NODE'
+const fs = require('fs');
+const path = require('path');
 
-db_url_with_ca="$(node - "$db_url" "$resolved_ca_path" <<'NODE'
+const [rawPath, workspaceDir] = process.argv.slice(2);
+let fullPath = rawPath;
+
+if (!path.isAbsolute(fullPath)) {
+  fullPath = path.join(workspaceDir, fullPath);
+}
+
+if (!fs.existsSync(fullPath)) {
+  console.error(`CA file not found: ${fullPath}`);
+  process.exit(1);
+}
+
+process.stdout.write(fs.realpathSync(fullPath));
+NODE
+)"
+
+  export NODE_EXTRA_CA_CERTS="$resolved_ca_path"
+  export PGSSLROOTCERT="$resolved_ca_path"
+
+  db_url="$(node - "$db_url" "$resolved_ca_path" <<'NODE'
 const [rawUrl, resolvedCaPath] = process.argv.slice(2);
 const u = new URL(rawUrl);
 
@@ -69,8 +69,9 @@ u.searchParams.set('sslmode', 'verify-full');
 process.stdout.write(u.toString());
 NODE
 )"
+fi
 
-export DATABASE_URL="$db_url_with_ca"
+export DATABASE_URL="$db_url"
 export PG_MCP_SMOKE_SQL="$sql"
 export PG_MCP_SMOKE_PG_MODULE_PATH="$pg_module_path"
 


### PR DESCRIPTION
## Summary
- update MCP and markdown tooling dependency resolution so `npm audit` is clean again
- add a bash `export-postgres-mcp-ca` helper for macOS/Linux and align the Postgres smoke scripts with local/no-TLS setups
- document optional `MCP_POSTGRES_CA_CERT_PATH` usage for hosted TLS Postgres in MCP tooling

## Verification
- `npm audit --audit-level=low`
- `bash scripts/codex-mcp-health-check.sh`
- `npm run ci:quick`
- `npm run hooks:pre-push`

Closes #196