### PR TITLE
fix: reduce database pool pressure

### DIFF
--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -25,6 +25,10 @@ function parseFilter(raw: string | null): 'all' | 'unread' {
   return raw === 'unread' ? 'unread' : 'all'
 }
 
+function parseSummary(raw: string | null): boolean {
+  return raw === '1' || raw === 'true'
+}
+
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions)
   if (!session?.user?.id) {
@@ -35,36 +39,44 @@ export async function GET(request: NextRequest) {
   const limit = parseLimit(searchParams.get('limit'))
   const offset = parseOffset(searchParams.get('offset'))
   const filter = parseFilter(searchParams.get('filter'))
+  const summary = parseSummary(searchParams.get('summary'))
   const where = {
     userId: session.user.id,
     channel: 'in_app' as const,
     ...(filter === 'unread' ? { readAt: null } : {}),
   }
 
-  const [notifications, unreadCount] = await Promise.all([
-    prisma.notifications.findMany({
-      where,
-      orderBy: {
-        createdAt: 'desc',
-      },
-      skip: offset,
-      take: limit + 1,
-      select: {
-        id: true,
-        type: true,
-        createdAt: true,
-        readAt: true,
-        payload: true,
-      },
-    }),
-    prisma.notifications.count({
-      where: {
-        userId: session.user.id,
-        channel: 'in_app',
-        readAt: null,
-      },
-    }),
-  ])
+  const unreadCount = await prisma.notifications.count({
+    where: {
+      userId: session.user.id,
+      channel: 'in_app',
+      readAt: null,
+    },
+  })
+
+  if (summary) {
+    return NextResponse.json({
+      notifications: [],
+      unreadCount,
+      hasMore: false,
+    })
+  }
+
+  const notifications = await prisma.notifications.findMany({
+    where,
+    orderBy: {
+      createdAt: 'desc',
+    },
+    skip: offset,
+    take: limit + 1,
+    select: {
+      id: true,
+      type: true,
+      createdAt: true,
+      readAt: true,
+      payload: true,
+    },
+  })
 
   const hasMore = notifications.length > limit
 

--- a/app/api/user/games/route.ts
+++ b/app/api/user/games/route.ts
@@ -76,50 +76,48 @@ export async function GET(request: NextRequest) {
     }
 
     // Fetch games with player data
-    const [games, totalCount] = await Promise.all([
-      prisma.games.findMany({
-        where,
-        include: {
-          lobby: {
-            select: {
-              code: true,
-              name: true,
-            },
+    const games = await prisma.games.findMany({
+      where,
+      include: {
+        lobby: {
+          select: {
+            code: true,
+            name: true,
           },
-          _count: {
-            select: {
-              snapshots: true,
-            },
+        },
+        _count: {
+          select: {
+            snapshots: true,
           },
-          players: {
-            select: {
-              id: true,
-              userId: true,
-              score: true,
-              finalScore: true,
-              placement: true,
-              isWinner: true,
-              user: {
-                select: {
-                  id: true,
-                  username: true,
-                  bot: true,  // Bot relation
-                },
+        },
+        players: {
+          select: {
+            id: true,
+            userId: true,
+            score: true,
+            finalScore: true,
+            placement: true,
+            isWinner: true,
+            user: {
+              select: {
+                id: true,
+                username: true,
+                bot: true,  // Bot relation
               },
             },
-            orderBy: {
-              placement: 'asc',
-            },
+          },
+          orderBy: {
+            placement: 'asc',
           },
         },
-        orderBy: {
-          createdAt: 'desc',
-        },
-        take: limit,
-        skip: offset,
-      }),
-      prisma.games.count({ where }),
-    ])
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: limit,
+      skip: offset,
+    })
+    const totalCount = await prisma.games.count({ where })
 
     logger.info('User game history fetched successfully', {
       userId,

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1804,9 +1804,11 @@ export default function ProfilePage() {
                         />
                       </Label>
 
-                      <div className={`${settingsToggleCardClassName} cursor-default items-center text-center opacity-80`}>
-                        <div className="min-w-0">
-                          <div className="flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-200">
+                      <div
+                        className={`${settingsToggleCardClassName} cursor-default items-center justify-center text-center opacity-80`}
+                      >
+                        <div className="min-w-0 text-center">
+                          <div className="flex items-center justify-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-200">
                             <span>{t('profile.settings.notifications.push')}</span>
                             <span className="inline-flex rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-700 dark:text-slate-300">
                               {t('profile.comingSoon')}

--- a/components/Friends.tsx
+++ b/components/Friends.tsx
@@ -141,23 +141,28 @@ export default function Friends() {
   useEffect(() => {
     const loadData = async () => {
       setLoading(true)
-      await Promise.all([
-        loadFriends(), 
-        loadRequests(),
-        loadMyFriendCode()
-      ])
-      setLoading(false)
+      try {
+        await loadFriends()
+        await loadRequests()
+        await loadMyFriendCode()
+      } finally {
+        setLoading(false)
+      }
     }
-    loadData()
+    void loadData()
 
-    // Auto-refresh every 30 seconds to sync friends list
+    // Auto-refresh only the active view to avoid unnecessary DB fan-out.
     const refreshInterval = setInterval(() => {
-      loadFriends()
-      loadRequests()
-    }, 30000)
+      if (activeTab === 'friends') {
+        void loadFriends()
+        return
+      }
+
+      void loadRequests()
+    }, 60000)
 
     return () => clearInterval(refreshInterval)
-  }, [loadFriends, loadRequests, loadMyFriendCode])
+  }, [activeTab, loadFriends, loadRequests, loadMyFriendCode])
 
   const handleSendRequest = useCallback(async (e: React.FormEvent) => {
     e.preventDefault()

--- a/components/Header/NotificationsMenu.tsx
+++ b/components/Header/NotificationsMenu.tsx
@@ -10,22 +10,36 @@ import {
 } from '@/lib/notification-ui'
 
 export function NotificationsMenu() {
+  const NOTIFICATIONS_BACKGROUND_REFRESH_INTERVAL_MS = 60_000
   const router = useRouter()
   const pathname = usePathname()
   const { t, i18n } = useTranslation()
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const fetchInFlightRef = useRef(false)
+  const lastBackgroundRefreshAtRef = useRef(0)
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
   const [notifications, setNotifications] = useState<InAppNotificationItem[]>([])
   const [unreadCount, setUnreadCount] = useState(0)
 
-  const fetchNotifications = useCallback(async (silent = false) => {
-    if (!silent) {
+  const fetchNotifications = useCallback(async (options?: { silent?: boolean; summary?: boolean; force?: boolean }) => {
+    const silent = options?.silent ?? false
+    const summary = options?.summary ?? false
+    const force = options?.force ?? false
+
+    if (fetchInFlightRef.current && !force) {
+      return
+    }
+
+    fetchInFlightRef.current = true
+
+    if (!silent && !summary) {
       setLoading(true)
     }
 
     try {
-      const response = await fetch('/api/notifications?limit=20', {
+      const search = summary ? '?summary=1' : '?limit=20'
+      const response = await fetch(`/api/notifications${search}`, {
         cache: 'no-store',
       })
 
@@ -34,38 +48,53 @@ export function NotificationsMenu() {
       }
 
       const data = (await response.json()) as InAppNotificationResponse
-      setNotifications(data.notifications || [])
       setUnreadCount(data.unreadCount || 0)
+
+      if (!summary) {
+        setNotifications(data.notifications || [])
+      }
     } catch {
-      if (!silent) {
+      if (!silent && !summary) {
         setNotifications([])
         setUnreadCount(0)
       }
     } finally {
-      if (!silent) {
+      fetchInFlightRef.current = false
+      if (!silent && !summary) {
         setLoading(false)
       }
     }
   }, [])
 
+  const refreshUnreadCount = useCallback((force = false) => {
+    const now = Date.now()
+
+    if (!force && now - lastBackgroundRefreshAtRef.current < NOTIFICATIONS_BACKGROUND_REFRESH_INTERVAL_MS) {
+      return
+    }
+
+    lastBackgroundRefreshAtRef.current = now
+    void fetchNotifications({ silent: true, summary: true, force })
+  }, [fetchNotifications])
+
   useEffect(() => {
-    void fetchNotifications(true)
+    refreshUnreadCount(true)
 
     const intervalId = window.setInterval(() => {
-      void fetchNotifications(true)
-    }, 60_000)
+      refreshUnreadCount()
+    }, NOTIFICATIONS_BACKGROUND_REFRESH_INTERVAL_MS)
 
     return () => {
       window.clearInterval(intervalId)
     }
-  }, [fetchNotifications])
+  }, [refreshUnreadCount])
 
   useEffect(() => {
     if (!open) {
       return
     }
 
-    void fetchNotifications()
+    void fetchNotifications({ force: true })
   }, [fetchNotifications, open])
 
   useEffect(() => {
@@ -92,7 +121,7 @@ export function NotificationsMenu() {
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        void fetchNotifications(true)
+        refreshUnreadCount()
       }
     }
 
@@ -100,7 +129,7 @@ export function NotificationsMenu() {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  }, [fetchNotifications])
+  }, [refreshUnreadCount])
 
   const markNotificationsRead = useCallback(async (ids: string[]) => {
     if (ids.length === 0) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -10,7 +10,7 @@ import { dbMonitor } from './db-monitoring'
 loadDatabaseEnv()
 
 const DEFAULT_DB_RETRY_MAX_ATTEMPTS = process.env.NODE_ENV === 'production' ? 3 : 2
-const DEFAULT_DB_QUERY_TIMEOUT_MS = process.env.NODE_ENV === 'production' ? 8000 : 12000
+const DEFAULT_DB_QUERY_TIMEOUT_MS = process.env.NODE_ENV === 'production' ? 12000 : 12000
 const DB_RETRY_MAX_ATTEMPTS = parsePositiveInt(
   process.env.DB_RETRY_MAX_ATTEMPTS,
   DEFAULT_DB_RETRY_MAX_ATTEMPTS
@@ -19,7 +19,7 @@ const DB_QUERY_TIMEOUT_MS = parseNonNegativeInt(
   process.env.DB_QUERY_TIMEOUT_MS,
   DEFAULT_DB_QUERY_TIMEOUT_MS
 )
-const RETRYABLE_PRISMA_ERROR_CODES = new Set(['P1001', 'P1002', 'P1008', 'P1017', 'P2024'])
+const RETRYABLE_PRISMA_ERROR_CODES = new Set(['P1001', 'P1002', 'P1008', 'P1017'])
 
 function loadDatabaseEnv() {
   const envLocalPath = resolve(process.cwd(), '.env.local')


### PR DESCRIPTION
## Summary
- reduce background notification load by polling unread-count summaries and only fetching the full notification list when the menu opens
- lower friends page refresh pressure by serializing the initial friend data load and refreshing only the active tab
- reduce concurrent database load in user game history and stop retrying pool-exhaustion errors while slightly increasing the query timeout budget

## Validation
- `npm run ci:quick`
- `npm test -- --runTestsByPath __tests__/components/notifications-menu.test.tsx __tests__/app/profile-page.test.tsx`
- pre-push smoke: `__tests__/lib/socket-url.test.ts`, `__tests__/lib/guest-helpers.test.ts`, `__tests__/lib/game-registry.test.ts`, `__tests__/lib/lobby-player-requirements.test.ts`

## Notes
- rebased onto current `develop` before validation
- the Prisma generated client currently emits the same non-blocking ESLint warnings seen on other Prisma 7 branches