### PR TITLE
fix: prevent header overflow on narrow tablet widths

### DIFF
--- a/__tests__/components/header-actions.test.tsx
+++ b/__tests__/components/header-actions.test.tsx
@@ -78,4 +78,18 @@ describe('HeaderActions responsive user block', () => {
     fireEvent.click(profileButton!)
     expect(mockNavigateToProfile).toHaveBeenCalled()
   })
+
+  it('keeps desktop action groups hidden until the large breakpoint', () => {
+    render(
+      <HeaderActions
+        isAuthenticated
+        userName="Denys"
+        userEmail="denys@example.com"
+      />
+    )
+
+    const logoutButton = screen.getByRole('button', { name: /logout/i })
+    expect(logoutButton.parentElement?.className).toContain('hidden')
+    expect(logoutButton.parentElement?.className).toContain('lg:flex')
+  })
 })

--- a/__tests__/components/header-navigation.test.tsx
+++ b/__tests__/components/header-navigation.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { HeaderNavigation } from '@/components/Header/HeaderNavigation'
+
+const mockPush = jest.fn()
+let mockPathname = '/'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  usePathname: () => mockPathname,
+}))
+
+jest.mock('@/lib/i18n-helpers', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+describe('HeaderNavigation responsive split', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPathname = '/'
+  })
+
+  it('keeps the full navigation hidden until the large breakpoint', () => {
+    const { container } = render(
+      <HeaderNavigation
+        isAuthenticated={false}
+        isAdmin={false}
+        isGuest={false}
+      />
+    )
+
+    const navigationContainer = container.firstChild as HTMLElement | null
+
+    expect(screen.getByRole('button', { name: /home/i })).toBeTruthy()
+    expect(navigationContainer?.className).toContain('hidden')
+    expect(navigationContainer?.className).toContain('lg:flex')
+  })
+})

--- a/__tests__/components/mobile-menu.test.tsx
+++ b/__tests__/components/mobile-menu.test.tsx
@@ -30,6 +30,11 @@ jest.mock('@/lib/profile-navigation', () => ({
   navigateToProfile: (...args: unknown[]) => mockNavigateToProfile(...args),
 }))
 
