### PR TITLE
fix(#241): persist explicit match timing and terminal metadata

### DIFF
--- a/app/api/game/[gameId]/abandon/route.ts
+++ b/app/api/game/[gameId]/abandon/route.ts
@@ -76,11 +76,18 @@ export async function POST(
     const humanPlayersCount = game.players.filter(p => !p.user.bot).length
 
     // Mark game as abandoned
+    const now = new Date()
+    const startedAt = (game as unknown as { startedAt?: Date | null }).startedAt
+    const durationSeconds =
+      startedAt instanceof Date ? Math.floor((now.getTime() - startedAt.getTime()) / 1000) : null
     await prisma.games.update({
       where: { id: gameId },
       data: {
         status: 'abandoned',
-        abandonedAt: new Date() // TypeScript cache issue - field exists in schema
+        abandonedAt: now,
+        endedAt: now,
+        ...(durationSeconds !== null ? { durationSeconds } : {}),
+        terminalMetadata: { outcome: 'abandoned', reason: 'manual' },
       }
     })
 

--- a/app/api/game/[gameId]/replay/route.ts
+++ b/app/api/game/[gameId]/replay/route.ts
@@ -101,8 +101,12 @@ export async function GET(
           ]
 
     const resolvedGameType = game.lobby.gameType || game.gameType
-    const endedAt = getGameEndedAt(game.status, game.updatedAt, game.abandonedAt)
-    const durationMs = getGameDurationMs(game.createdAt, endedAt)
+    const g = game as unknown as { endedAt?: Date | null; durationSeconds?: number | null }
+    const inferredEndedAt = getGameEndedAt(game.status, game.updatedAt, game.abandonedAt)
+    const endedAt = g.endedAt ?? inferredEndedAt
+    const durationMs = g.durationSeconds != null
+      ? g.durationSeconds * 1000
+      : getGameDurationMs(game.createdAt, endedAt)
 
     const replayPayload = {
       game: {
@@ -113,7 +117,7 @@ export async function GET(
         status: game.status,
         createdAt: game.createdAt.toISOString(),
         updatedAt: game.updatedAt.toISOString(),
-        endedAt: endedAt?.toISOString() || null,
+        endedAt: endedAt?.toISOString() ?? null,
         durationMs,
         players: game.players.map((player) => ({
           userId: player.userId,

--- a/app/api/game/[gameId]/results/route.ts
+++ b/app/api/game/[gameId]/results/route.ts
@@ -75,8 +75,13 @@ export async function GET(
     }
 
     const resolvedGameType = game.lobby.gameType || game.gameType
-    const endedAt = getGameEndedAt(game.status, game.updatedAt, game.abandonedAt)
-    const durationMs = getGameDurationMs(game.createdAt, endedAt)
+    const g = game as unknown as { endedAt?: Date | null; durationSeconds?: number | null; startedAt?: Date | null }
+    // Prefer explicit fields; fall back to inferred values for pre-migration records
+    const inferredEndedAt = getGameEndedAt(game.status, game.updatedAt, game.abandonedAt)
+    const endedAt = g.endedAt ?? inferredEndedAt
+    const durationMs = g.durationSeconds != null
+      ? g.durationSeconds * 1000
+      : getGameDurationMs(game.createdAt, endedAt)
 
     // Format response
     const formattedGame = {
@@ -87,8 +92,8 @@ export async function GET(
       status: game.status,
       createdAt: game.createdAt.toISOString(),
       updatedAt: game.updatedAt.toISOString(),
-      finishedAt: game.status === 'finished' ? endedAt?.toISOString() || null : null,
-      endedAt: endedAt?.toISOString() || null,
+      finishedAt: game.status === 'finished' ? endedAt?.toISOString() ?? null : null,
+      endedAt: endedAt?.toISOString() ?? null,
       durationMs,
       abandonedAt: game.abandonedAt?.toISOString() || null,
       hasReplay: game.status === 'finished',

--- a/app/api/game/[gameId]/state/route.ts
+++ b/app/api/game/[gameId]/state/route.ts
@@ -489,6 +489,37 @@ export async function POST(
       })
     }
 
+    const TERMINAL_STATUSES = new Set(['finished', 'abandoned', 'cancelled'])
+    const isTerminal = TERMINAL_STATUSES.has(newState.status)
+    const terminalFields = statusChanged && isTerminal
+      ? (() => {
+          const now = new Date()
+          const startedAt = (game as unknown as { startedAt?: Date | null }).startedAt
+          const durationSeconds =
+            startedAt instanceof Date
+              ? Math.floor((now.getTime() - startedAt.getTime()) / 1000)
+              : null
+          const winnerPlayer = newState.winner
+            ? (gamePlayers.find((p) => {
+                const ep = (enginePlayers as Player[]).find((e) => e.id === p.userId)
+                return ep?.id === newState.winner
+              }) ?? null)
+            : null
+          const terminalMetadata = {
+            outcome: newState.winner ? 'winner' : newState.status === 'finished' ? 'draw' : newState.status,
+            winnerUserId: winnerPlayer?.userId ?? null,
+            isDraw: newState.status === 'finished' && !newState.winner,
+            playerResults: (enginePlayers as Player[]).map((ep, i) => ({
+              userId: gamePlayers[i]?.userId ?? ep.id,
+              placement: typeof (ep as { placement?: number }).placement === 'number' ? (ep as { placement?: number }).placement : i + 1,
+              finalScore: typeof ep.score === 'number' ? ep.score : null,
+              isWinner: ep.id === newState.winner,
+            })),
+          }
+          return { endedAt: now, durationSeconds, terminalMetadata }
+        })()
+      : {}
+
     const gameUpdateResult = await prisma.$transaction(async (tx) => {
       // Optimistic concurrency control:
       // apply update only if game row is still at the same revision we loaded.
@@ -503,6 +534,7 @@ export async function POST(
           status: newState.status,
           currentTurn: newState.currentPlayerIndex,
           ...(lastMoveAtDate ? { lastMoveAt: lastMoveAtDate } : {}),
+          ...terminalFields,
           updatedAt: new Date(),
         },
       })

--- a/app/api/game/create/route.ts
+++ b/app/api/game/create/route.ts
@@ -394,6 +394,7 @@ export async function POST(request: NextRequest) {
         state: toPersistedGameStateInput(gameEngine.getState()),
         status: 'playing',
         gameType: persistedGameType,
+        startedAt: new Date(),
         updatedAt: new Date(),
       },
       include: {

--- a/lib/socket/disconnect-sync.ts
+++ b/lib/socket/disconnect-sync.ts
@@ -222,26 +222,29 @@ export function createDisconnectSyncManager({
           ? parsedState.currentPlayerIndex
           : activeGame.currentTurn
 
-      const updateData: {
-        state: ReturnType<typeof toPersistedGameStateInput>
-        currentTurn: number
-        updatedAt: Date
-        status?: 'abandoned'
-        abandonedAt?: Date
-        lastMoveAt?: Date
-      } = {
+      const abandonNow = new Date(now)
+      const startedAt = shouldAbandon
+        ? (activeGame as unknown as { startedAt?: Date | null }).startedAt
+        : null
+      const abandonDurationSeconds =
+        shouldAbandon && startedAt instanceof Date
+          ? Math.floor((abandonNow.getTime() - startedAt.getTime()) / 1000)
+          : null
+
+      const baseUpdateData = {
         state: toPersistedGameStateInput(parsedState),
         currentTurn: nextCurrentTurn,
         updatedAt: new Date(),
-      }
-
-      if (turnAdvanced) {
-        updateData.lastMoveAt = new Date(now)
-      }
-
-      if (shouldAbandon) {
-        updateData.status = 'abandoned'
-        updateData.abandonedAt = new Date(now)
+        ...(turnAdvanced ? { lastMoveAt: new Date(now) } : {}),
+        ...(shouldAbandon
+          ? {
+              status: 'abandoned' as const,
+              abandonedAt: abandonNow,
+              endedAt: abandonNow,
+              ...(abandonDurationSeconds !== null ? { durationSeconds: abandonDurationSeconds } : {}),
+              terminalMetadata: JSON.parse(JSON.stringify({ outcome: 'abandoned', reason: 'disconnect' })),
+            }
+          : {}),
       }
 
       const updateResult = await prisma.games.updateMany({
@@ -250,7 +253,7 @@ export function createDisconnectSyncManager({
           currentTurn: activeGame.currentTurn,
           updatedAt: activeGame.updatedAt,
         },
-        data: updateData,
+        data: baseUpdateData,
       })
 
       if (updateResult.count > 0) {

--- a/prisma/migrations/20260325000000_add_match_timing_metadata/migration.sql
+++ b/prisma/migrations/20260325000000_add_match_timing_metadata/migration.sql
@@ -1,0 +1,11 @@
+-- AddColumn: startedAt, endedAt, durationSeconds, terminalMetadata to Games
+-- All columns are nullable for full backwards compatibility with existing rows.
+
+ALTER TABLE "Games" ADD COLUMN "startedAt" TIMESTAMPTZ(3);
+ALTER TABLE "Games" ADD COLUMN "endedAt" TIMESTAMPTZ(3);
+ALTER TABLE "Games" ADD COLUMN "durationSeconds" INTEGER;
+ALTER TABLE "Games" ADD COLUMN "terminalMetadata" JSONB;
+
+-- Indexes for time-range queries and analytics
+CREATE INDEX "Games_startedAt_idx" ON "Games"("startedAt");
+CREATE INDEX "Games_endedAt_idx" ON "Games"("endedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,7 +195,11 @@ model Games {
   state       Json                 @db.JsonB
   status      GameStatus           @default(waiting)
   gameType    GameType             @default(yahtzee)
-  abandonedAt DateTime?            @db.Timestamptz(3)
+  abandonedAt      DateTime?            @db.Timestamptz(3)
+  startedAt        DateTime?            @db.Timestamptz(3) // Set when game transitions waiting → playing
+  endedAt          DateTime?            @db.Timestamptz(3) // Set on any terminal transition (finished/abandoned/cancelled)
+  durationSeconds  Int?                                    // floor((endedAt - startedAt) / 1000); null if no startedAt
+  terminalMetadata Json?                @db.JsonB           // { outcome, winnerUserId?, isDraw, reason?, playerResults[] }
   currentTurn Int                  @default(0)
   lastMoveAt  DateTime             @default(now()) @db.Timestamptz(3) // Track when last move was made for timer
   createdAt   DateTime             @default(now()) @db.Timestamptz(3)
@@ -207,6 +211,8 @@ model Games {
   @@index([status])
   @@index([gameType, status])
   @@index([createdAt])
+  @@index([startedAt])
+  @@index([endedAt])
 }
 
 model GameStateSnapshots {


### PR DESCRIPTION
## Summary
- Adds `startedAt`, `endedAt`, `durationSeconds`, `terminalMetadata` to `Games` table (nullable, fully backwards-compatible)
- Sets `startedAt` when game transitions `waiting → playing`
- Sets `endedAt` + `durationSeconds` + `terminalMetadata` on any terminal transition (finished/abandoned/cancelled), including disconnect-triggered abandons
- Results and replay APIs now prefer explicit fields with graceful fallback to inferred values for legacy records

## Migration
`20260325000000_add_match_timing_metadata` — 4 nullable columns + 2 indexes on `Games`

## Test plan
- [x] `npm run ci:quick` passes (lint + typecheck)
- [x] Jest smoke tests pass (47/47)
- [x] Migration applied to Supabase successfully
- [ ] Manual: start game → verify `startedAt` set; finish game → verify `endedAt`, `durationSeconds`, `terminalMetadata` populated
- [ ] Manual: `/api/game/[gameId]/results` returns explicit timing without inference

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)