### PR TITLE
fix: reassign lobby host when creator leaves

### DIFF
--- a/__tests__/api/lobby-code.test.ts
+++ b/__tests__/api/lobby-code.test.ts
@@ -589,6 +589,136 @@ describe('POST /api/lobby/[code]/leave', () => {
     expect(mockNotifySocket).not.toHaveBeenCalled()
   })
 
+  it('reassigns waiting lobby creator when host leaves and human players remain', async () => {
+    const waitingLobbyWithReplacementHost = {
+      ...mockLobby,
+      creatorId: 'user-123',
+      games: [
+        {
+          id: 'game-123',
+          status: 'waiting',
+          players: [
+            {
+              id: 'player-host',
+              userId: 'user-123',
+              gameId: 'game-123',
+              position: 0,
+              createdAt: new Date('2026-03-16T12:00:00.000Z'),
+              user: {
+                id: 'user-123',
+                username: 'host-user',
+                email: 'host@example.com',
+                bot: null,
+              },
+            },
+            {
+              id: 'player-456',
+              userId: 'user-456',
+              gameId: 'game-123',
+              position: 1,
+              createdAt: new Date('2026-03-16T12:00:10.000Z'),
+              user: {
+                id: 'user-456',
+                username: 'second-user',
+                email: 'second@example.com',
+                bot: null,
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    mockGetServerSession.mockResolvedValue(mockSession as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-123',
+      username: 'host-user',
+      suspended: false,
+    } as any)
+    mockPrisma.lobbies.findUnique.mockResolvedValue(waitingLobbyWithReplacementHost as any)
+    mockPrisma.players.delete.mockResolvedValue({ id: 'player-host' } as any)
+    mockPrisma.players.count
+      .mockResolvedValueOnce(1) // remaining players
+      .mockResolvedValueOnce(1) // remaining human players
+    mockPrisma.players.findFirst.mockResolvedValue({
+      userId: 'user-456',
+      user: {
+        username: 'second-user',
+      },
+    } as any)
+    mockPrisma.lobbies.update.mockResolvedValue({
+      id: 'lobby-123',
+      creatorId: 'user-456',
+      isActive: true,
+    } as any)
+
+    const request = new NextRequest('http://localhost:3000/api/lobby/ABC123/leave', {
+      method: 'POST',
+    })
+    const response = await LEAVE(request, { params: { code: 'ABC123' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(
+      expect.objectContaining({
+        gameEnded: false,
+        lobbyDeactivated: false,
+      })
+    )
+    expect(mockPrisma.players.findFirst).toHaveBeenCalledWith({
+      where: {
+        gameId: 'game-123',
+        user: {
+          bot: null,
+        },
+      },
+      orderBy: [
+        { position: 'asc' },
+        { createdAt: 'asc' },
+        { id: 'asc' },
+      ],
+      select: {
+        userId: true,
+        user: {
+          select: {
+            username: true,
+          },
+        },
+      },
+    })
+    expect(mockPrisma.lobbies.update).toHaveBeenCalledWith({
+      where: { id: 'lobby-123' },
+      data: { creatorId: 'user-456' },
+    })
+    expect(mockNotifySocket).toHaveBeenNthCalledWith(
+      1,
+      'lobby:ABC123',
+      'player-left',
+      expect.objectContaining({
+        userId: 'user-123',
+        playerId: 'user-123',
+        nextCreatorId: 'user-456',
+        nextCreatorName: 'second-user',
+        remainingPlayers: 1,
+      }),
+      0
+    )
+    expect(mockNotifySocket).toHaveBeenNthCalledWith(
+      2,
+      'lobby:ABC123',
+      'lobby-update',
+      {
+        lobbyCode: 'ABC123',
+        type: 'player-left',
+        data: {
+          creatorId: 'user-456',
+          creatorName: 'second-user',
+        },
+      },
+      0
+    )
+  })
+
   it('should return success when player is already absent from lobby', async () => {
     const lobbyWithoutPlayer = {
       ...mockLobby,

--- a/app/api/lobby/[code]/leave/route.ts
+++ b/app/api/lobby/[code]/leave/route.ts
@@ -9,6 +9,11 @@ import { pickRelevantLobbyGame } from '@/lib/lobby-snapshot'
 const limiter = rateLimit(rateLimitPresets.api)
 const SOCKET_NOTIFY_DEBOUNCE_MS = 0
 
+type ReassignedCreator = {
+  userId: string
+  username: string
+}
+
 function emitLobbyEvent(
   log: ReturnType<typeof apiLogger>,
   code: string,
@@ -31,6 +36,54 @@ function emitLobbyEvent(
         error,
       })
     })
+}
+
+async function reassignLobbyCreatorIfNeeded(
+  log: ReturnType<typeof apiLogger>,
+  lobbyId: string,
+  gameId: string,
+  lobbyCode: string
+): Promise<ReassignedCreator | null> {
+  const nextCreator = await prisma.players.findFirst({
+    where: {
+      gameId,
+      user: {
+        bot: null,
+      },
+    },
+    orderBy: [
+      { position: 'asc' },
+      { createdAt: 'asc' },
+      { id: 'asc' },
+    ],
+    select: {
+      userId: true,
+      user: {
+        select: {
+          username: true,
+        },
+      },
+    },
+  })
+
+  if (!nextCreator) {
+    log.warn('Unable to find replacement lobby creator after leave', {
+      lobbyId,
+      lobbyCode,
+      gameId,
+    })
+    return null
+  }
+
+  await prisma.lobbies.update({
+    where: { id: lobbyId },
+    data: { creatorId: nextCreator.userId },
+  })
+
+  return {
+    userId: nextCreator.userId,
+    username: nextCreator.user.username || 'Player',
+  }
 }
 
 export async function POST(
@@ -131,6 +184,32 @@ export async function POST(
       }),
     ])
 
+    const creatorLeft = lobby.creatorId === userId
+    const lobbyCanStayActive =
+      activeGame.status === 'waiting'
+        ? remainingPlayers > 0 && remainingHumanPlayers > 0
+        : remainingPlayers > 1 && remainingHumanPlayers > 0
+
+    const reassignedCreator =
+      creatorLeft && lobbyCanStayActive
+        ? await reassignLobbyCreatorIfNeeded(log, lobby.id, activeGame.id, code)
+        : null
+
+    const departedPlayerName = player.user.username || player.user.email || 'Guest'
+    const playerLeftEventPayload = {
+      userId,
+      playerId: userId,
+      username: departedPlayerName,
+      playerName: departedPlayerName,
+      remainingPlayers,
+      ...(reassignedCreator
+        ? {
+            nextCreatorId: reassignedCreator.userId,
+            nextCreatorName: reassignedCreator.username,
+          }
+        : {}),
+    }
+
     // Different behavior based on game status
     if (activeGame.status === 'waiting') {
       // In waiting state, just remove player
@@ -147,6 +226,20 @@ export async function POST(
           lobbyDeactivated: true
         })
       }
+
+      emitLobbyEvent(log, code, 'player-left', playerLeftEventPayload)
+      emitLobbyEvent(log, code, 'lobby-update', {
+        lobbyCode: code,
+        type: 'player-left',
+        ...(reassignedCreator
+          ? {
+              data: {
+                creatorId: reassignedCreator.userId,
+                creatorName: reassignedCreator.username,
+              },
+            }
+          : {}),
+      })
 
       return NextResponse.json({
         message: 'You left the lobby',
@@ -210,11 +303,17 @@ export async function POST(
     }
 
     // If multiple players remain (human or bot), continue the game
-    emitLobbyEvent(log, code, 'player-left', {
-      playerId: userId,
-      playerName: player.user.username || player.user.email || 'Guest',
-      remainingPlayers,
-    })
+    emitLobbyEvent(log, code, 'player-left', playerLeftEventPayload)
+    if (reassignedCreator) {
+      emitLobbyEvent(log, code, 'lobby-update', {
+        lobbyCode: code,
+        type: 'player-left',
+        data: {
+          creatorId: reassignedCreator.userId,
+          creatorName: reassignedCreator.username,
+        },
+      })
+    }
 
     return NextResponse.json({
       message: 'You left the lobby',


### PR DESCRIPTION
## Summary
- reassign `lobby.creatorId` to the oldest remaining non-bot player when the current creator leaves an active lobby
- broadcast waiting-lobby leave events so remaining clients refresh host state without a manual reload
- add a regression test for host reassignment on lobby leave

## Testing
- `npm test -- --runTestsByPath __tests__/api/lobby-code.test.ts`
- `npm run ci:quick`
- pre-push smoke suite

Closes #229