### PR TITLE
feat(seo): internal linking, games showcase, breadcrumb schema

### DIFF
--- a/app/games/memory/page.tsx
+++ b/app/games/memory/page.tsx
@@ -32,6 +32,16 @@ export const metadata: Metadata = {
   },
 }
 
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Memory', item: 'https://www.boardly.online/games/memory' },
+  ],
+}
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'VideoGame',
@@ -68,8 +78,21 @@ export default function MemoryPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
       <div className="min-h-screen bg-gradient-to-br from-green-400 via-teal-500 to-cyan-600">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/games" className="hover:text-white transition-colors">Games</Link>
+            <span>/</span>
+            <span className="text-white">Memory</span>
+          </nav>
 
           {/* Hero */}
           <div className="text-center mb-16">

--- a/app/games/spy/page.tsx
+++ b/app/games/spy/page.tsx
@@ -32,6 +32,16 @@ export const metadata: Metadata = {
   },
 }
 
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Guess the Spy', item: 'https://www.boardly.online/games/spy' },
+  ],
+}
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'VideoGame',
@@ -68,8 +78,21 @@ export default function SpyPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
       <div className="min-h-screen bg-gradient-to-br from-red-500 via-pink-600 to-purple-700">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/games" className="hover:text-white transition-colors">Games</Link>
+            <span>/</span>
+            <span className="text-white">Guess the Spy</span>
+          </nav>
 
           {/* Hero */}
           <div className="text-center mb-16">

--- a/app/games/tic-tac-toe/page.tsx
+++ b/app/games/tic-tac-toe/page.tsx
@@ -32,6 +32,16 @@ export const metadata: Metadata = {
   },
 }
 
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Tic Tac Toe', item: 'https://www.boardly.online/games/tic-tac-toe' },
+  ],
+}
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'VideoGame',
@@ -68,8 +78,21 @@ export default function TicTacToePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
       <div className="min-h-screen bg-gradient-to-br from-yellow-400 via-orange-500 to-red-500">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/games" className="hover:text-white transition-colors">Games</Link>
+            <span>/</span>
+            <span className="text-white">Tic Tac Toe</span>
+          </nav>
 
           {/* Hero */}
           <div className="text-center mb-16">

--- a/app/games/yahtzee/page.tsx
+++ b/app/games/yahtzee/page.tsx
@@ -32,6 +32,16 @@ export const metadata: Metadata = {
   },
 }
 
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Yahtzee', item: 'https://www.boardly.online/games/yahtzee' },
+  ],
+}
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'VideoGame',
@@ -68,8 +78,21 @@ export default function YahtzeePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
       <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/games" className="hover:text-white transition-colors">Games</Link>
+            <span>/</span>
+            <span className="text-white">Yahtzee</span>
+          </nav>
 
           {/* Hero */}
           <div className="text-center mb-16">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import AnimatedSection from '@/components/ui/AnimatedSection'
 import FeaturesGrid from '@/components/HomePage/FeaturesGrid'
 import HowItWorks from '@/components/HomePage/HowItWorks'
 import FaqSection from '@/components/HomePage/FaqSection'
+import GamesShowcase from '@/components/HomePage/GamesShowcase'
 
 // Keep home page fully static for fast global TTFB.
 export const dynamic = 'force-static'
@@ -36,6 +37,10 @@ export default function HomePage() {
           <AnimatedSection className="mb-8" threshold={0.4}>
             <HowItWorks />
           </AnimatedSection>
+        </div>
+        {/* Games Showcase - Static server component with links to game pages */}
+        <div className="mb-8">
+          <GamesShowcase />
         </div>
         {/* FAQ - Static server component for SEO */}
         <div className="mb-8">

--- a/components/HomePage/GamesShowcase.tsx
+++ b/components/HomePage/GamesShowcase.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link'
+
+const games = [
+  {
+    emoji: '🎲',
+    name: 'Yahtzee',
+    description: 'Roll dice, score combinations, beat your friends.',
+    players: '1–4 players',
+    href: '/games/yahtzee',
+    color: 'from-blue-500 to-purple-600',
+  },
+  {
+    emoji: '❌',
+    name: 'Tic Tac Toe',
+    description: 'Classic 3×3 strategy. Match mode available.',
+    players: '2 players',
+    href: '/games/tic-tac-toe',
+    color: 'from-yellow-400 to-orange-500',
+  },
+  {
+    emoji: '🧠',
+    name: 'Memory',
+    description: 'Flip cards, find pairs. Three difficulty levels.',
+    players: '2–4 players',
+    href: '/games/memory',
+    color: 'from-green-400 to-teal-500',
+  },
+  {
+    emoji: '🕵️',
+    name: 'Guess the Spy',
+    description: 'One spy, one secret location. Can you find them?',
+    players: '3–10 players',
+    href: '/games/spy',
+    color: 'from-red-500 to-pink-600',
+  },
+]
+
+export default function GamesShowcase() {
+  return (
+    <div className="bg-white/10 backdrop-blur-md rounded-3xl p-6 md:p-8 text-white">
+      <h2 className="text-3xl md:text-4xl font-bold text-center mb-2">
+        Play Now — Free
+      </h2>
+      <p className="text-white/70 text-center mb-8 text-sm">
+        No download. No account required.
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        {games.map(({ emoji, name, description, players, href, color }) => (
+          <Link
+            key={href}
+            href={href}
+            className="group flex flex-col bg-white/10 hover:bg-white/20 rounded-2xl p-5 transition-all duration-300 hover:scale-105"
+          >
+            <div className={`inline-flex items-center justify-center w-14 h-14 rounded-xl bg-gradient-to-br ${color} mb-4 shadow-lg`}>
+              <span className="text-3xl">{emoji}</span>
+            </div>
+            <h3 className="font-bold text-lg mb-1">{name}</h3>
+            <p className="text-white/70 text-sm flex-grow mb-3">{description}</p>
+            <span className="text-white/50 text-xs">{players}</span>
+          </Link>
+        ))}
+      </div>
+      <div className="text-center">
+        <Link
+          href="/games"
+          className="inline-block px-6 py-3 bg-white/20 hover:bg-white/30 rounded-xl text-sm font-semibold transition-all duration-300"
+        >
+          Browse all games →
+        </Link>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `GamesShowcase` server component on home page — 4 cards with direct `<Link>` to each game landing page (`/games/yahtzee`, `/games/tic-tac-toe`, `/games/memory`, `/games/spy`). Fixes orphaned pages with no inbound internal links.
- Add `BreadcrumbList` JSON-LD schema to all 4 game pages — enables breadcrumb rich snippets in Google (Home > Games > [Game])
- Add visual breadcrumb nav on each game page linking back to `/games`

## Why

Internal links were missing — game landing pages from the previous PR had no inbound links from the site, so Google gave them lower crawl priority. This also improves user navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)