### PR TITLE
fix(#239): redesign lobby waiting room — cleaner layout, no redundancy

### DIFF
--- a/app/lobby/[code]/components/LobbyInfo.tsx
+++ b/app/lobby/[code]/components/LobbyInfo.tsx
@@ -196,7 +196,7 @@ export default function LobbyInfo({
           </div>
         </div>
 
-        <div className="mt-3 grid grid-cols-2 lg:grid-cols-4 gap-2">
+        <div className="mt-3 grid grid-cols-3 gap-2">
           <div
             className={`rounded-xl border border-white/15 bg-white/5 px-3 py-2 ${
               canEditLobbySettings
@@ -215,10 +215,6 @@ export default function LobbyInfo({
             <p className="mt-1 text-sm font-semibold text-white break-words">
               {t('lobby.playerOccupancy', { current: currentPlayers, max: maxPlayers })}
             </p>
-          </div>
-          <div className="rounded-xl border border-white/15 bg-white/5 px-3 py-2">
-            <p className="text-[11px] uppercase tracking-wider text-white/50">{t('game.ui.gameTypeLabel')}</p>
-            <p className="mt-1 text-sm font-semibold text-white break-words">{gameMeta?.name ?? t('lobby.gameUnknown')}</p>
           </div>
           <div
             className={`rounded-xl border border-white/15 bg-white/5 px-3 py-2 ${

--- a/app/lobby/[code]/components/WaitingRoom.tsx
+++ b/app/lobby/[code]/components/WaitingRoom.tsx
@@ -41,28 +41,18 @@ export default function WaitingRoom({
   const openSlots = Math.max(maxPlayers - playerCount, 0)
   const missingPlayers = Math.max(minPlayers - playerCount, 0)
   const hasBot = game?.players?.some((p: GamePlayer) => !!p.user?.bot)
-  const gameMeta = getGameMetadata(lobby.gameType)
   const supportsBots = hasBotSupport(lobby.gameType)
   const canAddMorePlayers = playerCount < maxPlayers
   const canConfigureBots = supportsBots && canAddMorePlayers
   const canStartWithAutoBot = supportsBots && !hasBot && playerCount > 0 && playerCount < minPlayers && canAddMorePlayers
   const canStartImmediately = playerCount >= minPlayers || canStartWithAutoBot
   const creatorName = lobby?.creator?.username || lobby?.creator?.email || t('lobby.ownerFallback')
-  const occupancyPercent = Math.min(100, Math.round((playerCount / Math.max(maxPlayers, 1)) * 100))
-  const quickRuleByGameType: Record<string, string> = {
-    yahtzee: t('game.ui.howToPlayRuleYahtzee'),
-    guess_the_spy: t('game.ui.howToPlayRuleSpy'),
-    tic_tac_toe: t('game.ui.howToPlayRuleTicTacToe'),
-    rock_paper_scissors: t('game.ui.howToPlayRuleRps'),
-    memory: t('game.ui.howToPlayRuleMemory'),
-  }
-  const quickRule = quickRuleByGameType[lobby?.gameType as string] || t('game.ui.howToPlayRuleFallback')
   const difficultyLabelMap: Record<BotDifficulty, string> = {
     easy: t('game.ui.botDifficultyEasy'),
     medium: t('game.ui.botDifficultyMedium'),
     hard: t('game.ui.botDifficultyHard'),
   }
-  // Show loading overlay when starting game
+
   if (startingGame) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -84,117 +74,99 @@ export default function WaitingRoom({
   }
 
   return (
-    <div className="max-w-5xl mx-auto w-full px-1 py-4 space-y-5">
+    <div className="max-w-5xl mx-auto w-full px-1 py-4 space-y-4">
+      {/* Players section — merged status + player list */}
       <section className="rounded-2xl border border-white/20 bg-white/10 backdrop-blur-xl p-5 sm:p-6">
-        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-          <div className="min-w-0">
-            <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs text-white/80 mb-3">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2.5">
+            <h2 className="text-base font-bold text-white">{t('game.ui.playersInLobbyTitle')}</h2>
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
+                canStartImmediately
+                  ? 'border-emerald-300/40 bg-emerald-500/20 text-emerald-200'
+                  : 'border-amber-300/40 bg-amber-500/20 text-amber-200'
+              }`}
+            >
               <span>{canStartImmediately ? '🟢' : '🟡'}</span>
               <span>{canStartImmediately ? t('game.ui.readyToStart') : t('game.ui.waiting')}</span>
-            </div>
-            <h2 className="text-2xl sm:text-3xl font-extrabold text-white mb-1">{t('game.ui.readyToPlay')}</h2>
-            <p className="text-sm text-white/70">
-              {canStartImmediately ? t('game.ui.addBotOrWait') : t('game.ui.needMorePlayers', { count: missingPlayers })}
-            </p>
-          </div>
-
-          <div className="w-full lg:w-80 rounded-xl border border-white/20 bg-white/5 p-3">
-            <div className="flex items-center justify-between text-xs text-white/70 mb-2">
-              <span>{t('game.ui.playersInLobbyTitle')}</span>
-              <span>
-                {playerCount}/{maxPlayers}
-              </span>
-            </div>
-            <div className="h-2 rounded-full bg-white/15 overflow-hidden">
-              <div className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-blue-500" style={{ width: `${occupancyPercent}%` }} />
-            </div>
-            <p className="mt-2 text-xs text-white/65">
-              {t('game.ui.availableSlots')}: {openSlots}
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md p-5">
-        <h3 className="text-sm font-semibold text-white/80 uppercase tracking-wider mb-2">
-          {t('game.ui.howToPlayTitle')}
-        </h3>
-        <p className="text-sm text-white/65 mb-3">{t('game.ui.howToPlayDescription')}</p>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-2.5">
-          <div className="rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-white/85">
-            1. {t('game.ui.howToPlayReady')}
-          </div>
-          <div className="rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-white/85">
-            2. {quickRule}
-          </div>
-          <div className="rounded-xl border border-white/15 bg-white/5 px-3 py-2.5 text-sm text-white/85">
-            3. {t('game.ui.howToPlayStart')}
-          </div>
-        </div>
-      </section>
-
-      {game?.players && game.players.length > 0 && (
-        <section className="rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md p-5">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-sm font-semibold text-white/75 uppercase tracking-wider">{t('game.ui.playersInLobbyTitle')}</h3>
-            <span className="text-xs text-white/60">
-              {playerCount}/{maxPlayers}
             </span>
           </div>
+          <span className="text-sm font-semibold text-white/60">
+            {playerCount}/{maxPlayers}
+          </span>
+        </div>
 
-          <div className="space-y-2.5">
-            {game.players.map((p: GamePlayer, index: number) => {
-              const isBot = !!p.user?.bot
-              const playerName = p.user?.username || p.user?.email || (isBot ? t('game.ui.aiBot') : t('game.ui.player'))
-              const isCurrentUser = p.userId === getCurrentUserId()
-              const botDifficultyValue = p.user?.bot?.difficulty as BotDifficulty | undefined
-              const botDifficultyLabel = botDifficultyValue ? difficultyLabelMap[botDifficultyValue] : null
+        <div className="space-y-2">
+          {game?.players?.map((p: GamePlayer, index: number) => {
+            const isBot = !!p.user?.bot
+            const playerName = p.user?.username || p.user?.email || (isBot ? t('game.ui.aiBot') : t('game.ui.player'))
+            const isCurrentUser = p.userId === getCurrentUserId()
+            const botDifficultyValue = p.user?.bot?.difficulty as BotDifficulty | undefined
+            const botDifficultyLabel = botDifficultyValue ? difficultyLabelMap[botDifficultyValue] : null
 
-              return (
-                <div
-                  key={p.id}
-                  className={`flex items-center gap-3 rounded-xl px-3 sm:px-4 py-3 border ${
-                    isCurrentUser
-                      ? 'bg-emerald-500/15 border-emerald-300/45'
-                      : isBot
-                        ? 'bg-violet-500/15 border-violet-300/40'
-                        : 'bg-white/5 border-white/15'
-                  }`}
-                >
-                  <div className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center text-white text-sm font-bold">
-                    {index + 1}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-semibold text-white text-sm truncate">{playerName}</span>
-                      {isCurrentUser && !isBot && (
-                        <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-emerald-500/85 text-white">
-                          {t('game.ui.you')}
-                        </span>
-                      )}
-                      {isBot && (
-                        <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-violet-500/85 text-white">
-                          AI
-                        </span>
-                      )}
-                      {isBot && botDifficultyLabel && (
-                        <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-indigo-500/80 text-white">
-                          {botDifficultyLabel}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  <span className="text-emerald-300 text-lg">✓</span>
+            return (
+              <div
+                key={p.id}
+                className={`flex items-center gap-3 rounded-xl px-3 sm:px-4 py-2.5 border ${
+                  isCurrentUser
+                    ? 'bg-emerald-500/15 border-emerald-300/40'
+                    : isBot
+                      ? 'bg-violet-500/15 border-violet-300/35'
+                      : 'bg-white/5 border-white/12'
+                }`}
+              >
+                <div className="w-7 h-7 rounded-full bg-white/15 flex items-center justify-center text-white/80 text-xs font-bold shrink-0">
+                  {index + 1}
                 </div>
-              )
-            })}
-          </div>
-        </section>
-      )}
+                <div className="flex-1 min-w-0 flex flex-wrap items-center gap-1.5">
+                  <span className="font-semibold text-white text-sm truncate">{playerName}</span>
+                  {isCurrentUser && !isBot && (
+                    <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-emerald-500/80 text-white">
+                      {t('game.ui.you')}
+                    </span>
+                  )}
+                  {isBot && (
+                    <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-violet-500/80 text-white">
+                      AI
+                    </span>
+                  )}
+                  {isBot && botDifficultyLabel && (
+                    <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-indigo-500/75 text-white">
+                      {botDifficultyLabel}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )
+          })}
 
+          {/* Empty slots */}
+          {Array.from({ length: openSlots }).map((_, i) => (
+            <div
+              key={`empty-${i}`}
+              className="flex items-center gap-3 rounded-xl px-3 sm:px-4 py-2.5 border border-white/8 border-dashed"
+            >
+              <div className="w-7 h-7 rounded-full bg-white/8 flex items-center justify-center text-white/30 text-xs font-bold shrink-0">
+                {playerCount + i + 1}
+              </div>
+              <span className="text-sm text-white/30 italic">
+                {i < missingPlayers ? t('game.ui.waitingForPlayer') : t('game.ui.openSlot')}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {!canStartImmediately && missingPlayers > 0 && (
+          <p className="mt-3 text-xs text-amber-200/70">
+            {t('game.ui.needMorePlayers', { count: missingPlayers })}
+          </p>
+        )}
+      </section>
+
+      {/* Actions */}
       <section className="rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md p-5">
         {canStartGame ? (
-          <div className="space-y-4">
+          <div className="space-y-3">
             <button
               onClick={() => {
                 sounds.play('click')
@@ -210,17 +182,53 @@ export default function WaitingRoom({
             </button>
 
             {supportsBots && playerCount === 1 && !hasBot && (
-              <div className="rounded-xl border border-blue-300/35 bg-blue-500/10 px-4 py-3">
+              <div className="rounded-xl border border-blue-300/30 bg-blue-500/10 px-4 py-2.5">
                 <p className="text-blue-100 text-xs">
                   💡 <strong>{t('game.ui.tip')}:</strong> {t('game.ui.botAutoAddTip')}
                 </p>
               </div>
             )}
 
+            <div className="flex flex-col sm:flex-row gap-2.5">
+              {supportsBots && canAddMorePlayers && (
+                <button
+                  onClick={() => {
+                    sounds.play('click')
+                    onAddBot()
+                  }}
+                  disabled={!canAddMorePlayers}
+                  className="flex-1 px-4 py-3 bg-white/10 hover:bg-white/20 text-white rounded-xl font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed border border-white/20"
+                  title={!canAddMorePlayers ? t('game.ui.lobbyFull') : t('game.ui.addAiOpponent')}
+                >
+                  <span className="inline-flex items-center justify-center gap-2">
+                    <span>🤖</span>
+                    <span>{t('game.ui.addBotPlayer')}</span>
+                  </span>
+                </button>
+              )}
+
+              {onInviteFriends && canAddMorePlayers && (
+                <button
+                  onClick={() => {
+                    sounds.play('click')
+                    onInviteFriends()
+                  }}
+                  disabled={!canAddMorePlayers}
+                  className="flex-1 px-4 py-3 bg-white/20 hover:bg-white/30 text-white rounded-xl font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed border border-white/20"
+                  title={!canAddMorePlayers ? t('game.ui.lobbyFull') : t('game.ui.inviteFriendsToJoin')}
+                >
+                  <span className="inline-flex items-center justify-center gap-2">
+                    <span>👥</span>
+                    <span>{t('game.ui.inviteFriends')}</span>
+                  </span>
+                </button>
+              )}
+            </div>
+
             {canConfigureBots && (
-              <div className="rounded-xl border border-white/20 bg-white/5 px-4 py-3">
-                <p className="text-white/80 text-xs font-semibold uppercase tracking-wide mb-2">{t('game.ui.botDifficulty')}</p>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              <div className="rounded-xl border border-white/15 bg-white/5 px-4 py-3">
+                <p className="text-white/70 text-xs font-semibold uppercase tracking-wide mb-2">{t('game.ui.botDifficulty')}</p>
+                <div className="grid grid-cols-3 gap-2">
                   {BOT_DIFFICULTIES.map((difficulty) => (
                     <button
                       key={difficulty}
@@ -242,52 +250,16 @@ export default function WaitingRoom({
                 </div>
               </div>
             )}
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-              {supportsBots && canAddMorePlayers && (
-                <button
-                  onClick={() => {
-                    sounds.play('click')
-                    onAddBot()
-                  }}
-                  disabled={!canAddMorePlayers}
-                  className="w-full px-4 py-3 bg-white/10 hover:bg-white/20 text-white rounded-xl font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed border border-white/20"
-                  title={!canAddMorePlayers ? t('game.ui.lobbyFull') : t('game.ui.addAiOpponent')}
-                >
-                  <span className="inline-flex items-center justify-center gap-2">
-                    <span>🤖</span>
-                    <span>{t('game.ui.addBotPlayer')}</span>
-                  </span>
-                </button>
-              )}
-
-              {onInviteFriends && canAddMorePlayers && (
-                <button
-                  onClick={() => {
-                    sounds.play('click')
-                    onInviteFriends()
-                  }}
-                  disabled={!canAddMorePlayers}
-                  className="w-full px-4 py-3 bg-white/20 hover:bg-white/30 text-white rounded-xl font-semibold transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed border border-white/20"
-                  title={!canAddMorePlayers ? t('game.ui.lobbyFull') : t('game.ui.inviteFriendsToJoin')}
-                >
-                  <span className="inline-flex items-center justify-center gap-2">
-                    <span>👥</span>
-                    <span>{t('game.ui.inviteFriends')}</span>
-                  </span>
-                </button>
-              )}
-            </div>
           </div>
         ) : (
-          <div className="rounded-xl border border-white/20 bg-white/5 px-4 py-5 text-center">
-            <div className="flex items-center justify-center gap-2 mb-2">
-              <span className="text-xl">⌛</span>
-              <p className="text-white font-bold text-base">{t('game.ui.waitingForHost')}</p>
+          <div className="flex items-center gap-3 rounded-xl border border-white/15 bg-white/5 px-4 py-4">
+            <span className="text-2xl shrink-0">⌛</span>
+            <div className="min-w-0">
+              <p className="text-white font-bold text-sm">{t('game.ui.waitingForHost')}</p>
+              <p className="text-white/55 text-xs mt-0.5">
+                {t('game.ui.host')}: <span className="font-semibold text-white/75">{creatorName}</span>
+              </p>
             </div>
-            <p className="text-white/60 text-sm">
-              {t('game.ui.host')}: <span className="font-semibold text-white/80">{creatorName}</span>
-            </p>
           </div>
         )}
       </section>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -622,6 +622,8 @@ const en = {
       spectatorsLabel: 'Spectators',
       spectatorsDisabled: 'Disabled',
       availableSlots: 'Open slots',
+      waitingForPlayer: 'Waiting for player...',
+      openSlot: 'Open slot',
       howToPlayTitle: 'How to Play',
       howToPlayDescription: 'Quick instructions before the game starts',
       howToPlayReady: 'Wait for enough players to join the lobby.',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -622,6 +622,8 @@ const no = {
       spectatorsLabel: 'Tilskuere',
       spectatorsDisabled: 'Deaktivert',
       availableSlots: 'Ledige plasser',
+      waitingForPlayer: 'Venter på spiller...',
+      openSlot: 'Ledig plass',
       howToPlayTitle: 'Slik spiller du',
       howToPlayDescription: 'Raske instruksjoner før spillet starter',
       howToPlayReady: 'Vent til nok spillere har blitt med i lobbyen.',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -622,6 +622,8 @@ const ru = {
       spectatorsLabel: 'Зрители',
       spectatorsDisabled: 'Отключено',
       availableSlots: 'Свободные места',
+      waitingForPlayer: 'Ожидание игрока...',
+      openSlot: 'Свободное место',
       howToPlayTitle: 'Как играть',
       howToPlayDescription: 'Краткие инструкции перед началом игры',
       howToPlayReady: 'Дождитесь, пока в лобби присоединится достаточно игроков.',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -624,6 +624,8 @@ const uk: Translation = {
       spectatorsLabel: 'Глядачі',
       spectatorsDisabled: 'Вимкнено',
       availableSlots: 'Вільні місця',
+      waitingForPlayer: 'Очікування гравця...',
+      openSlot: 'Вільне місце',
       howToPlayTitle: 'Як грати',
       howToPlayDescription: 'Короткі інструкції перед початком гри',
       howToPlayReady: 'Дочекайтесь, поки до лобі приєднається достатньо гравців.',


### PR DESCRIPTION
## Summary
- Removed **'How to Play'** section from WaitingRoom (irrelevant once you've joined the lobby)
- Removed **duplicate occupancy bar** (already visible in LobbyInfo stats grid)
- Merged the separate status card + player list into **one unified Players section** with inline status badge
- Added **empty slot rows** (dashed) for visual context — distinguishes "waiting for required player" vs "open optional slot"
- Removed **'Game Type' info card** from LobbyInfo (redundant with breadcrumb navigation immediately above it)
- Stats grid reduced from 4 columns to 3 (Players / Turn Timer / Spectators)
- Added `game.ui.waitingForPlayer` and `game.ui.openSlot` locale keys across en/ru/uk/no

## Result
- 3 sections → 2 sections in WaitingRoom
- 4 stats cards → 3 in LobbyInfo
- Cleaner information hierarchy with no duplicated data

## Test plan
- [ ] Waiting room shows correct player count and status badge
- [ ] Empty slots render correctly (dashed rows)
- [ ] LobbyInfo shows 3 cards (Players / Turn Timer / Spectators), no Game Type card
- [ ] Host can still edit settings via clicking cards
- [ ] All 4 locales show correct new strings

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)