### PR TITLE
chore: auto-close linked issues on develop merge

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,7 @@ State flow:
 - **Auth and guest identity**: use `NEXTAUTH_SECRET` as primary signing secret. `JWT_SECRET` is deprecated; do not introduce new logic based on it. Guest identity must use signed tokens (`X-Guest-Token`), not raw client IDs/names.
 - **Realtime robustness**: protect timer/auto-action paths against duplicate processing, handle reconnect/out-of-order events defensively, and advance turn safely when the current player disconnects.
 - **Code quality**: keep TypeScript strictness and minimal readable changes. Keep comments in English and never put secrets in code or docs.
-- **Branching workflow**: for every ticket/feature/fix, create a dedicated branch from `develop` and open a PR back into `develop`. Do not commit task work directly to `develop` or `main`. After PR merge, delete the local task branch; remote source branches are auto-deleted by repository settings.
+- **Branching workflow**: for every ticket/feature/fix, create a dedicated branch from `develop` and open a PR back into `develop`. Every task commit should include the related ticket or issue number in the commit message so the implementation is easy to trace from the ticket later (for example `fix(#229): reassign lobby host on creator leave`). PRs merged into `develop` should also include `Closes #...`, `Fixes #...`, or `Resolves #...` in the PR body so issue-closing automation can close the linked ticket on merge. Do not commit task work directly to `develop` or `main`. After PR merge, delete the local task branch; remote source branches are auto-deleted by repository settings.
 
 ## High-priority areas when touching code
 

--- a/.github/workflows/close-issues-on-develop-merge.yml
+++ b/.github/workflows/close-issues-on-develop-merge.yml
@@ -1,0 +1,104 @@
+name: Close Issues On Develop Merge
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - develop
+
+concurrency:
+  group: close-issues-on-develop-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Close linked issues from PR body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const body = pr.body || ''
+
+            const closingKeywordPattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b/i
+            const issueReferencePattern =
+              /(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+))?#(?<number>\d+)/g
+
+            const issueNumbers = new Set()
+            for (const rawLine of body.split(/\r?\n/)) {
+              const line = rawLine.trim()
+              if (!line || !closingKeywordPattern.test(line)) {
+                continue
+              }
+
+              for (const match of line.matchAll(issueReferencePattern)) {
+                const referenceOwner = match.groups?.owner || owner
+                const referenceRepo = match.groups?.repo || repo
+                const issueNumber = Number.parseInt(match.groups?.number || '', 10)
+
+                if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+                  continue
+                }
+
+                if (referenceOwner === owner && referenceRepo === repo) {
+                  issueNumbers.add(issueNumber)
+                }
+              }
+            }
+
+            if (issueNumbers.size === 0) {
+              core.info('No same-repository closing keywords found in the merged PR body.')
+              return
+            }
+
+            for (const issue_number of issueNumbers) {
+              const { data: issue } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number,
+              })
+
+              if (issue.pull_request) {
+                core.info(`Skipping #${issue_number} because it is a pull request, not an issue.`)
+                continue
+              }
+
+              if (issue.state === 'closed') {
+                core.info(`Skipping #${issue_number} because it is already closed.`)
+                continue
+              }
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number,
+                state: 'closed',
+              })
+
+              const commentLines = [
+                `Closed automatically after PR #${pr.number} was merged into \`${pr.base.ref}\`.`,
+                '',
+                `PR: ${pr.html_url}`,
+              ]
+
+              if (pr.merge_commit_sha) {
+                commentLines.push(`Merge commit: ${pr.merge_commit_sha}`)
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: commentLines.join('\n'),
+              })
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ Core flow:
 ## Branch and PR Policy
 
 - For each ticket/feature/fix, create a dedicated branch from `develop` (for example `feature/<ticket>-<short-name>`, `fix/<ticket>-<short-name>`, `chore/<short-name>`).
+- Every task commit must reference its ticket or issue number in the commit message so the ticket timeline can be traced back to the implementation commit later (for example `fix(#229): reassign lobby host on creator leave` or `chore(#226): tighten mobile header layout`).
+- Pull requests merged into `develop` should include `Closes #...`, `Fixes #...`, or `Resolves #...` in the PR body so the linked issue can be auto-closed by automation when the PR is merged.
 - Open PRs from task branches into `develop`. Do not push task commits directly to `develop`.
 - Promote to production only through PRs from `develop` into `main`.
 - Treat direct pushes to `main` and `develop` as emergency-only exceptions.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that closes same-repo issues referenced by closing keywords when a PR is merged into `develop`
- document that task commits must reference their issue numbers and that PRs into `develop` should include `Closes #...`, `Fixes #...`, or `Resolves #...` in the PR body
- keep the existing `feature/fix -> develop -> main` workflow without changing the default branch

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "YAML OK"' .github/workflows/close-issues-on-develop-merge.yml`
- pre-push checks (`npm run db:generate`, `npm run check:locales`, `npm run ci:quick`, Jest smoke suite)

Closes #232