### PR TITLE
fix: restore lobby player sync before bot-start flow

### DIFF
--- a/__tests__/app/useLobbyActions.test.tsx
+++ b/__tests__/app/useLobbyActions.test.tsx
@@ -1,0 +1,310 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useLobbyActions } from '@/app/lobby/[code]/hooks/useLobbyActions'
+import { restoreGameEngineClient } from '@/lib/restore-game-engine-client'
+import { showToast } from '@/lib/i18n-toast'
+
+jest.mock('@/lib/restore-game-engine-client', () => ({
+  restoreGameEngineClient: jest.fn(),
+}))
+
+jest.mock('@/lib/socket-url', () => ({
+  getAuthHeaders: jest.fn(() => ({
+    'Content-Type': 'application/json',
+  })),
+}))
+
+jest.mock('@/lib/client-logger', () => ({
+  clientLogger: {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/analytics', () => ({
+  trackAuth: jest.fn(),
+  trackError: jest.fn(),
+  trackFunnelStep: jest.fn(),
+  trackLobbyJoined: jest.fn(),
+  trackGameStarted: jest.fn(),
+  trackStartAloneAutoBotResult: jest.fn(),
+}))
+
+jest.mock('@/lib/i18n-toast', () => ({
+  showToast: {
+    loading: jest.fn(),
+    dismiss: jest.fn(),
+    error: jest.fn(),
+    errorFrom: jest.fn(),
+    success: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/lobby-create-metrics', () => ({
+  finalizePendingLobbyCreateMetric: jest.fn(),
+}))
+
+const mockRestoreGameEngineClient = restoreGameEngineClient as jest.MockedFunction<
+  typeof restoreGameEngineClient
+>
+const mockedShowToast = showToast as jest.Mocked<typeof showToast>
+
+const originalFetch = global.fetch
+const mockFetch = jest.fn()
+
+function createPlayer(userId: string, username: string, options?: { isBot?: boolean }) {
+  return {
+    id: `player-${userId}`,
+    userId,
+    name: username,
+    score: 0,
+    user: {
+      id: userId,
+      username,
+      bot: options?.isBot
+        ? {
+            id: `bot-${userId}`,
+            userId,
+            botType: 'tic_tac_toe',
+            difficulty: 'medium',
+          }
+        : null,
+    },
+  }
+}
+
+function createWaitingGame(players: ReturnType<typeof createPlayer>[]) {
+  return {
+    id: 'game-123',
+    status: 'waiting' as const,
+    state: JSON.stringify({ phase: 'waiting' }),
+    players,
+  }
+}
+
+function createStartedGame(players: ReturnType<typeof createPlayer>[]) {
+  return {
+    id: 'game-123',
+    status: 'playing' as const,
+    state: JSON.stringify({ phase: 'playing' }),
+    players,
+    currentTurn: 0,
+  }
+}
+
+describe('useLobbyActions', () => {
+  beforeAll(() => {
+    ;(global as any).fetch = mockFetch
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRestoreGameEngineClient.mockResolvedValue({} as never)
+  })
+
+  afterAll(() => {
+    ;(global as any).fetch = originalFetch
+  })
+
+  it('refreshes the authoritative lobby snapshot before deciding to auto-add a bot', async () => {
+    const staleGame = createStartedGame([createPlayer('creator-123', 'Host')])
+    const authoritativeWaitingGame = {
+      ...createWaitingGame([
+        createPlayer('creator-123', 'Host'),
+        createPlayer('user-456', 'Guest'),
+      ]),
+      // Missing currentTurn is the stale waiting-room shape that should still reconcile.
+      currentTurn: undefined,
+    }
+    const startedGame = createStartedGame([
+      createPlayer('creator-123', 'Host'),
+      createPlayer('user-456', 'Guest'),
+    ])
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      if (input === '/api/lobby/ABCD?includeFinished=true') {
+        return {
+          ok: true,
+          json: async () => ({
+            lobby: {
+              id: 'lobby-123',
+              code: 'ABCD',
+              gameType: 'tic_tac_toe',
+              maxPlayers: 2,
+              turnTimer: 60,
+            },
+            activeGame: authoritativeWaitingGame,
+          }),
+        } as Response
+      }
+
+      if (input === '/api/game/create') {
+        return {
+          ok: true,
+          json: async () => ({ game: startedGame }),
+        } as Response
+      }
+
+      throw new Error(`Unexpected fetch call: ${String(input)}`)
+    })
+
+    const setGame = jest.fn()
+    const setGameEngine = jest.fn()
+
+    const { result } = renderHook(() =>
+      useLobbyActions({
+        code: 'ABCD',
+        lobby: {
+          id: 'lobby-123',
+          code: 'ABCD',
+          gameType: 'tic_tac_toe',
+          maxPlayers: 2,
+          turnTimer: 60,
+          creatorId: 'creator-123',
+        },
+        game: staleGame as any,
+        setGame,
+        setLobby: jest.fn(),
+        setGameEngine,
+        setTimerActive: jest.fn(),
+        setTimeLeft: jest.fn(),
+        setRollHistory: jest.fn(),
+        setCelebrationEvent: jest.fn(),
+        setChatMessages: jest.fn(),
+        socket: null,
+        isGuest: false,
+        guestId: null,
+        guestName: null,
+        guestToken: null,
+        userId: 'creator-123',
+        username: 'Host',
+        setGuestMode: jest.fn().mockResolvedValue(undefined),
+        setError: jest.fn(),
+        setLoading: jest.fn(),
+        setStartingGame: jest.fn(),
+        selectedBotDifficulty: 'medium',
+      })
+    )
+
+    await act(async () => {
+      await result.current.handleStartGame()
+    })
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/game/create',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    expect(
+      mockFetch.mock.calls.some(([url]) => url === '/api/lobby/ABCD/add-bot')
+    ).toBe(false)
+    expect(setGame).toHaveBeenCalledWith(startedGame)
+    expect(setGameEngine).toHaveBeenCalled()
+    expect(mockedShowToast.error).not.toHaveBeenCalledWith('toast.botAddFailed')
+  })
+
+  it('reconciles stale lobby state after bot-add failure and still starts when a second human already joined', async () => {
+    const initialWaitingGame = createWaitingGame([createPlayer('creator-123', 'Host')])
+    const reconciledWaitingGame = createWaitingGame([
+      createPlayer('creator-123', 'Host'),
+      createPlayer('user-456', 'Guest'),
+    ])
+    const startedGame = createStartedGame([
+      createPlayer('creator-123', 'Host'),
+      createPlayer('user-456', 'Guest'),
+    ])
+
+    let lobbyFetchCount = 0
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      if (input === '/api/lobby/ABCD?includeFinished=true') {
+        lobbyFetchCount += 1
+        return {
+          ok: true,
+          json: async () => ({
+            lobby: {
+              id: 'lobby-123',
+              code: 'ABCD',
+              gameType: 'tic_tac_toe',
+              maxPlayers: 2,
+              turnTimer: 60,
+            },
+            activeGame: lobbyFetchCount === 1 ? initialWaitingGame : reconciledWaitingGame,
+          }),
+        } as Response
+      }
+
+      if (input === '/api/lobby/ABCD/add-bot') {
+        return {
+          ok: false,
+          json: async () => ({ error: 'Lobby is full' }),
+        } as Response
+      }
+
+      if (input === '/api/game/create') {
+        return {
+          ok: true,
+          json: async () => ({ game: startedGame }),
+        } as Response
+      }
+
+      throw new Error(`Unexpected fetch call: ${String(input)}`)
+    })
+
+    const setGame = jest.fn()
+
+    const { result } = renderHook(() =>
+      useLobbyActions({
+        code: 'ABCD',
+        lobby: {
+          id: 'lobby-123',
+          code: 'ABCD',
+          gameType: 'tic_tac_toe',
+          maxPlayers: 2,
+          turnTimer: 60,
+          creatorId: 'creator-123',
+        },
+        game: initialWaitingGame as any,
+        setGame,
+        setLobby: jest.fn(),
+        setGameEngine: jest.fn(),
+        setTimerActive: jest.fn(),
+        setTimeLeft: jest.fn(),
+        setRollHistory: jest.fn(),
+        setCelebrationEvent: jest.fn(),
+        setChatMessages: jest.fn(),
+        socket: null,
+        isGuest: false,
+        guestId: null,
+        guestName: null,
+        guestToken: null,
+        userId: 'creator-123',
+        username: 'Host',
+        setGuestMode: jest.fn().mockResolvedValue(undefined),
+        setError: jest.fn(),
+        setLoading: jest.fn(),
+        setStartingGame: jest.fn(),
+        selectedBotDifficulty: 'medium',
+      })
+    )
+
+    await act(async () => {
+      await result.current.handleStartGame()
+    })
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/game/create',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    expect(
+      mockFetch.mock.calls.filter(([url]) => url === '/api/lobby/ABCD/add-bot')
+    ).toHaveLength(1)
+    expect(setGame).toHaveBeenCalledWith(startedGame)
+    expect(mockedShowToast.error).not.toHaveBeenCalledWith('toast.botAddFailed')
+    expect(mockedShowToast.errorFrom).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/socket/useSocketConnection.test.ts
+++ b/__tests__/socket/useSocketConnection.test.ts
@@ -273,7 +273,7 @@ describe('useSocketConnection', () => {
       expect(result.current.isConnected).toBe(false)
     })
 
