### PR TITLE
feat(seo): /guides content section with 3 long-tail articles

### DIFF
--- a/app/guides/best-free-multiplayer-browser-games/page.tsx
+++ b/app/guides/best-free-multiplayer-browser-games/page.tsx
@@ -1,0 +1,200 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Best Free Multiplayer Browser Games 2025 - No Download',
+  description:
+    'The best free multiplayer browser games you can play right now — no download, no account needed. Yahtzee, Tic Tac Toe, Memory, spy games and more. Play with friends instantly.',
+  keywords: [
+    'free multiplayer browser games',
+    'best online games no download',
+    'free online games with friends',
+    'multiplayer games no download',
+    'browser games 2025',
+    'free online board games',
+    'play games online with friends free',
+    'instant play browser games',
+  ],
+  openGraph: {
+    title: 'Best Free Multiplayer Browser Games 2025 | Boardly',
+    description: 'Top free browser games you can play with friends right now — no download, no account required.',
+    url: 'https://www.boardly.online/guides/best-free-multiplayer-browser-games',
+    type: 'article',
+  },
+  alternates: {
+    canonical: 'https://www.boardly.online/guides/best-free-multiplayer-browser-games',
+  },
+}
+
+const articleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'Best Free Multiplayer Browser Games in 2025 — No Download Required',
+  description: 'A curated list of the best free multiplayer games you can play in any browser with friends instantly.',
+  url: 'https://www.boardly.online/guides/best-free-multiplayer-browser-games',
+  image: 'https://www.boardly.online/opengraph-image',
+  datePublished: '2025-01-01',
+  dateModified: new Date().toISOString().split('T')[0],
+  author: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+}
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://www.boardly.online/guides' },
+    { '@type': 'ListItem', position: 3, name: 'Best Free Multiplayer Browser Games 2025', item: 'https://www.boardly.online/guides/best-free-multiplayer-browser-games' },
+  ],
+}
+
+const games = [
+  {
+    rank: 1,
+    emoji: '🎲',
+    name: 'Yahtzee',
+    players: '1–4 players',
+    href: '/games/yahtzee',
+    why: 'The ultimate turn-based dice game. Perfect for remote hangouts — you can chat while playing since there\'s no time pressure between turns. Supports AI bots to fill empty spots.',
+    best: 'Casual sessions, family game nights, anyone who likes strategy but wants to relax',
+  },
+  {
+    rank: 2,
+    emoji: '🕵️',
+    name: 'Guess the Spy',
+    players: '3–10 players',
+    href: '/games/spy',
+    why: 'The best party game for larger groups. No board needed, no pieces — just quick thinking and bluffing. Every round is different thanks to random location assignments.',
+    best: 'Game nights, friend groups of 4+, anyone who loves social deduction games like Among Us',
+  },
+  {
+    rank: 3,
+    emoji: '🧠',
+    name: 'Memory Card Game',
+    players: '2–4 players',
+    href: '/games/memory',
+    why: 'Deceptively competitive. Easy to teach anyone in 30 seconds, but the tension rises fast as the board clears. Three difficulty levels keep it interesting for all ages.',
+    best: 'Casual matches, playing with younger friends or family, short sessions',
+  },
+  {
+    rank: 4,
+    emoji: '❌',
+    name: 'Tic Tac Toe',
+    players: '2 players',
+    href: '/games/tic-tac-toe',
+    why: 'The classic for a reason. Best-of-3 and best-of-5 match modes make it surprisingly competitive. Quick to play, rematch ready in seconds.',
+    best: '1-on-1 challenges, killing 5 minutes, testing your reflexes against an AI',
+  },
+]
+
+export default function BestBrowserGamesGuide() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+
+      <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/guides" className="hover:text-white transition-colors">Guides</Link>
+            <span>/</span>
+            <span className="text-white">Best Free Multiplayer Browser Games</span>
+          </nav>
+
+          {/* Header */}
+          <header className="mb-12">
+            <div className="text-6xl mb-4">🎮</div>
+            <h1 className="text-4xl md:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight">
+              Best Free Multiplayer Browser Games in 2025
+            </h1>
+            <p className="text-white/70 text-sm">4 min read · All games free on Boardly · No download required</p>
+          </header>
+
+          {/* Intro */}
+          <div className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <p className="text-white/90 leading-relaxed text-lg">
+              The best multiplayer games don&apos;t need a download, a subscription, or an account. They just need a browser and a friend. Here are the top free multiplayer games you can play right now — no setup, no waiting, just open the link and play.
+            </p>
+          </div>
+
+          {/* What to look for */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">What Makes a Great Browser Multiplayer Game?</h2>
+            <ul className="space-y-2 text-white/85 text-sm">
+              <li>✅ <strong>Zero setup</strong> — works the moment you open it</li>
+              <li>✅ <strong>Easy to share</strong> — one link gets your friends in</li>
+              <li>✅ <strong>Short sessions</strong> — rounds that fit in 5–15 minutes</li>
+              <li>✅ <strong>No skill barrier</strong> — anyone can join and have fun immediately</li>
+              <li>✅ <strong>Real-time or async</strong> — plays well with remote friends</li>
+            </ul>
+          </section>
+
+          {/* Games list */}
+          <section className="space-y-6 mb-12">
+            <h2 className="text-2xl font-bold text-white">The Best Games Available Right Now</h2>
+            {games.map(({ rank, emoji, name, players, href, why, best }) => (
+              <div key={name} className="bg-white/10 backdrop-blur-md rounded-3xl p-6 text-white">
+                <div className="flex items-start gap-4 mb-4">
+                  <span className="flex-shrink-0 w-10 h-10 rounded-full bg-white/20 flex items-center justify-center font-bold">
+                    {rank}
+                  </span>
+                  <div className="flex-grow">
+                    <div className="flex items-center gap-3 mb-1">
+                      <span className="text-2xl">{emoji}</span>
+                      <h3 className="text-xl font-bold">{name}</h3>
+                      <span className="text-white/50 text-xs">{players}</span>
+                    </div>
+                  </div>
+                </div>
+                <p className="text-white/80 text-sm mb-3 leading-relaxed">{why}</p>
+                <p className="text-white/55 text-xs mb-4"><strong className="text-white/70">Best for:</strong> {best}</p>
+                <Link
+                  href={href}
+                  className="inline-block px-5 py-2.5 bg-white/20 hover:bg-white/30 rounded-xl text-sm font-semibold transition-all duration-300"
+                >
+                  Play {name} →
+                </Link>
+              </div>
+            ))}
+          </section>
+
+          {/* Why browser games */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Why Browser Games Beat App Downloads</h2>
+            <p className="text-white/85 leading-relaxed mb-4">
+              Convincing a group of friends to all download the same app is surprisingly hard. Someone&apos;s phone is full, someone else can&apos;t find it in their country&apos;s store, and one person is always on a work laptop with no admin rights.
+            </p>
+            <p className="text-white/85 leading-relaxed">
+              Browser games solve all of this. You send one link, everyone opens it, and you&apos;re all in the same game within 30 seconds. No installs, no updates, no friction — just play.
+            </p>
+          </section>
+
+          {/* CTA */}
+          <div className="text-center">
+            <Link
+              href="/games"
+              className="inline-block px-10 py-4 bg-white text-blue-600 rounded-2xl font-bold text-lg hover:bg-blue-50 transition-all duration-300 shadow-xl hover:scale-105"
+            >
+              Browse All Games →
+            </Link>
+            <p className="text-white/50 text-sm mt-3">All games free · No account required</p>
+          </div>
+
+          {/* Related */}
+          <div className="mt-12 pt-8 border-t border-white/20">
+            <h3 className="text-white/70 text-sm font-semibold mb-4 uppercase tracking-wide">More guides</h3>
+            <div className="flex flex-col gap-3">
+              <Link href="/guides/how-to-play-yahtzee-online" className="text-white hover:underline text-sm">→ How to Play Yahtzee Online with Friends</Link>
+              <Link href="/guides/how-to-play-spy-game-online" className="text-white hover:underline text-sm">→ How to Play Guess the Spy Online</Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/guides/how-to-play-spy-game-online/page.tsx
+++ b/app/guides/how-to-play-spy-game-online/page.tsx
@@ -1,0 +1,194 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'How to Play Guess the Spy Online - Rules & Strategy Guide',
+  description:
+    'Learn how to play Guess the Spy (Spyfall) online. Rules explained, tips for finding the spy, how to survive as the spy, and how to run the perfect game night.',
+  keywords: [
+    'how to play guess the spy',
+    'spyfall rules',
+    'how to play spy game online',
+    'spy game strategy',
+    'social deduction game guide',
+    'guess the spy tips',
+    'spyfall online guide',
+    'how to play spyfall',
+  ],
+  openGraph: {
+    title: 'How to Play Guess the Spy Online | Boardly',
+    description: 'Complete guide to Guess the Spy — rules, strategy for both sides, and tips for a great game night.',
+    url: 'https://www.boardly.online/guides/how-to-play-spy-game-online',
+    type: 'article',
+  },
+  alternates: {
+    canonical: 'https://www.boardly.online/guides/how-to-play-spy-game-online',
+  },
+}
+
+const articleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to Play Guess the Spy Online — Rules & Strategy Guide',
+  description: 'Complete guide to the social deduction game Guess the Spy — rules, tips for both sides, and how to host a great game.',
+  url: 'https://www.boardly.online/guides/how-to-play-spy-game-online',
+  image: 'https://www.boardly.online/opengraph-image',
+  datePublished: '2025-01-01',
+  dateModified: new Date().toISOString().split('T')[0],
+  author: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+}
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://www.boardly.online/guides' },
+    { '@type': 'ListItem', position: 3, name: 'How to Play Guess the Spy Online', item: 'https://www.boardly.online/guides/how-to-play-spy-game-online' },
+  ],
+}
+
+export default function HowToPlaySpyGuide() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+
+      <div className="min-h-screen bg-gradient-to-br from-red-500 via-pink-600 to-purple-700">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/guides" className="hover:text-white transition-colors">Guides</Link>
+            <span>/</span>
+            <span className="text-white">How to Play Guess the Spy</span>
+          </nav>
+
+          {/* Header */}
+          <header className="mb-12">
+            <div className="text-6xl mb-4">🕵️</div>
+            <h1 className="text-4xl md:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight">
+              How to Play Guess the Spy Online
+            </h1>
+            <p className="text-white/70 text-sm">4 min read · Free to play on Boardly · 3–10 players</p>
+          </header>
+
+          {/* Intro */}
+          <div className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <p className="text-white/90 leading-relaxed text-lg">
+              Guess the Spy is a social deduction party game where one player (the spy) has no idea where everyone else is. The group asks clever questions to expose the spy, while the spy bluffs to survive and guess the location. It&apos;s one of the best online party games for groups of friends — no board needed, just sharp thinking and poker faces.
+            </p>
+          </div>
+
+          {/* Setup */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Game Setup</h2>
+            <ul className="space-y-2 text-white/85">
+              <li>👥 <strong>3–10 players</strong> — works great at any size in this range</li>
+              <li>🕐 <strong>~5–8 minutes per round</strong></li>
+              <li>🌍 <strong>One secret location</strong> per round (e.g. Beach, Hospital, Space Station)</li>
+              <li>🕵️ <strong>One spy</strong> — randomly assigned, hidden from other players</li>
+            </ul>
+          </section>
+
+          {/* Rules */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-6">How a Round Works</h2>
+            <ol className="space-y-5">
+              {[
+                {
+                  step: '1',
+                  title: 'Roles are secretly assigned',
+                  detail: 'All players except the spy are shown the secret location (e.g. "Train Station"). The spy only sees "You are the spy" — they have no idea where everyone is.',
+                },
+                {
+                  step: '2',
+                  title: 'Questioning phase begins',
+                  detail: 'Players take turns asking each other one question about the location. Keep questions vague enough to not give away the location to the spy, but specific enough to prove you know it.',
+                },
+                {
+                  step: '3',
+                  title: 'Anyone can call a vote',
+                  detail: 'At any time, a player can call a vote to accuse someone of being the spy. If the majority agrees, the accused is revealed. Accusing the wrong person loses the round for the group.',
+                },
+                {
+                  step: '4',
+                  title: 'The spy can guess the location',
+                  detail: 'Before being voted out, the spy can declare "I know the location!" and make a guess. A correct guess wins the round for the spy — even if they were about to be exposed.',
+                },
+              ].map(({ step, title, detail }) => (
+                <li key={step} className="flex gap-4">
+                  <span className="flex-shrink-0 w-8 h-8 rounded-full bg-white/20 flex items-center justify-center font-bold text-sm">{step}</span>
+                  <div>
+                    <strong className="block mb-1">{title}</strong>
+                    <p className="text-white/75 text-sm">{detail}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          {/* Tips for innocents */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Tips for Innocents — How to Find the Spy</h2>
+            <ul className="space-y-4">
+              {[
+                { tip: 'Ask specific-but-not-obvious questions', detail: 'At a beach: "How crowded is it?" is specific enough to test the spy but doesn\'t reveal the location outright. Avoid "What do you smell?"  — too easy to bluff.' },
+                { tip: 'Watch hesitation and vagueness', detail: 'Innocents answer quickly and naturally. Spies pause, use hedging words like "maybe" or "it depends," and often give oddly short answers.' },
+                { tip: 'Don\'t rush the vote', detail: 'The spy wants you to vote incorrectly. Let the questioning reveal patterns before committing to a vote — a wrong vote is a loss.' },
+                { tip: 'Cross-reference answers', detail: 'If two innocents give consistent answers about the same location detail and a third gives something contradictory — that\'s your spy.' },
+              ].map(({ tip, detail }) => (
+                <li key={tip} className="border-b border-white/10 pb-4 last:border-0 last:pb-0">
+                  <strong className="block mb-1">🔍 {tip}</strong>
+                  <p className="text-white/75 text-sm">{detail}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Tips for spy */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Tips for the Spy — How to Survive</h2>
+            <ul className="space-y-4">
+              {[
+                { tip: 'Give confident, vague answers', detail: 'The worst thing you can do is sound unsure. Be assertive — pick a direction and commit. "It\'s always busier than people expect" works for many locations.' },
+                { tip: 'Eliminate locations fast', detail: 'Listen closely to others\' questions and answers — they\'re leaking information about the location. By round 3–4, you should be narrowing down your guesses.' },
+                { tip: 'Accuse someone early', detail: 'Counterintuitive, but voting to accuse another player shifts suspicion away from you. Pick someone who\'s been quiet and call them out.' },
+                { tip: 'Know when to guess', detail: 'If the vote is swinging toward you and you have a strong guess, fire early. A correct location guess wins even if you\'re caught — it\'s your trump card.' },
+              ].map(({ tip, detail }) => (
+                <li key={tip} className="border-b border-white/10 pb-4 last:border-0 last:pb-0">
+                  <strong className="block mb-1">🎭 {tip}</strong>
+                  <p className="text-white/75 text-sm">{detail}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* CTA */}
+          <div className="text-center">
+            <p className="text-white/80 mb-4">Gather 3–10 friends and try it now.</p>
+            <Link
+              href="/lobby/create?gameType=guess_the_spy"
+              className="inline-block px-10 py-4 bg-white text-red-600 rounded-2xl font-bold text-lg hover:bg-red-50 transition-all duration-300 shadow-xl hover:scale-105"
+            >
+              Play Guess the Spy →
+            </Link>
+            <p className="text-white/50 text-sm mt-3">Free · No account required · 3–10 players</p>
+          </div>
+
+          {/* Related */}
+          <div className="mt-12 pt-8 border-t border-white/20">
+            <h3 className="text-white/70 text-sm font-semibold mb-4 uppercase tracking-wide">More guides</h3>
+            <div className="flex flex-col gap-3">
+              <Link href="/guides/how-to-play-yahtzee-online" className="text-white hover:underline text-sm">→ How to Play Yahtzee Online with Friends</Link>
+              <Link href="/guides/best-free-multiplayer-browser-games" className="text-white hover:underline text-sm">→ Best Free Multiplayer Browser Games in 2025</Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/guides/how-to-play-yahtzee-online/page.tsx
+++ b/app/guides/how-to-play-yahtzee-online/page.tsx
@@ -1,0 +1,196 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'How to Play Yahtzee Online with Friends - Complete Guide',
+  description:
+    'Learn how to play Yahtzee online step by step. Scoring categories explained, strategy tips for beginners and veterans, and how to start a multiplayer game instantly.',
+  keywords: [
+    'how to play yahtzee online',
+    'yahtzee rules',
+    'yahtzee scoring categories',
+    'yahtzee strategy',
+    'play yahtzee with friends online',
+    'yahtzee multiplayer guide',
+    'yahtzee for beginners',
+  ],
+  openGraph: {
+    title: 'How to Play Yahtzee Online with Friends | Boardly',
+    description: 'Complete Yahtzee guide — rules, scoring categories, strategy tips. Free multiplayer in your browser.',
+    url: 'https://www.boardly.online/guides/how-to-play-yahtzee-online',
+    type: 'article',
+  },
+  alternates: {
+    canonical: 'https://www.boardly.online/guides/how-to-play-yahtzee-online',
+  },
+}
+
+const articleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to Play Yahtzee Online with Friends — Complete Guide',
+  description: 'Step-by-step guide to playing Yahtzee online — rules, scoring, and strategy tips.',
+  url: 'https://www.boardly.online/guides/how-to-play-yahtzee-online',
+  image: 'https://www.boardly.online/opengraph-image',
+  datePublished: '2025-01-01',
+  dateModified: new Date().toISOString().split('T')[0],
+  author: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+}
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://www.boardly.online/guides' },
+    { '@type': 'ListItem', position: 3, name: 'How to Play Yahtzee Online', item: 'https://www.boardly.online/guides/how-to-play-yahtzee-online' },
+  ],
+}
+
+export default function HowToPlayYahtzeeGuide() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+
+      <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/guides" className="hover:text-white transition-colors">Guides</Link>
+            <span>/</span>
+            <span className="text-white">How to Play Yahtzee Online</span>
+          </nav>
+
+          {/* Header */}
+          <header className="mb-12">
+            <div className="text-6xl mb-4">🎲</div>
+            <h1 className="text-4xl md:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight">
+              How to Play Yahtzee Online with Friends
+            </h1>
+            <p className="text-white/70 text-sm">5 min read · Free to play on Boardly</p>
+          </header>
+
+          {/* Intro */}
+          <div className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <p className="text-white/90 leading-relaxed text-lg">
+              Yahtzee is one of the most popular dice games in the world — and on Boardly, you can play it online with friends in real-time, completely free. This guide covers everything you need to know: the rules, all 13 scoring categories, and tips to improve your strategy.
+            </p>
+          </div>
+
+          {/* What you need */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">What You Need</h2>
+            <ul className="space-y-2 text-white/85">
+              <li>✅ 1–4 players (play solo against AI or with friends)</li>
+              <li>✅ A browser — desktop, tablet, or mobile</li>
+              <li>✅ No account required (guest play available)</li>
+              <li>✅ Free — no ads, no download</li>
+            </ul>
+          </section>
+
+          {/* Basic rules */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">The Basic Rules</h2>
+            <p className="text-white/85 leading-relaxed mb-4">
+              Each turn, you roll five dice. You may re-roll any or all of them up to two more times (three rolls total). After your rolls, you must assign your result to one of 13 scoring categories. Once a category is filled, it cannot be changed. The game ends when all 13 categories are filled by every player.
+            </p>
+            <p className="text-white/85 leading-relaxed">
+              The player with the highest total score wins. A bonus of 35 points is awarded if your upper section score (Aces through Sixes) totals 63 or more.
+            </p>
+          </section>
+
+          {/* Scoring categories */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-6">All 13 Scoring Categories</h2>
+
+            <h3 className="text-lg font-semibold mb-3 text-white/90">Upper Section</h3>
+            <div className="space-y-3 mb-6">
+              {[
+                { name: 'Aces (1s)', desc: 'Sum of all dice showing 1', example: '1+1+3+4+6 = 2 pts' },
+                { name: 'Twos (2s)', desc: 'Sum of all dice showing 2', example: '2+2+2+4+6 = 6 pts' },
+                { name: 'Threes (3s)', desc: 'Sum of all dice showing 3', example: '3+3+3+4+6 = 9 pts' },
+                { name: 'Fours (4s)', desc: 'Sum of all dice showing 4', example: '4+4+4+4+6 = 16 pts' },
+                { name: 'Fives (5s)', desc: 'Sum of all dice showing 5', example: '5+5+5+5+6 = 20 pts' },
+                { name: 'Sixes (6s)', desc: 'Sum of all dice showing 6', example: '6+6+6+6+6 = 30 pts' },
+              ].map(({ name, desc, example }) => (
+                <div key={name} className="flex justify-between gap-4 border-b border-white/10 pb-3 last:border-0 last:pb-0">
+                  <div>
+                    <strong className="text-sm">{name}</strong>
+                    <p className="text-white/65 text-xs">{desc}</p>
+                  </div>
+                  <span className="text-white/50 text-xs shrink-0 self-center">{example}</span>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-lg font-semibold mb-3 text-white/90">Lower Section</h3>
+            <div className="space-y-3">
+              {[
+                { name: 'Three of a Kind', desc: 'At least 3 identical dice — score is sum of all 5 dice', example: 'e.g. 3+3+3+5+6 = 20 pts' },
+                { name: 'Four of a Kind', desc: 'At least 4 identical dice — score is sum of all 5 dice', example: 'e.g. 4+4+4+4+2 = 18 pts' },
+                { name: 'Full House', desc: 'Three of one number + two of another', example: '25 pts fixed' },
+                { name: 'Small Straight', desc: 'Four sequential dice (e.g. 1-2-3-4 or 3-4-5-6)', example: '30 pts fixed' },
+                { name: 'Large Straight', desc: 'Five sequential dice (1-2-3-4-5 or 2-3-4-5-6)', example: '40 pts fixed' },
+                { name: 'Yahtzee!', desc: 'All five dice the same', example: '50 pts (100 bonus for extra)' },
+                { name: 'Chance', desc: 'Any combination — score is sum of all 5 dice', example: 'Useful as a dump' },
+              ].map(({ name, desc, example }) => (
+                <div key={name} className="flex justify-between gap-4 border-b border-white/10 pb-3 last:border-0 last:pb-0">
+                  <div>
+                    <strong className="text-sm">{name}</strong>
+                    <p className="text-white/65 text-xs">{desc}</p>
+                  </div>
+                  <span className="text-white/50 text-xs shrink-0 self-center">{example}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Strategy tips */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Strategy Tips</h2>
+            <ul className="space-y-4">
+              {[
+                { tip: 'Chase the upper section bonus', detail: 'Aim for at least 3 of each number in the upper section — that gets you to 63 points and the 35-point bonus, which is huge.' },
+                { tip: 'Keep Yahtzee attempts alive', detail: 'If you have 3 or 4 of the same number on your first roll, it\'s usually worth going for the Yahtzee rather than settling for three-of-a-kind.' },
+                { tip: 'Use Chance as a last resort', detail: 'Chance scores the sum of all dice — save it for turns where nothing else fits. A good Chance score is usually 20+.' },
+                { tip: 'Fill low-value categories early', detail: 'If you roll a bad set and have already filled high-value categories, put zeros in Aces or Twos early — they\'re worth little anyway.' },
+                { tip: 'Prioritize Large Straight over Small', detail: 'Large Straight scores 40 vs 30 for Small. If you have 4 sequential dice after roll 1, go for the large.' },
+              ].map(({ tip, detail }) => (
+                <li key={tip} className="border-b border-white/10 pb-4 last:border-0 last:pb-0">
+                  <strong className="block mb-1">💡 {tip}</strong>
+                  <p className="text-white/75 text-sm">{detail}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* CTA */}
+          <div className="text-center">
+            <p className="text-white/80 mb-4">Ready to put this into practice?</p>
+            <Link
+              href="/lobby/create?gameType=yahtzee"
+              className="inline-block px-10 py-4 bg-white text-blue-600 rounded-2xl font-bold text-lg hover:bg-blue-50 transition-all duration-300 shadow-xl hover:scale-105"
+            >
+              Play Yahtzee Now →
+            </Link>
+            <p className="text-white/50 text-sm mt-3">Free · No account required · 1–4 players</p>
+          </div>
+
+          {/* Related */}
+          <div className="mt-12 pt-8 border-t border-white/20">
+            <h3 className="text-white/70 text-sm font-semibold mb-4 uppercase tracking-wide">More guides</h3>
+            <div className="flex flex-col gap-3">
+              <Link href="/guides/how-to-play-spy-game-online" className="text-white hover:underline text-sm">→ How to Play Guess the Spy Online</Link>
+              <Link href="/guides/best-free-multiplayer-browser-games" className="text-white hover:underline text-sm">→ Best Free Multiplayer Browser Games in 2025</Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Board Game Guides & Tips - How to Play Online',
+  description:
+    'Learn how to play popular board games online. Step-by-step guides for Yahtzee, Spy, Memory, Tic Tac Toe and more. Free multiplayer games in your browser.',
+  openGraph: {
+    title: 'Board Game Guides & Tips | Boardly',
+    description: 'Step-by-step guides for playing board games online with friends.',
+    url: 'https://www.boardly.online/guides',
+    type: 'website',
+  },
+  alternates: {
+    canonical: 'https://www.boardly.online/guides',
+  },
+}
+
+const guides = [
+  {
+    slug: 'how-to-play-yahtzee-online',
+    title: 'How to Play Yahtzee Online with Friends',
+    description: 'Complete guide to playing Yahtzee online — scoring categories, strategy tips, and how to set up a multiplayer game.',
+    emoji: '🎲',
+    readTime: '5 min read',
+  },
+  {
+    slug: 'best-free-multiplayer-browser-games',
+    title: 'Best Free Multiplayer Browser Games in 2025',
+    description: 'No download, no payment. The best multiplayer games you can play right now in any browser with friends.',
+    emoji: '🎮',
+    readTime: '4 min read',
+  },
+  {
+    slug: 'how-to-play-spy-game-online',
+    title: 'How to Play Guess the Spy Online',
+    description: 'Master the social deduction game — tips for finding the spy, bluffing as the spy, and running a great game night.',
+    emoji: '🕵️',
+    readTime: '4 min read',
+  },
+]
+
+export default function GuidesPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+
+        {/* Breadcrumb */}
+        <nav className="mb-8 text-white/60 text-sm flex items-center gap-2" aria-label="Breadcrumb">
+          <Link href="/" className="hover:text-white transition-colors">Home</Link>
+          <span>/</span>
+          <span className="text-white">Guides</span>
+        </nav>
+
+        <div className="text-center mb-12">
+          <h1 className="text-5xl md:text-6xl font-extrabold text-white mb-4 drop-shadow-lg">
+            Guides
+          </h1>
+          <p className="text-xl text-white/90 max-w-2xl mx-auto">
+            How to play, strategy tips, and everything you need to win.
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          {guides.map(({ slug, title, description, emoji, readTime }) => (
+            <Link
+              key={slug}
+              href={`/guides/${slug}`}
+              className="group flex gap-5 bg-white/10 hover:bg-white/20 backdrop-blur-md rounded-2xl p-6 text-white transition-all duration-300 hover:scale-[1.01]"
+            >
+              <div className="flex-shrink-0 w-14 h-14 rounded-xl bg-white/20 flex items-center justify-center text-3xl">
+                {emoji}
+              </div>
+              <div className="flex-grow">
+                <h2 className="text-xl font-bold mb-1 group-hover:underline">{title}</h2>
+                <p className="text-white/70 text-sm mb-2">{description}</p>
+                <span className="text-white/50 text-xs">{readTime}</span>
+              </div>
+              <div className="flex-shrink-0 self-center text-white/40 group-hover:text-white text-xl transition-colors">
+                →
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -41,6 +41,31 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.85,
     },
+    // Guides — long-tail content
+    {
+      url: `${baseUrl}/guides`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/guides/how-to-play-yahtzee-online`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/guides/how-to-play-spy-game-online`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.75,
+    },
+    {
+      url: `${baseUrl}/guides/best-free-multiplayer-browser-games`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.75,
+    },
     {
       url: `${baseUrl}/lobby`,
       lastModified: new Date(),


### PR DESCRIPTION
## Summary

Adds a `/guides` content section targeting long-tail search queries — users searching for how-to guides and game recommendations rather than just the game name.

### New pages

| URL | Target keywords |
|-----|----------------|
| `/guides` | board game guides, how to play online |
| `/guides/how-to-play-yahtzee-online` | how to play yahtzee online, yahtzee rules, yahtzee scoring |
| `/guides/how-to-play-spy-game-online` | how to play guess the spy, spyfall rules, spy game strategy |
| `/guides/best-free-multiplayer-browser-games` | free multiplayer browser games, online games no download |

### Each article includes
- Full Article + BreadcrumbList JSON-LD schema
- Unique metadata (title, description, keywords, canonical, OG)
- Substantive content (rules, strategy tips, comparisons) — not thin content
- Cross-links between articles and back to game landing pages
- CTA to play

### Sitemap
All 4 new pages added at priority 0.75–0.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)