### PR TITLE
chore(release): promote reliability alerts TLS hotfix to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,9 @@ REPLAY_RETENTION_DAYS=90
 # Database connection is shared from DATABASE_URL above.
 # Optional only for hosted/TLS PostgreSQL when MCP scripts must enforce verify-full.
 # Not needed for a local PostgreSQL instance on localhost.
+# If your hosted URL uses `sslmode=require` and no custom CA bundle, runtime keeps
+# libpq-compatible TLS semantics automatically. Set a CA path only when you want
+# strict certificate verification (`verify-full`).
 # MCP_POSTGRES_CA_CERT_PATH=./certs/postgres-ca.pem
 
 # ------------------------------------------------------------

--- a/__tests__/lib/db-connection-string.test.ts
+++ b/__tests__/lib/db-connection-string.test.ts
@@ -1,0 +1,42 @@
+import { normalizeRuntimeDatabaseUrl } from '@/lib/db-connection-string'
+
+describe('normalizeRuntimeDatabaseUrl', () => {
+  it('enables libpq compatibility for sslmode=require when no CA bundle is configured', () => {
+    const normalized = normalizeRuntimeDatabaseUrl(
+      'postgresql://postgres:secret@db.example.com:5432/postgres?sslmode=require'
+    )
+
+    const parsed = new URL(normalized)
+    expect(parsed.searchParams.get('sslmode')).toBe('require')
+    expect(parsed.searchParams.get('uselibpqcompat')).toBe('true')
+  })
+
+  it('does not override an explicit uselibpqcompat setting', () => {
+    const normalized = normalizeRuntimeDatabaseUrl(
+      'postgresql://postgres:secret@db.example.com:5432/postgres?sslmode=require&uselibpqcompat=false'
+    )
+
+    const parsed = new URL(normalized)
+    expect(parsed.searchParams.get('uselibpqcompat')).toBe('false')
+  })
+
+  it('keeps strict verify-full mode when a CA bundle is configured', () => {
+    const normalized = normalizeRuntimeDatabaseUrl(
+      'postgresql://postgres:secret@db.example.com:5432/postgres?sslmode=require&uselibpqcompat=true',
+      { caCertPath: '/etc/ssl/private/postgres-ca.pem' }
+    )
+
+    const parsed = new URL(normalized)
+    expect(parsed.searchParams.get('sslmode')).toBe('verify-full')
+    expect(parsed.searchParams.get('sslrootcert')).toBe('/etc/ssl/private/postgres-ca.pem')
+    expect(parsed.searchParams.get('uselibpqcompat')).toBeNull()
+  })
+
+  it('leaves URLs without sslmode untouched when no CA bundle is configured', () => {
+    const normalized = normalizeRuntimeDatabaseUrl(
+      'postgresql://postgres:secret@db.example.com:5432/postgres'
+    )
+
+    expect(normalized).toBe('postgresql://postgres:secret@db.example.com:5432/postgres')
+  })
+})

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -75,6 +75,7 @@ Recommended:
 - `CRON_SECRET` (required in production; recommended locally to test `/api/cron/*`)
 - `NEXT_PUBLIC_SOCKET_URL` (explicit socket endpoint in non-local envs)
 - `MCP_POSTGRES_CA_CERT_PATH` (optional CA bundle path for hosted/TLS PostgreSQL used by Prisma 7 adapter and MCP scripts; not needed for local localhost PostgreSQL)
+- hosted `DATABASE_URL` note: if your provider ships `sslmode=require` without a CA bundle, Boardly now enables libpq-compatible TLS semantics at runtime unless `MCP_POSTGRES_CA_CERT_PATH` is configured for strict `verify-full`
 - `BOT_UX_DELAY_MS` or `BOT_UX_DELAY_SCALE` + `BOT_UX_DELAY_MIN_MS` + `BOT_UX_DELAY_MAX_MS` (optional bot UX timing controls)
 - `ANALYTICS_ALLOWED_USER_IDS` / `ANALYTICS_ALLOWED_EMAILS` (restrict analytics endpoints)
 - `OPS_ALERT_WEBHOOK_URL` (alerts channel webhook)
