### PR TITLE
fix(#265): remove chess and uno from GameType enum

### DIFF
--- a/app/api/user/games/route.ts
+++ b/app/api/user/games/route.ts
@@ -14,7 +14,7 @@ export const dynamic = 'force-dynamic'
  * Returns user's game history with filters
  * Query params: 
  *   - status: waiting | playing | finished | abandoned | cancelled (optional)
- *   - gameType: yahtzee | tic_tac_toe | rock_paper_scissors | memory | chess | guess_the_spy | uno | other (optional)
+ *   - gameType: yahtzee | tic_tac_toe | rock_paper_scissors | memory | guess_the_spy | other (optional)
  *   - limit: number of games to return (default 50)
  *   - offset: pagination offset (default 0)
  */

--- a/components/GameHistory.tsx
+++ b/components/GameHistory.tsx
@@ -20,12 +20,10 @@ const GAME_HISTORY_STATUS_KEYS = {
 const GAME_TYPE_FILTER_OPTIONS = [
   'all',
   'yahtzee',
-  'chess',
   'guess_the_spy',
   'tic_tac_toe',
   'rock_paper_scissors',
   'memory',
-  'uno',
 ] as const
 
 const STATUS_FILTER_OPTIONS = [

--- a/lib/bots/core/bot-helpers.ts
+++ b/lib/bots/core/bot-helpers.ts
@@ -52,9 +52,7 @@ export function botSupportsGame(botType: string | null, gameType: string): boole
         'tic_tac_toe': ['tic_tac_toe'],
         'rock_paper_scissors': ['rock_paper_scissors'],
         'spy': ['guess_the_spy'],
-        'uno': ['uno'],
-        'chess': ['chess'],
-        'generic': ['yahtzee', 'tic_tac_toe', 'rock_paper_scissors', 'guess_the_spy', 'uno', 'chess'] // Generic bots support all games
+        'generic': ['yahtzee', 'tic_tac_toe', 'rock_paper_scissors', 'guess_the_spy'] // Generic bots support all games
     }
 
     return supportMap[botType]?.includes(gameType) ?? false

--- a/lib/game-display.ts
+++ b/lib/game-display.ts
@@ -2,8 +2,6 @@ export function formatGameTypeLabel(gameType: string): string {
   switch (gameType) {
     case 'yahtzee':
       return 'Yahtzee'
-    case 'chess':
-      return 'Chess'
     case 'guess_the_spy':
       return 'Guess the Spy'
     case 'tic_tac_toe':
@@ -12,8 +10,6 @@ export function formatGameTypeLabel(gameType: string): string {
       return 'Rock Paper Scissors'
     case 'memory':
       return 'Memory'
-    case 'uno':
-      return 'Uno'
     default:
       return gameType
   }

--- a/lib/game-type-storage.ts
+++ b/lib/game-type-storage.ts
@@ -5,13 +5,11 @@ const PERSISTED_GAME_TYPES = new Set<PrismaGameType>([
   'tic_tac_toe',
   'rock_paper_scissors',
   'memory',
-  'chess',
   'guess_the_spy',
   'telephone_doodle',
   'sketch_and_guess',
   'liars_party',
   'fake_artist',
-  'uno',
   'other',
 ])
 

--- a/prisma/migrations/20260325120000_remove_chess_uno_from_gametype/migration.sql
+++ b/prisma/migrations/20260325120000_remove_chess_uno_from_gametype/migration.sql
@@ -1,0 +1,32 @@
+-- RemoveEnumValues: chess and uno from GameType
+-- Reassign any existing rows (should be zero, but safe for any legacy data)
+UPDATE "Games" SET "gameType" = 'other' WHERE "gameType" IN ('chess', 'uno');
+
+-- Drop default before altering column type (required by PostgreSQL)
+ALTER TABLE "Games" ALTER COLUMN "gameType" DROP DEFAULT;
+
+-- PostgreSQL does not support DROP VALUE from enum directly.
+-- Standard approach: create new enum, alter column, swap.
+CREATE TYPE "GameType_new" AS ENUM (
+  'yahtzee',
+  'tic_tac_toe',
+  'rock_paper_scissors',
+  'memory',
+  'guess_the_spy',
+  'telephone_doodle',
+  'sketch_and_guess',
+  'liars_party',
+  'fake_artist',
+  'other'
+);
+
+ALTER TABLE "Games"
+  ALTER COLUMN "gameType" TYPE "GameType_new"
+  USING "gameType"::text::"GameType_new";
+
+-- Restore default with new type
+ALTER TABLE "Games"
+  ALTER COLUMN "gameType" SET DEFAULT 'yahtzee'::"GameType_new";
+
+DROP TYPE "GameType";
+ALTER TYPE "GameType_new" RENAME TO "GameType";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,7 +76,7 @@ model Bots {
   id         String   @id @default(cuid())
   userId     String   @unique
   user       Users    @relation(fields: [userId], references: [id], onDelete: Cascade)
-  botType    String   @default("yahtzee") // Game type: "yahtzee", "chess", "spy"
+  botType    String   @default("yahtzee") // Game type: "yahtzee", "spy", etc.
   difficulty String   @default("medium") // Difficulty level: "easy", "medium", "hard"
   createdAt  DateTime @default(now()) @db.Timestamptz(3)
 
@@ -245,13 +245,11 @@ enum GameType {
   tic_tac_toe
   rock_paper_scissors
   memory
-  chess
   guess_the_spy
   telephone_doodle
   sketch_and_guess
   liars_party
   fake_artist
-  uno
   other
 }
 


### PR DESCRIPTION
## Summary
`chess` and `uno` existed in the DB `GameType` enum and various code references but had zero engine or lobby implementation — causing noise in analytics, filter dropdowns, and developer confusion.

## Changes
- **Migration** `20260325120000_remove_chess_uno_from_gametype`: safely reassigns any legacy `chess`/`uno` rows to `other`, then swaps the enum via the standard PostgreSQL `CREATE TYPE_new → ALTER → DROP → RENAME` pattern
- **`prisma/schema.prisma`**: removed `chess`, `uno` values from `GameType` enum
- **`lib/game-display.ts`**: removed `chess`/`uno` cases from `formatGameTypeLabel`
- **`lib/game-type-storage.ts`**: removed from `PERSISTED_GAME_TYPES` set
- **`lib/bots/core/bot-helpers.ts`**: removed `chess`/`uno` from bot `supportMap`
- **`components/GameHistory.tsx`**: removed from `GAME_TYPE_FILTER_OPTIONS` filter dropdown
- **`app/api/user/games/route.ts`**: updated JSDoc comment

## Test plan
- [x] Migration applied to Supabase successfully
- [x] Prisma client regenerated with no type errors
- [x] `npm run ci:quick` passes
- [ ] Game history filter no longer shows Chess / Uno options
- [ ] No broken references to removed enum values at runtime

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)