### PR TITLE
fix: sync post-game leave state with rematch flow

### DIFF
--- a/__tests__/api/lobby-code.test.ts
+++ b/__tests__/api/lobby-code.test.ts
@@ -796,6 +796,121 @@ describe('POST /api/lobby/[code]/leave', () => {
     })
   })
 
+  it('removes player from a finished game and reassigns the lobby creator after post-game leave', async () => {
+    const finishedLobby = {
+      ...mockLobby,
+      creatorId: 'user-123',
+      games: [
+        {
+          id: 'game-finished',
+          status: 'finished',
+          updatedAt: new Date('2026-03-18T12:00:00.000Z'),
+          players: [
+            {
+              id: 'player-123',
+              userId: 'user-123',
+              gameId: 'game-finished',
+              position: 0,
+              createdAt: new Date('2026-03-18T12:00:00.000Z'),
+              user: {
+                id: 'user-123',
+                username: 'testuser',
+                email: 'test@example.com',
+                bot: null,
+              },
+            },
+            {
+              id: 'player-456',
+              userId: 'user-456',
+              gameId: 'game-finished',
+              position: 1,
+              createdAt: new Date('2026-03-18T12:00:10.000Z'),
+              user: {
+                id: 'user-456',
+                username: 'another-user',
+                email: 'another@example.com',
+                bot: null,
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    mockGetServerSession.mockResolvedValue(mockSession as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-123',
+      username: 'testuser',
+      suspended: false,
+    } as any)
+    mockPrisma.lobbies.findUnique.mockResolvedValue(finishedLobby as any)
+    mockPrisma.players.delete.mockResolvedValue({ id: 'player-123' } as any)
+    mockPrisma.players.count
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+    mockPrisma.players.findFirst.mockResolvedValue({
+      userId: 'user-456',
+      user: {
+        username: 'another-user',
+      },
+    } as any)
+    mockPrisma.lobbies.update.mockResolvedValue({
+      id: 'lobby-123',
+      creatorId: 'user-456',
+      isActive: true,
+    } as any)
+
+    const request = new NextRequest('http://localhost:3000/api/lobby/ABC123/leave', {
+      method: 'POST',
+    })
+    const response = await LEAVE(request, { params: { code: 'ABC123' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(
+      expect.objectContaining({
+        message: 'You left the lobby',
+        gameEnded: false,
+        lobbyDeactivated: false,
+      })
+    )
+    expect(mockPrisma.players.delete).toHaveBeenCalledWith({
+      where: { id: 'player-123' },
+    })
+    expect(mockPrisma.games.update).not.toHaveBeenCalled()
+    expect(mockPrisma.lobbies.update).toHaveBeenCalledWith({
+      where: { id: 'lobby-123' },
+      data: { creatorId: 'user-456' },
+    })
+    expect(mockNotifySocket).toHaveBeenNthCalledWith(
+      1,
+      'lobby:ABC123',
+      'player-left',
+      expect.objectContaining({
+        userId: 'user-123',
+        playerId: 'user-123',
+        nextCreatorId: 'user-456',
+        nextCreatorName: 'another-user',
+        remainingPlayers: 1,
+      }),
+      0
+    )
+    expect(mockNotifySocket).toHaveBeenNthCalledWith(
+      2,
+      'lobby:ABC123',
+      'lobby-update',
+      {
+        lobbyCode: 'ABC123',
+        type: 'player-left',
+        data: {
+          creatorId: 'user-456',
+          creatorName: 'another-user',
+        },
+      },
+      0
+    )
+  })
+
   it('responds without waiting for socket notify when other players remain', async () => {
     const playingLobby = {
       ...mockLobby,

--- a/__tests__/api/social-loop-api.test.ts
+++ b/__tests__/api/social-loop-api.test.ts
@@ -213,6 +213,40 @@ describe('Social loop APIs', () => {
       expect(mockNotifySocket).not.toHaveBeenCalled()
     })
 
+    it('returns no notifications when requester is the only remaining latest-game participant', async () => {
+      mockGetRequestAuthUser.mockResolvedValue({
+        id: 'host-1',
+        username: 'Host',
+        isGuest: false,
+      })
+      mockPrisma.lobbies.findUnique.mockResolvedValue({
+        id: 'lobby-1',
+        code: 'ABCD',
+        name: 'Lobby',
+        gameType: 'yahtzee',
+        creatorId: 'host-1',
+        games: [
+          {
+            id: 'game-1',
+            players: [{ userId: 'host-1', user: { username: 'Host', email: 'host@example.com' } }],
+          },
+        ],
+      } as any)
+
+      const request = new NextRequest('http://localhost:3000/api/lobby/ABCD/rematch', {
+        method: 'POST',
+      })
+      const response = await REQUEST_REMATCH(request, {
+        params: Promise.resolve({ code: 'ABCD' }),
+      })
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.notifiedCount).toBe(0)
+      expect(data.notifiedUserIds).toEqual([])
+      expect(mockNotifySocket).not.toHaveBeenCalled()
+    })
+
     it('returns localized error when lobby has no games yet', async () => {
       mockGetRequestAuthUser.mockResolvedValue({
         id: 'host-1',

--- a/app/api/lobby/[code]/leave/route.ts
+++ b/app/api/lobby/[code]/leave/route.ts
@@ -114,12 +114,6 @@ export async function POST(
       where: { code },
       include: {
         games: {
-          where: {
-            OR: [
-              { status: 'waiting' },
-              { status: 'playing' }
-            ]
-          },
           orderBy: {
             updatedAt: 'desc',
           },
@@ -145,7 +139,7 @@ export async function POST(
       lobby.games.find((game) =>
         game.players.some((p) => p.userId === userId)
       ) || null
-    const activeGame = playerOwnedGame || pickRelevantLobbyGame(lobby.games)
+    const activeGame = playerOwnedGame || pickRelevantLobbyGame(lobby.games, { includeFinished: true })
 
     if (!activeGame) {
       return NextResponse.json(
@@ -186,10 +180,9 @@ export async function POST(
 
     const creatorLeft = lobby.creatorId === userId
     const lobbyCanStayActive =
-      activeGame.status === 'waiting'
-        ? remainingPlayers > 0 && remainingHumanPlayers > 0
-        : remainingPlayers > 1 && remainingHumanPlayers > 0
-
+      activeGame.status === 'playing'
+        ? remainingPlayers > 1 && remainingHumanPlayers > 0
+        : remainingPlayers > 0 && remainingHumanPlayers > 0
     const reassignedCreator =
       creatorLeft && lobbyCanStayActive
         ? await reassignLobbyCreatorIfNeeded(log, lobby.id, activeGame.id, code)
@@ -214,6 +207,46 @@ export async function POST(
     if (activeGame.status === 'waiting') {
       // In waiting state, just remove player
       // If no players or no human players left, deactivate the lobby
+      if (remainingPlayers === 0 || remainingHumanPlayers === 0) {
+        await prisma.lobbies.update({
+          where: { id: lobby.id },
+          data: { isActive: false }
+        })
+
+        return NextResponse.json({
+          message: 'You left the lobby',
+          gameEnded: false,
+          lobbyDeactivated: true
+        })
+      }
+
+      emitLobbyEvent(log, code, 'player-left', playerLeftEventPayload)
+      emitLobbyEvent(log, code, 'lobby-update', {
+        lobbyCode: code,
+        type: 'player-left',
+        ...(reassignedCreator
+          ? {
+              data: {
+                creatorId: reassignedCreator.userId,
+                creatorName: reassignedCreator.username,
+              },
+            }
+          : {}),
+      })
+
+      return NextResponse.json({
+        message: 'You left the lobby',
+        gameEnded: false,
+        lobbyDeactivated: false
+      })
+    }
+
+    // For terminal games, update lobby membership without mutating the settled result.
+    if (
+      activeGame.status === 'finished' ||
+      activeGame.status === 'abandoned' ||
+      activeGame.status === 'cancelled'
+    ) {
       if (remainingPlayers === 0 || remainingHumanPlayers === 0) {
         await prisma.lobbies.update({
           where: { id: lobby.id },


### PR DESCRIPTION
## Summary
- update post-game leave handling to remove departed players from terminal game membership
- keep finished/abandoned/cancelled results intact while still reassigning lobby creator when needed
- add regression coverage for post-game leave and rematch notification scenarios

## Verification
- `npx jest __tests__/api/lobby-code.test.ts --runInBand`
- `npx jest __tests__/api/social-loop-api.test.ts --runInBand`
- `npx jest __tests__/api/game-create.test.ts --runInBand`
- `npm run ci:quick`
- repository pre-push hook (`db:generate`, `check:locales`, `ci:quick`, Jest smoke tests)

Fixes #227