+jest.mock('@/components/LanguageSwitcher', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mobile-language-switcher" />,
+}))
+
 describe('MobileMenu', () => {
   beforeEach(() => {
     jest.useFakeTimers()
@@ -152,5 +157,29 @@ describe('MobileMenu', () => {
       '/',
       { tab: 'settings' }
     )
+  })
+
+  it('keeps the compact menu split active through the tablet breakpoint', () => {
+    render(
+      <MobileMenu
+        isAuthenticated={false}
+        isAdmin={false}
+      />
+    )
+
+    expect(screen.getByLabelText('Open menu').className).toContain('lg:hidden')
+  })
+
+  it('renders the language switcher inside the menu panel', () => {
+    render(
+      <MobileMenu
+        isAuthenticated={false}
+        isAdmin={false}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('Open menu'))
+
+    expect(screen.getByTestId('mobile-language-switcher')).toBeTruthy()
   })
 })

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -57,12 +57,12 @@ export default function Header() {
           <div className="flex shrink-0 items-center gap-2 sm:gap-3">
             {/* Guest indicator */}
             {isGuestSession && guestName && (
-              <div className="hidden sm:flex items-center gap-2 px-3 py-1 bg-yellow-400/20 backdrop-blur-sm rounded-full border border-yellow-400/30">
+              <div className="hidden lg:flex items-center gap-2 px-3 py-1 bg-yellow-400/20 backdrop-blur-sm rounded-full border border-yellow-400/30">
                 <span className="max-w-[140px] truncate text-yellow-100 text-sm">👤 {guestName}</span>
               </div>
             )}
 
-            <div className="hidden sm:block">
+            <div className="hidden lg:block">
               <LanguageSwitcher />
             </div>
 

--- a/components/Header/HeaderActions.tsx
+++ b/components/Header/HeaderActions.tsx
@@ -52,7 +52,7 @@ export function HeaderActions({ isAuthenticated, userName, userEmail, userImage 
 
   if (isGuestSession) {
     return (
-      <div className="hidden md:flex shrink-0 items-center gap-2">
+      <div className="hidden lg:flex shrink-0 items-center gap-2">
         <button
           onClick={() => router.push(buildCurrentAuthUrl('login'))}
           className="px-4 py-2 rounded-lg font-medium text-white/90 hover:bg-white/10 transition-colors"
@@ -71,7 +71,7 @@ export function HeaderActions({ isAuthenticated, userName, userEmail, userImage 
 
   if (!isAuthenticated) {
     return (
-      <div className="hidden md:flex shrink-0 items-center gap-2">
+      <div className="hidden lg:flex shrink-0 items-center gap-2">
         <button
           onClick={() => router.push(buildCurrentAuthUrl('login'))}
           className="px-4 py-2 rounded-lg font-medium text-white/90 hover:bg-white/10 transition-colors"
@@ -89,7 +89,7 @@ export function HeaderActions({ isAuthenticated, userName, userEmail, userImage 
   }
 
   return (
-    <div className="hidden md:flex items-center gap-2 lg:gap-4 min-w-0">
+    <div className="hidden lg:flex items-center gap-2 lg:gap-4 min-w-0">
       <div className="min-w-0 max-w-[220px] self-center text-right lg:max-w-[280px]">
         <div className="flex flex-col items-end justify-center leading-tight">
         <span

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -17,7 +17,7 @@ export function HeaderNavigation({ isAuthenticated, isAdmin = false, isGuest }: 
   const isActive = (path: string) => pathname === path
 
   return (
-    <div className="hidden md:flex" style={{ marginLeft: 'clamp(30px, 3vw, 50px)', gap: 'clamp(10px, 1vw, 20px)' }}>
+    <div className="hidden lg:flex" style={{ marginLeft: 'clamp(30px, 3vw, 50px)', gap: 'clamp(10px, 1vw, 20px)' }}>
       <button
         onClick={() => router.push('/')}
         className={`rounded-lg font-medium transition-colors ${isActive('/')

--- a/components/Header/MobileMenu.tsx
+++ b/components/Header/MobileMenu.tsx
@@ -7,6 +7,7 @@ import { useGuest } from '@/contexts/GuestContext'
 import { navigateToProfile } from '@/lib/profile-navigation'
 import { buildCurrentAuthUrl } from '@/lib/auth-redirect'
 import { UserAvatar } from './UserAvatar'
+import LanguageSwitcher from '@/components/LanguageSwitcher'
 
 interface MobileMenuProps {
   isAuthenticated: boolean
@@ -120,7 +121,7 @@ export function MobileMenu({
             setMobileMenuOpen(true)
           }
         }}
-        className="md:hidden rounded-lg transition-all duration-200 relative z-50"
+        className="lg:hidden rounded-lg transition-all duration-200 relative z-50"
         style={{
           padding: 'clamp(8px, 0.8vh, 12px)',
           backgroundColor: mobileMenuOpen ? 'rgba(59, 130, 246, 0.1)' : 'transparent'
@@ -152,14 +153,14 @@ export function MobileMenu({
         <>
           {/* Backdrop */}
           <div
-            className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-40 md:hidden ${isClosing ? 'animate-fade-out' : 'animate-fade-in'
+            className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-40 lg:hidden ${isClosing ? 'animate-fade-out' : 'animate-fade-in'
               }`}
             onClick={closeMenu}
           />
 
           {/* Menu panel */}
           <div
-            className={`fixed top-0 right-0 bottom-0 flex h-full w-[85vw] max-w-sm flex-col bg-white dark:bg-gray-900 shadow-2xl z-50 md:hidden overflow-hidden ${isClosing ? 'animate-slide-out-right' : 'animate-slide-in-right'
+            className={`fixed top-0 right-0 bottom-0 flex h-full w-[85vw] max-w-sm flex-col bg-white dark:bg-gray-900 shadow-2xl z-50 lg:hidden overflow-hidden ${isClosing ? 'animate-slide-out-right' : 'animate-slide-in-right'
               }`}
             style={{
               borderLeft: '1px solid',
@@ -340,6 +341,13 @@ export function MobileMenu({
                     <div className="h-px bg-gray-200 dark:bg-gray-700 my-2" />
                   </>
                 )}
+
+                <div className="rounded-2xl border border-gray-200 bg-white/80 p-3 shadow-sm dark:border-gray-700 dark:bg-gray-800/60">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
+                    Language
+                  </p>
+                  <LanguageSwitcher variant="panel" />
+                </div>
               </div>
             </nav>
 

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -4,8 +4,13 @@ import { useTranslation } from '@/lib/i18n-helpers'
 import { availableLocales } from '@/locales'
 import { setStoredAppearanceLocale } from '@/lib/appearance-preferences'
 
-export default function LanguageSwitcher() {
+interface LanguageSwitcherProps {
+  variant?: 'header' | 'panel'
+}
+
+export default function LanguageSwitcher({ variant = 'header' }: LanguageSwitcherProps) {
   const { i18n } = useTranslation()
+  const isPanelVariant = variant === 'panel'
 
   const handleLocaleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const nextLanguage = e.target.value
@@ -43,11 +48,15 @@ export default function LanguageSwitcher() {
   }
 
   return (
-    <div className="relative min-w-[138px] max-w-[156px]">
+    <div className={isPanelVariant ? 'relative w-full' : 'relative min-w-[138px] max-w-[156px]'}>
       <select
         value={i18n.language}
         onChange={handleLocaleChange}
-        className="w-full appearance-none rounded-xl border border-white/30 bg-white/24 px-3 py-2 pr-9 text-xs font-semibold text-white shadow-[0_10px_30px_rgba(37,99,235,0.18),inset_0_1px_0_rgba(255,255,255,0.22)] backdrop-blur-md outline-none transition hover:bg-white/28 focus:border-white/40 focus:bg-white/32 focus:ring-2 focus:ring-white/25"
+        className={
+          isPanelVariant
+            ? 'w-full appearance-none rounded-xl border border-slate-200 bg-white px-3 py-2.5 pr-9 text-sm font-semibold text-slate-700 shadow-sm outline-none transition hover:border-slate-300 hover:bg-slate-50 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:border-slate-600 dark:hover:bg-slate-800 dark:focus:border-blue-400 dark:focus:ring-blue-500/20'
+            : 'w-full appearance-none rounded-xl border border-white/30 bg-white/24 px-3 py-2 pr-9 text-xs font-semibold text-white shadow-[0_10px_30px_rgba(37,99,235,0.18),inset_0_1px_0_rgba(255,255,255,0.22)] backdrop-blur-md outline-none transition hover:bg-white/28 focus:border-white/40 focus:bg-white/32 focus:ring-2 focus:ring-white/25'
+        }
         aria-label="Select language"
       >
         {availableLocales.map((loc) => (
@@ -58,7 +67,11 @@ export default function LanguageSwitcher() {
       </select>
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-white/70"
+        className={
+          isPanelVariant
+            ? 'pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-slate-500 dark:text-slate-400'
+            : 'pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-white/70'
+        }
       >
         ▾
       </span>


### PR DESCRIPTION
## Summary
- keep the shared desktop header on `lg` and move narrow tablet widths to the compact menu layout
- add the language switcher to the mobile/tablet menu so hidden desktop controls stay accessible
- cover the responsive split with targeted header component tests

## Verification
- `npx jest __tests__/components/mobile-menu.test.tsx __tests__/components/header-actions.test.tsx __tests__/components/header-navigation.test.tsx --runInBand`
- `npm run ci:quick`
- verified the guest header in a real browser at `780px` and `860px` widths after the fix

Fixes #226