### PR TITLE
fix: speed up tic-tac-toe turn flow

### DIFF
--- a/__tests__/api/game-bot-turn-auth.test.ts
+++ b/__tests__/api/game-bot-turn-auth.test.ts
@@ -7,11 +7,15 @@ import { POST } from '@/app/api/game/[gameId]/bot-turn/route'
 import { prisma } from '@/lib/db'
 import { restoreGameEngine } from '@/lib/game-registry'
 import { getRequestAuthUser } from '@/lib/request-auth'
+import { executeBotTurn } from '@/lib/bots'
+import { notifySocket } from '@/lib/socket-url'
+import { appendGameReplaySnapshot } from '@/lib/game-replay'
 
 jest.mock('@/lib/db', () => ({
   prisma: {
     games: {
       findUnique: jest.fn(),
+      update: jest.fn(),
     },
     players: {
       update: jest.fn(),
@@ -60,6 +64,11 @@ jest.mock('@/lib/logger', () => ({
 
 const mockGetRequestAuthUser = getRequestAuthUser as jest.MockedFunction<typeof getRequestAuthUser>
 const mockRestoreGameEngine = restoreGameEngine as jest.MockedFunction<typeof restoreGameEngine>
+const mockExecuteBotTurn = executeBotTurn as jest.MockedFunction<typeof executeBotTurn>
+const mockNotifySocket = notifySocket as jest.MockedFunction<typeof notifySocket>
+const mockAppendGameReplaySnapshot = appendGameReplaySnapshot as jest.MockedFunction<
+  typeof appendGameReplaySnapshot
+>
 const originalSocketSecret = process.env.SOCKET_SERVER_INTERNAL_SECRET
 
 function buildRequest(body: unknown, headers: Record<string, string> = {}) {
@@ -77,6 +86,9 @@ describe('POST /api/game/[gameId]/bot-turn auth guard', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     process.env.SOCKET_SERVER_INTERNAL_SECRET = 'test-internal-secret'
+    ;(prisma.games.update as jest.Mock).mockResolvedValue({} as any)
+    mockNotifySocket.mockResolvedValue(true as any)
+    mockAppendGameReplaySnapshot.mockResolvedValue(undefined)
   })
 
   afterAll(() => {
@@ -194,5 +206,124 @@ describe('POST /api/game/[gameId]/bot-turn auth guard', () => {
     expect(payload.error).toBe('Internal server error')
     expect(payload.code).toBe('BOT_TURN_FAILED')
     expect(payload.details).toBeUndefined()
+  })
+
+  it('skips unchanged score writes and uses fast notify timeout for Tic-Tac-Toe bot turns', async () => {
+    mockGetRequestAuthUser.mockResolvedValue({
+      id: 'player-1',
+      username: 'Player 1',
+      suspended: false,
+      isGuest: false,
+    } as any)
+
+    const initialState = {
+      players: [
+        { id: 'player-1', score: 0 },
+        { id: 'bot-1', score: 0 },
+      ],
+      status: 'playing',
+      currentPlayerIndex: 1,
+      data: {
+        board: [
+          ['X', null, null],
+          [null, null, null],
+          [null, null, null],
+        ],
+        currentSymbol: 'O',
+      },
+    }
+    const updatedState = {
+      ...initialState,
+      currentPlayerIndex: 0,
+      lastMoveAt: Date.now(),
+      updatedAt: new Date().toISOString(),
+      data: {
+        ...initialState.data,
+        board: [
+          ['X', 'O', null],
+          [null, null, null],
+          [null, null, null],
+        ],
+        currentSymbol: 'X',
+      },
+    }
+
+    ;(prisma.games.findUnique as jest.Mock).mockResolvedValue({
+      id: 'game-123',
+      state: JSON.stringify(initialState),
+      status: 'playing',
+      currentTurn: 1,
+      players: [
+        {
+          id: 'db-player-1',
+          userId: 'player-1',
+          score: 0,
+          scorecard: '{}',
+          user: { id: 'player-1', bot: null },
+        },
+        {
+          id: 'db-player-bot',
+          userId: 'bot-1',
+          score: 0,
+          scorecard: '{}',
+          user: { id: 'bot-1', bot: { id: 'bot-meta-1' } },
+        },
+      ],
+      lobby: {
+        id: 'lobby-123',
+        code: 'ABCD12',
+        gameType: 'tic_tac_toe',
+      },
+    } as any)
+
+    mockRestoreGameEngine.mockReturnValue({
+      getState: jest
+        .fn()
+        .mockReturnValueOnce(initialState)
+        .mockReturnValueOnce(updatedState)
+        .mockReturnValue(updatedState),
+      getPlayers: jest.fn(() => [
+        { id: 'player-1', score: 0 },
+        { id: 'bot-1', score: 0 },
+      ]),
+      makeMove: jest.fn().mockReturnValue(true),
+    } as any)
+
+    mockExecuteBotTurn.mockImplementation(async (_gameType, _engine, _botUserId, _difficulty, onMove) => {
+      await onMove({
+        playerId: 'bot-1',
+        type: 'place',
+        data: { row: 0, col: 1 },
+        timestamp: new Date(),
+      } as any)
+    })
+
+    const response = await POST(
+      buildRequest({
+        botUserId: 'bot-1',
+        lobbyCode: 'ABCD12',
+      }),
+      { params: Promise.resolve({ gameId: 'game-123' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(prisma.games.update).toHaveBeenCalledTimes(1)
+    expect(prisma.players.update).not.toHaveBeenCalled()
+    expect(mockAppendGameReplaySnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gameId: 'game-123',
+        playerId: 'bot-1',
+        actionType: 'bot:place',
+      })
+    )
+    expect(mockNotifySocket).toHaveBeenCalledWith(
+      'lobby:ABCD12',
+      'game-update',
+      expect.objectContaining({
+        action: 'state-change',
+      }),
+      0,
+      250
+    )
   })
 })

--- a/__tests__/api/game-state.test.ts
+++ b/__tests__/api/game-state.test.ts
@@ -568,6 +568,15 @@ describe('POST /api/game/[gameId]/state', () => {
         triggeredAt: expect.any(Number),
       })
     )
+    expect(mockNotifySocket).toHaveBeenCalledWith(
+      'lobby:ABCD12',
+      'game-update',
+      expect.objectContaining({
+        action: 'state-change',
+      }),
+      0,
+      250
+    )
   })
 
   it('auto-triggers RPS bot turn when bot has not submitted choice', async () => {

--- a/app/api/game/[gameId]/bot-turn/route.ts
+++ b/app/api/game/[gameId]/bot-turn/route.ts
@@ -15,6 +15,14 @@ export const maxDuration = 60 // Allow up to 60 seconds for bot execution
 
 // In-memory lock to prevent concurrent bot turns for the same game
 const botTurnLocks = new Map<string, boolean>()
+const DEFAULT_BOT_STATE_NOTIFY_TIMEOUT_MS = 2000
+const FAST_BOT_STATE_NOTIFY_TIMEOUT_MS = 250
+
+function resolveBotStateNotifyTimeoutMs(gameType: string): number {
+  return gameType === 'tic_tac_toe'
+    ? FAST_BOT_STATE_NOTIFY_TIMEOUT_MS
+    : DEFAULT_BOT_STATE_NOTIFY_TIMEOUT_MS
+}
 
 export async function POST(
   request: NextRequest,
@@ -349,54 +357,83 @@ export async function POST(
               })
             }
 
-            await appendGameReplaySnapshot({
+            const getScorecard =
+              typeof (gameEngine as unknown as { getScorecard?: (playerId: string) => unknown }).getScorecard === 'function'
+                ? (gameEngine as unknown as { getScorecard: (playerId: string) => unknown }).getScorecard.bind(gameEngine)
+                : null
+            const dbPlayersByUserId = new Map(
+              game.players.map((player: any) => [player.userId, player])
+            )
+            const changedPlayerUpdates: Array<{ id: string; score: number; scorecard: string }> = []
+
+            for (const player of gameEngine.getPlayers()) {
+              const dbPlayer = dbPlayersByUserId.get(player.id)
+              if (!dbPlayer) continue
+
+              const nextScore = typeof player.score === 'number' ? player.score : 0
+              const nextScorecard = JSON.stringify(getScorecard ? getScorecard(player.id) : {})
+
+              if (dbPlayer.score === nextScore && dbPlayer.scorecard === nextScorecard) {
+                continue
+              }
+
+              changedPlayerUpdates.push({
+                id: dbPlayer.id,
+                score: nextScore,
+                scorecard: nextScorecard,
+              })
+            }
+
+            const replaySnapshotPromise = appendGameReplaySnapshot({
               gameId: game.id,
               playerId: botUserId,
               actionType: `bot:${botMove.type}`,
               actionPayload: botMove.data,
               state: newState,
+            }).catch((replayError) => {
+              log.warn('Failed to append replay snapshot after bot move', {
+                gameId,
+                botUserId,
+                moveType: botMove.type,
+                error: replayError,
+              })
             })
-          } catch (dbError) {
-            log.error('Critical: Failed to save game state after retry', dbError as Error)
-            throw new Error('Database connection failed. Please try again.')
-          }
 
-          // Update player scores - do this sequentially to avoid connection issues
-          // Vercel serverless + Supabase pooler can have timeout issues with parallel queries
-          for (const player of gameEngine.getPlayers()) {
-            const dbPlayer = game.players.find((p: any) => p.userId === player.id)
-            if (dbPlayer) {
+            for (const scoreUpdate of changedPlayerUpdates) {
               try {
                 await prisma.players.update({
-                  where: { id: dbPlayer.id },
+                  where: { id: scoreUpdate.id },
                   data: {
-                    score: player.score || 0,
-                    scorecard: JSON.stringify((gameEngine as any).getScorecard?.(player.id) ?? {}),
+                    score: scoreUpdate.score,
+                    scorecard: scoreUpdate.scorecard,
                   },
-                }).catch(async (retryError) => {
+                }).catch(async () => {
                   // Retry once on connection error
-                  log.warn('Player update failed, retrying...', { playerId: dbPlayer.id })
+                  log.warn('Player update failed, retrying...', { playerId: scoreUpdate.id })
                   await new Promise(resolve => setTimeout(resolve, 100))
                   return prisma.players.update({
-                    where: { id: dbPlayer.id },
+                    where: { id: scoreUpdate.id },
                     data: {
-                      score: player.score || 0,
-                      scorecard: JSON.stringify((gameEngine as any).getScorecard?.(player.id) ?? {}),
+                      score: scoreUpdate.score,
+                      scorecard: scoreUpdate.scorecard,
                     },
                   })
                 })
               } catch (playerUpdateError) {
                 log.error('Failed to update player score', playerUpdateError as Error, {
-                  playerId: dbPlayer.id,
-                  userId: player.id
+                  playerId: scoreUpdate.id,
                 })
                 // Continue with other players even if one fails
               }
             }
+            void replaySnapshotPromise
+          } catch (dbError) {
+            log.error('Critical: Failed to save game state after retry', dbError as Error)
+            throw new Error('Database connection failed. Please try again.')
           }
           log.info('Player scores updated')
 
-          // Broadcast state update after each move - fire-and-forget
+          const notifyTimeoutMs = resolveBotStateNotifyTimeoutMs(gameType)
           const currentState = gameEngine.getState()
           await notifySocket(
             `lobby:${resolvedLobbyCode}`,
@@ -404,7 +441,9 @@ export async function POST(
             {
               action: 'state-change',
               payload: currentState,
-            }
+            },
+            0,
+            notifyTimeoutMs
           )
         } catch (error) {
           log.error('Error processing bot move', error as Error, {

--- a/app/api/game/[gameId]/state/route.ts
+++ b/app/api/game/[gameId]/state/route.ts
@@ -26,6 +26,7 @@ const autoActionDebounceMap = new Map<string, number>()
 const AUTO_ACTION_DEBOUNCE_MS = 2000
 const AUTO_ACTION_DEBOUNCE_TTL_MS = 60000
 const STATE_CHANGE_NOTIFY_TIMEOUT_MS = 750
+const FAST_STATE_CHANGE_NOTIFY_TIMEOUT_MS = 250
 const BOT_TURN_TRIGGER_TIMEOUT_MS = 15000
 const limiter = rateLimit(rateLimitPresets.game)
 
@@ -93,6 +94,12 @@ function resolveTurnEndToBotTriggerMs(state: unknown, triggeredAt: number): numb
 
   const latencyMs = triggeredAt - lastMoveAt
   return Number.isFinite(latencyMs) && latencyMs >= 0 ? latencyMs : null
+}
+
+function resolveStateChangeNotifyTimeoutMs(gameType: string): number {
+  return gameType === 'tic_tac_toe'
+    ? FAST_STATE_CHANGE_NOTIFY_TIMEOUT_MS
+    : STATE_CHANGE_NOTIFY_TIMEOUT_MS
 }
 
 function autoTriggerBotTurn(params: {
@@ -599,7 +606,7 @@ export async function POST(
         payload: authoritativeState,
       },
       0,
-      STATE_CHANGE_NOTIFY_TIMEOUT_MS
+      resolveStateChangeNotifyTimeoutMs(game.lobby.gameType)
     )
     void replaySnapshotPromise
 

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from '@/lib/i18n-helpers'
 import { showToast } from '@/lib/i18n-toast'
 import { useGuest } from '@/contexts/GuestContext'
 import { fetchWithGuest } from '@/lib/fetch-with-guest'
-import { Game } from '@/types/game'
+import { AnyGameState, Game, GameUpdatePayload } from '@/types/game'
 import { normalizeLobbySnapshotResponse } from '@/lib/lobby-snapshot'
 import { finalizePendingLobbyCreateMetric } from '@/lib/lobby-create-metrics'
 import TicTacToeGameBoard from '@/components/TicTacToeGameBoard'
@@ -40,6 +40,29 @@ const LEAVE_REDIRECT_FALLBACK_MS = 1500
 const LIFECYCLE_REDIRECT_FALLBACK_MS = 1600
 type LeaveApiOutcome = 'pending' | 'ok' | 'non_ok' | 'timeout' | 'error'
 
+function extractAuthoritativeStateFromGameUpdate(payload: unknown): AnyGameState | null {
+    if (!payload || typeof payload !== 'object') {
+        return null
+    }
+
+    const updatePayload = payload as GameUpdatePayload
+    if (updatePayload.action !== 'state-change') {
+        return null
+    }
+
+    const rawPayload = updatePayload.payload
+    if (!rawPayload || typeof rawPayload !== 'object') {
+        return null
+    }
+
+    const nestedState = (rawPayload as Record<string, unknown>).state
+    if (nestedState && typeof nestedState === 'object') {
+        return nestedState as AnyGameState
+    }
+
+    return rawPayload as AnyGameState
+}
+
 export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
     const router = useRouter()
     const { data: session, status } = useSession()
@@ -56,6 +79,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
     const [isRematchSubmitting, setIsRematchSubmitting] = useState(false)
     const isLeavingLobbyRef = React.useRef(false)
     const lifecycleRedirectInFlightRef = React.useRef(false)
+    const activeGameIdRef = React.useRef<string | null>(null)
     const leaveStartedAtRef = React.useRef<number | null>(null)
     const leaveApiOutcomeRef = React.useRef<LeaveApiOutcome>('pending')
     const leaveApiStatusCodeRef = React.useRef<number | null>(null)
@@ -126,6 +150,39 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
     const getCurrentUserId = useCallback(() => {
         return isGuest ? guestId : session?.user?.id
     }, [isGuest, guestId, session?.user?.id])
+
+    const applyAuthoritativeState = useCallback(
+        (gameId: string, authoritativeState: unknown, statusOverride?: Game['status']): boolean => {
+            if (!authoritativeState || typeof authoritativeState !== 'object') {
+                return false
+            }
+
+            const authoritativeEngine = new TicTacToeGame(gameId)
+            authoritativeEngine.restoreState(authoritativeState as AnyGameState)
+            const resolvedState = authoritativeEngine.getState()
+
+            setGameEngine(authoritativeEngine)
+            setGame((prevGame) => {
+                if (!prevGame || prevGame.id !== gameId) {
+                    return prevGame
+                }
+
+                return {
+                    ...prevGame,
+                    status: (statusOverride ?? resolvedState.status) as Game['status'],
+                    currentTurn: resolvedState.currentPlayerIndex,
+                    state: JSON.stringify(authoritativeState),
+                }
+            })
+
+            return true
+        },
+        []
+    )
+
+    useEffect(() => {
+        activeGameIdRef.current = game?.id ?? null
+    }, [game?.id])
 
     // Load lobby data
     const loadLobby = useCallback(async () => {
@@ -272,19 +329,8 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
             }
 
             const authoritativeState = data?.game?.state
-            if (authoritativeState) {
-                const authoritativeEngine = new TicTacToeGame(game.id)
-                authoritativeEngine.restoreState(authoritativeState)
-                setGameEngine(authoritativeEngine)
-                setGame((prevGame) => {
-                    if (!prevGame) return prevGame
-                    return {
-                        ...prevGame,
-                        status: data?.game?.status ?? prevGame.status,
-                        currentTurn: authoritativeState.currentPlayerIndex,
-                        state: JSON.stringify(authoritativeState),
-                    }
-                })
+            if (authoritativeState && !applyAuthoritativeState(game.id, authoritativeState, data?.game?.status)) {
+                await loadLobby()
             }
 
             trackMoveSubmitApplied({
@@ -335,7 +381,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
         } finally {
             setIsMoveSubmitting(false)
         }
-    }, [gameEngine, game, socket, code, getCurrentUserId, loadLobby, isMoveSubmitting, isGuest])
+    }, [applyAuthoritativeState, gameEngine, game, socket, code, getCurrentUserId, loadLobby, isMoveSubmitting, isGuest])
 
     // Socket connection
     useEffect(() => {
@@ -381,8 +427,16 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
 
             newSocket.on('game-update', (payload: any) => {
                 clientLogger.log('📡 Game update received:', payload)
-                // Reload to get latest state from server
-                loadLobby()
+                const activeGameId = activeGameIdRef.current
+                const directState = extractAuthoritativeStateFromGameUpdate(payload)
+
+                if (directState && activeGameId) {
+                    applyAuthoritativeState(activeGameId, directState)
+                    return
+                }
+
+                // Fallback for non-state updates or before the local game is initialized.
+                void loadLobby()
             })
 
             newSocket.on('disconnect', () => {
@@ -403,7 +457,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
                 activeSocket?.close()
             }
         }
-    }, [status, isGuest, guestToken, code, loadLobby])
+    }, [applyAuthoritativeState, status, isGuest, guestToken, code, loadLobby])
 
     const isMyTurn = useCallback(() => {
         if (!gameEngine || !game) return false
@@ -530,20 +584,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
                 }
 
                 const authoritativeState = data?.game?.state
-                if (authoritativeState) {
-                    const authoritativeEngine = new TicTacToeGame(game.id)
-                    authoritativeEngine.restoreState(authoritativeState)
-                    setGameEngine(authoritativeEngine)
-                    setGame((prevGame) => {
-                        if (!prevGame) return prevGame
-                        return {
-                            ...prevGame,
-                            status: data?.game?.status ?? prevGame.status,
-                            currentTurn: authoritativeState.currentPlayerIndex,
-                            state: JSON.stringify(authoritativeState),
-                        }
-                    })
-                } else {
+                if (!authoritativeState || !applyAuthoritativeState(game.id, authoritativeState, data?.game?.status)) {
                     await loadLobby()
                 }
 
@@ -607,7 +648,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
         } finally {
             setIsRematchSubmitting(false)
         }
-    }, [code, game, gameEngine, getCurrentUserId, lobby, loadLobby, router, isGuest])
+    }, [applyAuthoritativeState, code, game, gameEngine, getCurrentUserId, lobby, loadLobby, router, isGuest])
 
     if (loading) {
         return (

--- a/lib/bots/tic-tac-toe/tic-tac-toe-bot-executor.ts
+++ b/lib/bots/tic-tac-toe/tic-tac-toe-bot-executor.ts
@@ -35,7 +35,8 @@ export class TicTacToeBotExecutor {
       message: `${botPlayer.name} is thinking...`,
     })
 
-    await this.delay(difficulty, 250)
+    // Keep Tic-Tac-Toe bot turns snappy because each move is a single action.
+    await this.delay(difficulty, 120)
 
     const decision = await bot.makeDecision()
     const move = bot.decisionToMove(decision)


### PR DESCRIPTION
## Summary
- apply Tic-Tac-Toe socket state-change payloads directly on the client instead of reloading the whole lobby on every move
- shorten Tic-Tac-Toe state-change notify timeouts and reduce the bot executor base delay
- skip unchanged player score writes during Tic-Tac-Toe bot turns and keep replay snapshot persistence off the critical path

## Testing
- `npm run typecheck`
- `npm test -- --runInBand __tests__/api/game-state.test.ts __tests__/api/game-bot-turn-auth.test.ts`
- `npx eslint 'app/api/game/[gameId]/state/route.ts' 'app/api/game/[gameId]/bot-turn/route.ts' 'app/lobby/[code]/tic-tac-toe-page.tsx' 'lib/bots/tic-tac-toe/tic-tac-toe-bot-executor.ts' '__tests__/api/game-state.test.ts' '__tests__/api/game-bot-turn-auth.test.ts'`
- `npm run ci:quick`

Closes #206