@@ -176,6 +177,12 @@ Then rerun:
 ```bash
 bash scripts/codex-mcp-health-check.sh
 ```
+
+Runtime note:
+
+- Prisma 7 / `pg-connection-string` may treat `sslmode=require` more strictly than older libpq-style clients.
+- Boardly normalizes hosted runtime URLs with `sslmode=require|prefer|verify-ca` to libpq-compatible behavior when no CA bundle is configured.
+- If you want strict certificate verification, configure `MCP_POSTGRES_CA_CERT_PATH` so runtime uses `sslmode=verify-full`.
 
 ### Render build hangs after Prisma datasource log
 

--- a/lib/db-connection-string.ts
+++ b/lib/db-connection-string.ts
@@ -1,0 +1,36 @@
+export interface NormalizeDatabaseUrlOptions {
+  caCertPath?: string | null
+}
+
+function shouldEnableLibpqCompat(sslMode: string | null): boolean {
+  return sslMode === 'prefer' || sslMode === 'require' || sslMode === 'verify-ca'
+}
+
+export function normalizeRuntimeDatabaseUrl(
+  rawDatabaseUrl: string,
+  options: NormalizeDatabaseUrlOptions = {}
+): string {
+  const databaseUrl = new URL(rawDatabaseUrl)
+  const caCertPath = options.caCertPath ?? null
+
+  if (caCertPath) {
+    if (!databaseUrl.searchParams.has('sslrootcert')) {
+      databaseUrl.searchParams.set('sslrootcert', caCertPath)
+    }
+
+    databaseUrl.searchParams.set('sslmode', 'verify-full')
+    databaseUrl.searchParams.delete('uselibpqcompat')
+
+    return databaseUrl.toString()
+  }
+
+  const sslMode = databaseUrl.searchParams.get('sslmode')
+  if (shouldEnableLibpqCompat(sslMode) && !databaseUrl.searchParams.has('uselibpqcompat')) {
+    // Prisma 7 + pg-connection-string treat sslmode=require/prefer/verify-ca as verify-full
+    // unless libpq compatibility is explicitly enabled. Our hosted production URLs often rely
+    // on libpq semantics when no CA bundle is configured.
+    databaseUrl.searchParams.set('uselibpqcompat', 'true')
+  }
+
+  return databaseUrl.toString()
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv'
 import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { Prisma, PrismaClient } from '@/prisma/client'
+import { normalizeRuntimeDatabaseUrl } from '@/lib/db-connection-string'
 import { logger } from './logger'
 import { DatabaseTimeoutError } from './database-errors'
 import { dbMonitor } from './db-monitoring'
@@ -75,19 +76,7 @@ function getRuntimeDatabaseUrl(): string {
   }
 
   const caCertPath = resolveTlsCaCertPath(process.env.MCP_POSTGRES_CA_CERT_PATH)
-  if (!caCertPath) {
-    return rawDatabaseUrl
-  }
-
-  const databaseUrl = new URL(rawDatabaseUrl)
-
-  if (!databaseUrl.searchParams.has('sslrootcert')) {
-    databaseUrl.searchParams.set('sslrootcert', caCertPath)
-  }
-
-  databaseUrl.searchParams.set('sslmode', 'verify-full')
-
-  return databaseUrl.toString()
+  return normalizeRuntimeDatabaseUrl(rawDatabaseUrl, { caCertPath })
 }
 
 function createPrismaAdapter() {


### PR DESCRIPTION
## Summary
- promote the reliability alerts cron TLS hotfix from `develop` to `main`
- restore libpq-compatible semantics for hosted PostgreSQL URLs using `sslmode=require` when no CA bundle is configured

## Context
This fixes the production failure behind:
- GitHub Actions workflow: `Reliability Alerts Cron / trigger-reliability-alerts`
- runtime error: `Error opening a TLS connection: self-signed certificate in certificate chain`

Closes #246