-    it('should sync state only after lobby join confirmation on reconnect', async () => {
+    it('should sync state after lobby join confirmation on initial connect and reconnect', async () => {
       const onStateSync = jest.fn().mockResolvedValue(undefined)
       renderHook(() =>
         useSocketConnection({
@@ -296,8 +296,7 @@ describe('useSocketConnection', () => {
         await new Promise(resolve => setTimeout(resolve, 10))
       })
 
-      // First connection should not trigger reconnect sync.
-      expect(onStateSync).not.toHaveBeenCalled()
+      expect(onStateSync).toHaveBeenCalledTimes(1)
 
       const disconnectHandler = getHandler<(reason: string) => void>('disconnect')
       await act(async () => {
@@ -317,14 +316,14 @@ describe('useSocketConnection', () => {
       })
 
       // Reconnect should wait for JOINED_LOBBY acknowledgment.
-      expect(onStateSync).not.toHaveBeenCalled()
+      expect(onStateSync).toHaveBeenCalledTimes(1)
 
       await act(async () => {
         joinedLobbyHandler?.({ lobbyCode: defaultProps.code, success: true })
         await new Promise(resolve => setTimeout(resolve, 10))
       })
 
-      expect(onStateSync).toHaveBeenCalledTimes(1)
+      expect(onStateSync).toHaveBeenCalledTimes(2)
       expect(analytics.trackSocketReconnectRecovered).toHaveBeenCalledWith(
         expect.objectContaining({
           attemptsTotal: 2,

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -130,6 +130,7 @@ const RockPaperScissorsLobbyPage = dynamic(() => import('./rock-paper-scissors-p
 const LEAVE_REQUEST_TIMEOUT_MS = 2500
 const LEAVE_REDIRECT_FALLBACK_MS = 1500
 const LIFECYCLE_REDIRECT_FALLBACK_MS = 1600
+const WAITING_LOBBY_SYNC_INTERVAL_MS = 2000
 type LeaveApiOutcome = 'pending' | 'ok' | 'non_ok' | 'timeout' | 'error'
 
 function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage?: (gameType: string) => void }) {
@@ -840,6 +841,41 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     if (!loadLobbyRef.current) return
     await loadLobbyRef.current()
   }, [])
+
+  useEffect(() => {
+    if (!lobby?.id || !loadLobbyRef.current) {
+      return
+    }
+
+    if (game?.status !== 'waiting' || startingGame || error) {
+      return
+    }
+
+    const syncFromServer = () => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+        return
+      }
+      if (isLeavingLobbyRef.current || !loadLobbyRef.current) {
+        return
+      }
+      void loadLobbyRef.current().catch((syncError) => {
+        clientLogger.warn(
+          'Waiting lobby fallback sync failed:',
+          syncError instanceof Error ? syncError.message : String(syncError)
+        )
+      })
+    }
+
+    const intervalId = window.setInterval(syncFromServer, WAITING_LOBBY_SYNC_INTERVAL_MS)
+    window.addEventListener('focus', syncFromServer)
+    document.addEventListener('visibilitychange', syncFromServer)
+
+    return () => {
+      window.clearInterval(intervalId)
+      window.removeEventListener('focus', syncFromServer)
+      document.removeEventListener('visibilitychange', syncFromServer)
+    }
+  }, [error, game?.status, lobby?.id, startingGame])
 
   // Bot turn automation hook
   const { triggerBotTurn } = useBotTurn({

--- a/app/lobby/[code]/hooks/useLobbyActions.ts
+++ b/app/lobby/[code]/hooks/useLobbyActions.ts
@@ -84,6 +84,11 @@ interface LobbySettingsUpdatePayload {
   allowSpectators?: boolean
 }
 
+interface LobbySnapshotResult {
+  lobby: Lobby | null
+  game: Game | null
+}
+
 const ANALYTICS_GAME_TYPES = new Set<AnalyticsGameType>([
   'yahtzee',
   'tic_tac_toe',
@@ -122,13 +127,15 @@ function coerceGame(value: unknown): Game | null {
     typeof candidate.id !== 'string' ||
     typeof candidate.status !== 'string' ||
     !('state' in candidate) ||
-    !Array.isArray(candidate.players) ||
-    typeof candidate.currentTurn !== 'number'
+    !Array.isArray(candidate.players)
   ) {
     return null
   }
 
-  return candidate as Game
+  return {
+    ...candidate,
+    currentTurn: typeof candidate.currentTurn === 'number' ? candidate.currentTurn : 0,
+  } as Game
 }
 
 export function useLobbyActions(props: UseLobbyActionsProps) {
@@ -164,6 +171,7 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
   // Use ref to avoid circular dependencies
   const loadLobbyRef = useRef<(() => Promise<void>) | null>(null)
   const startGameInFlightRef = useRef(false)
+  const lobbySnapshotRequestRef = useRef<Promise<LobbySnapshotResult> | null>(null)
 
   useEffect(() => {
     if (!guestName) {
@@ -173,67 +181,110 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
     setGuestNameInput(guestName)
   }, [guestName])
 
-  const loadLobby = useCallback(async () => {
-    try {
+  const applyLobbySnapshot = useCallback(async (snapshot: LobbySnapshotResult) => {
+    const normalizedLobby = snapshot.lobby
+    const normalizedGame = snapshot.game
+
+    setLobby(normalizedLobby)
+    if (normalizedLobby?.code) {
+      finalizePendingLobbyCreateMetric({
+        lobbyCode: normalizedLobby.code,
+        fallbackGameType: normalizedLobby.gameType || DEFAULT_GAME_TYPE,
+      })
+    }
+
+    if (normalizedGame) {
+      setGame(normalizedGame)
+      if (normalizedGame.state) {
+        try {
+          const parsedState =
+            typeof normalizedGame.state === 'string'
+              ? JSON.parse(normalizedGame.state)
+              : normalizedGame.state
+
+          // Create the correct engine based on game type
+          const gt = normalizedLobby?.gameType || DEFAULT_GAME_TYPE
+          const engine = await restoreGameEngineClient(gt, normalizedGame.id, parsedState)
+          setGameEngine(engine)
+        } catch (parseError) {
+          clientLogger.error('Failed to parse game state:', parseError)
+          setError('Game state is corrupted. Please start a new game.')
+        }
+      }
+    }
+  }, [setGame, setGameEngine, setError, setLobby])
+
+  const requestLobbySnapshot = useCallback(async (): Promise<LobbySnapshotResult> => {
+    if (lobbySnapshotRequestRef.current) {
+      return await lobbySnapshotRequestRef.current
+    }
+
+    const request = (async (): Promise<LobbySnapshotResult> => {
       const headers = getAuthHeaders(isGuest, guestId, guestName, guestToken, {
         includeContentType: false,
       })
 
-      const res = await fetch(`/api/lobby/${code}?includeFinished=true`, { headers })
-      const data = await res.json()
+      const res = await fetch(`/api/lobby/${code}?includeFinished=true`, {
+      headers,
+      cache: 'no-store',
+    })
+    const data = await res.json()
 
-      if (!res.ok) {
-        throw new Error(data.error || 'Failed to load lobby')
-      }
+    if (!res.ok) {
+      throw new Error(data.error || 'Failed to load lobby')
+    }
 
       const { lobby: lobbyPayload, activeGame } = normalizeLobbySnapshotResponse(data)
       const normalizedLobby = (lobbyPayload as Lobby | null) ?? null
       const normalizedGame = coerceGame(activeGame)
 
-      setLobby(normalizedLobby)
-      if (normalizedLobby?.code) {
-        finalizePendingLobbyCreateMetric({
-          lobbyCode: normalizedLobby.code,
-          fallbackGameType: normalizedLobby.gameType || DEFAULT_GAME_TYPE,
-        })
+      return {
+        lobby: normalizedLobby,
+        game: normalizedGame,
       }
+    })()
 
-      if (normalizedGame) {
-        setGame(normalizedGame)
-        if (normalizedGame.state) {
-          try {
-            const parsedState =
-              typeof normalizedGame.state === 'string'
-                ? JSON.parse(normalizedGame.state)
-                : normalizedGame.state
-
-            // Create the correct engine based on game type
-            const gt = normalizedLobby?.gameType || DEFAULT_GAME_TYPE
-            const engine = await restoreGameEngineClient(gt, normalizedGame.id, parsedState)
-            setGameEngine(engine)
-          } catch (parseError) {
-            clientLogger.error('Failed to parse game state:', parseError)
-            setError('Game state is corrupted. Please start a new game.')
-          }
-        }
+    lobbySnapshotRequestRef.current = request
+    try {
+      return await request
+    } finally {
+      if (lobbySnapshotRequestRef.current === request) {
+        lobbySnapshotRequestRef.current = null
       }
+    }
+  }, [
+    code,
+    guestId,
+    guestName,
+    guestToken,
+    isGuest,
+  ])
+
+  const fetchLobbySnapshot = useCallback(async (
+    options: { applyState?: boolean } = {}
+  ): Promise<LobbySnapshotResult> => {
+    const applyState = options.applyState !== false
+    const snapshot = await requestLobbySnapshot()
+
+    if (applyState) {
+      await applyLobbySnapshot(snapshot)
+    }
+
+    return snapshot
+  }, [
+    applyLobbySnapshot,
+    requestLobbySnapshot,
+  ])
+
+  const loadLobby = useCallback(async () => {
+    try {
+      await fetchLobbySnapshot({ applyState: true })
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)
     }
-  }, [
-    code,
-    isGuest,
-    guestId,
-    guestName,
-    guestToken,
-    setLobby,
-    setGame,
-    setGameEngine,
-    setError,
-    setLoading,
-  ])
+  }, [fetchLobbySnapshot, setError, setLoading])
 
   // Update ref when loadLobby changes
   useEffect(() => {
@@ -445,7 +496,7 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
   }, [code, guestNameInput, guestToken, password, setError, setGame, setGuestMode])
 
   const handleStartGame = useCallback(async () => {
-    if (!game || !lobby?.id) return
+    if (!lobby?.id) return
     if (startGameInFlightRef.current) {
       clientLogger.warn('Start game already in progress, ignoring duplicate request', { code })
       return
@@ -459,14 +510,30 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
 
     try {
       setStartingGame(true)
+      let authoritativeSnapshot: LobbySnapshotResult | null = null
+      try {
+        authoritativeSnapshot = await fetchLobbySnapshot({ applyState: true })
+      } catch (snapshotError) {
+        clientLogger.warn(
+          'Failed to refresh lobby snapshot before starting game:',
+          snapshotError instanceof Error ? snapshotError.message : String(snapshotError)
+        )
+      }
+
+      const effectiveLobby = authoritativeSnapshot?.lobby ?? lobby
+      let effectiveGame = authoritativeSnapshot?.game ?? game
+      if (!effectiveLobby?.id) {
+        throw new Error('Failed to resolve lobby state before starting game')
+      }
+
       const lobbyGameType =
-        typeof lobby.gameType === 'string' ? lobby.gameType : DEFAULT_GAME_TYPE
+        typeof effectiveLobby.gameType === 'string' ? effectiveLobby.gameType : DEFAULT_GAME_TYPE
       const requirements = getLobbyPlayerRequirements(lobbyGameType)
       const gameType = requirements.gameType || DEFAULT_GAME_TYPE
       const supportsBots = requirements.supportsBots
       const requiredMinPlayers = requirements.minPlayersRequired
       const desiredPlayerCount = requirements.desiredPlayerCount
-      let playerCount = game?.players?.length || 0
+      let playerCount = effectiveGame?.players?.length || 0
       const requiresAutoBotFlow = supportsBots && playerCount < desiredPlayerCount
       let autoBotMetricTracked = false
       reportAutoBotFlowResult = (
@@ -499,39 +566,49 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
         showToast.dismiss('add-bot')
 
         if (!botResult.success) {
-          reportAutoBotFlowResult(false, 'bot_add_failed')
-          setStartingGame(false)
-          showToast.error('toast.botAddFailed')
-          return
+          try {
+            authoritativeSnapshot = await fetchLobbySnapshot({ applyState: true })
+            effectiveGame = authoritativeSnapshot.game ?? effectiveGame
+            playerCount = effectiveGame?.players?.length || playerCount
+          } catch (refreshError) {
+            clientLogger.warn(
+              'Failed to reconcile lobby after bot add failure:',
+              refreshError instanceof Error ? refreshError.message : String(refreshError)
+            )
+          }
+
+          if (playerCount < requiredMinPlayers) {
+            reportAutoBotFlowResult(false, 'bot_add_failed')
+            setStartingGame(false)
+            showToast.error('toast.botAddFailed')
+            return
+          }
+        } else {
+          announceBotJoined(botResult.botName, botResult.botDifficulty)
+
+          try {
+            authoritativeSnapshot = await fetchLobbySnapshot({ applyState: true })
+            effectiveGame = authoritativeSnapshot.game ?? effectiveGame
+            playerCount = effectiveGame?.players?.length || Math.max(playerCount + 1, game?.players?.length || 0)
+          } catch (refreshError) {
+            clientLogger.warn(
+              'Failed to refresh lobby after bot add:',
+              refreshError instanceof Error ? refreshError.message : String(refreshError)
+            )
+            playerCount = Math.max(playerCount + 1, game?.players?.length || 0)
+          }
         }
-
-        // Announce bot joined
-        announceBotJoined(botResult.botName, botResult.botDifficulty)
-
-        // Wait for lobby to reload and get updated player list
-        if (loadLobbyRef.current) {
-          await loadLobbyRef.current()
-        }
-
-        // Small delay to ensure state is updated
-        await new Promise(resolve => setTimeout(resolve, 500))
-
-        // Refresh local count after reconciliation.
-        // `game` in this closure can be stale until React re-renders, so never
-        // trust it to be lower than the successful bot add we just performed.
-        const observedPlayerCount = game?.players?.length || 0
-        playerCount = Math.max(playerCount + 1, observedPlayerCount)
       }
 
       if (playerCount < requiredMinPlayers) {
-          reportAutoBotFlowResult(false, 'insufficient_players')
-          setStartingGame(false)
-          showToast.error(
-            'toast.gameStartFailed',
-            `Need at least ${requiredMinPlayers} players to start ${gameType.replace(/_/g, ' ')}.`
-          )
-          return
-        }
+        reportAutoBotFlowResult(false, 'insufficient_players')
+        setStartingGame(false)
+        showToast.error(
+          'toast.gameStartFailed',
+          `Need at least ${requiredMinPlayers} players to start ${gameType.replace(/_/g, ' ')}.`
+        )
+        return
+      }
 
       const headers = getAuthHeaders(isGuest, guestId, guestName, guestToken)
       const res = await fetch('/api/game/create', {
@@ -539,9 +616,9 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
         headers,
         body: JSON.stringify({
           gameType,
-          lobbyId: lobby.id,
+          lobbyId: effectiveLobby.id,
           config: {
-            maxPlayers: readFiniteNumber(lobby.maxPlayers, 4),
+            maxPlayers: readFiniteNumber(effectiveLobby.maxPlayers, 4),
             minPlayers: requiredMinPlayers,
           }
         }),
@@ -586,16 +663,16 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
       const botCount = players.filter((p: GamePlayer) => p.user?.bot).length
       trackGameStarted({
         lobbyCode: code,
-        gameType: normalizeAnalyticsGameType(lobby.gameType),
-        isPrivate: !!lobby?.isPrivate,
-        maxPlayers: readFiniteNumber(lobby.maxPlayers, 4),
+        gameType: normalizeAnalyticsGameType(effectiveLobby.gameType),
+        isPrivate: !!effectiveLobby?.isPrivate,
+        maxPlayers: readFiniteNumber(effectiveLobby.maxPlayers, 4),
         playerCount: players.length,
         hasBot: botCount > 0,
         botCount,
       })
       reportAutoBotFlowResult(true, 'started')
 
-      const turnTimerLimit = readFiniteNumber(lobby.turnTimer, 60)
+      const turnTimerLimit = readFiniteNumber(effectiveLobby.turnTimer, 60)
       setTimerActive(true)
       setTimeLeft(turnTimerLimit)
 
@@ -630,7 +707,7 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
       startGameInFlightRef.current = false
       setStartingGame(false)
     }
-  }, [game, lobby, code, addBotToLobby, announceBotJoined, setGame, setGameEngine, setTimerActive, setTimeLeft, setRollHistory, setCelebrationEvent, setChatMessages, setStartingGame, isGuest, guestId, guestName, guestToken, selectedBotDifficulty])
+  }, [game, lobby, code, addBotToLobby, announceBotJoined, fetchLobbySnapshot, setGame, setGameEngine, setTimerActive, setTimeLeft, setRollHistory, setCelebrationEvent, setChatMessages, setStartingGame, isGuest, guestId, guestName, guestToken, selectedBotDifficulty])
 
   const updateLobbySettings = useCallback(async (updates: LobbySettingsUpdatePayload) => {
     const headers = getAuthHeaders(isGuest, guestId, guestName, guestToken)

--- a/app/lobby/[code]/hooks/useSocketConnection.ts
+++ b/app/lobby/[code]/hooks/useSocketConnection.ts
@@ -428,19 +428,29 @@ export function useSocketConnection({
         }
       }
 
-      const syncStateAfterReconnect = async () => {
-        if (!shouldSyncAfterJoinRef.current || !onStateSyncRef.current) {
+      const syncStateAfterLobbyJoin = async (trigger: 'initial-join' | 'reconnect') => {
+        if (!onStateSyncRef.current) {
+          shouldSyncAfterJoinRef.current = false
           return
         }
 
         shouldSyncAfterJoinRef.current = false
 
         try {
-          clientLogger.log('🔄 Syncing state after reconnect...')
+          clientLogger.log(
+            trigger === 'reconnect'
+              ? '🔄 Syncing state after reconnect...'
+              : '🔄 Syncing state after initial lobby join...'
+          )
           await onStateSyncRef.current()
           clientLogger.log('✅ State synced successfully')
         } catch (error) {
-          clientLogger.error('❌ Failed to sync state after reconnect:', error)
+          clientLogger.error(
+            trigger === 'reconnect'
+              ? '❌ Failed to sync state after reconnect:'
+              : '❌ Failed to sync state after initial lobby join:',
+            error
+          )
         }
       }
 
@@ -550,7 +560,9 @@ export function useSocketConnection({
         }
 
         flushPendingEmits()
-        void syncStateAfterReconnect()
+        const syncTrigger = shouldSyncAfterJoinRef.current ? 'reconnect' : 'initial-join'
+        shouldSyncAfterJoinRef.current = true
+        void syncStateAfterLobbyJoin(syncTrigger)
       })
 
       newSocket.on('connect', () => {


### PR DESCRIPTION
## Summary
- restore the waiting-lobby sync fix so hosts reconcile player count reliably when another player joins
- refresh authoritative lobby state before auto-bot start logic runs and add a waiting-room fallback sync path
- add focused regression coverage for stale player counts, join reconciliation, and start-with-bot behavior

## Testing
- `npm test -- --runTestsByPath __tests__/app/useLobbyActions.test.tsx __tests__/socket/useSocketConnection.test.ts`
- `npm run ci:quick`
- pre-push checks (`npm run db:generate`, `npm run check:locales`, `npm run ci:quick`, Jest smoke suite)

Closes #225