### PR TITLE
fix(#263): persist last 50 lobby chat messages in Redis

### DIFF
--- a/app/api/lobby/[code]/chat/route.ts
+++ b/app/api/lobby/[code]/chat/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
+import { getRequestAuthUser } from '@/lib/request-auth'
+import { getChatHistory } from '@/lib/chat-history'
+
+const apiLimiter = rateLimit(rateLimitPresets.api)
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  const { code } = await params
+
+  if (!code || typeof code !== 'string') {
+    return NextResponse.json({ error: 'Invalid lobby code' }, { status: 400 })
+  }
+
+  const rateLimitResult = await apiLimiter(req)
+  if (rateLimitResult) return rateLimitResult
+
+  const user = await getRequestAuthUser(req)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Verify the user is a player in this lobby
+  const lobby = await prisma.lobbies.findUnique({
+    where: { code },
+    select: {
+      id: true,
+      games: {
+        where: { status: { in: ['waiting', 'playing'] } },
+        select: {
+          players: { where: { userId: user.id }, select: { id: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 1,
+      },
+    },
+  })
+
+  if (!lobby) {
+    return NextResponse.json({ error: 'Lobby not found' }, { status: 404 })
+  }
+
+  const isPlayer = lobby.games.some((g) => g.players.length > 0)
+  if (!isPlayer) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const messages = await getChatHistory(code)
+  return NextResponse.json({ messages })
+}

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -1132,6 +1132,40 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     }
   }, [status, isGuest, guestToken, code])
 
+  // Load chat history on initial connect (and re-load on reconnect)
+  const chatHistoryLoadedRef = React.useRef(false)
+  useEffect(() => {
+    if (!isConnected) return
+    if (status === 'loading') return
+    if (isGuest && !guestToken) return
+
+    // On reconnect, always reload; on first connect, only once
+    if (chatHistoryLoadedRef.current && !isReconnecting) return
+    chatHistoryLoadedRef.current = true
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (isGuest && guestId && guestToken) {
+      headers['X-Guest-Id'] = guestId
+      headers['X-Guest-Token'] = guestToken
+      if (username) headers['X-Guest-Name'] = username
+    }
+
+    fetch(`/api/lobby/${code}/chat`, { headers })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.messages && Array.isArray(data.messages) && data.messages.length > 0) {
+          setChatMessages((prev) => {
+            const existingIds = new Set(prev.map((m) => m.id))
+            const fresh = (data.messages as ChatMessagePayload[]).filter((m) => !existingIds.has(m.id))
+            return fresh.length > 0 ? [...fresh, ...prev] : prev
+          })
+        }
+      })
+      .catch(() => {
+        // non-critical; ignore
+      })
+  }, [isConnected, isReconnecting, status, isGuest, guestToken, guestId, username, code])
+
   // Handle bot overlay progression
   useEffect(() => {
     if (!showingBotOverlay || botMoveSteps.length === 0) return

--- a/lib/chat-history.ts
+++ b/lib/chat-history.ts
@@ -1,0 +1,124 @@
+/**
+ * Redis-backed lobby chat history.
+ * Stores the last 50 messages per lobby with a 24h TTL.
+ * Degrades gracefully to no-op when Redis is unavailable.
+ */
+
+import { logger } from './logger'
+
+const CHAT_KEY_PREFIX = 'chat:lobby:'
+const MAX_MESSAGES = 50
+const TTL_SECONDS = 24 * 60 * 60 // 24 hours
+
+interface ChatRedisClient {
+  lpush(key: string, ...values: string[]): Promise<unknown>
+  ltrim(key: string, start: number, stop: number): Promise<unknown>
+  expire(key: string, seconds: number): Promise<unknown>
+  lrange(key: string, start: number, stop: number): Promise<string[]>
+}
+
+interface UpstashRedisModule {
+  Redis: new (config: { url: string; token: string }) => ChatRedisClient
+}
+
+let _client: ChatRedisClient | null | undefined = undefined
+let _clientPromise: Promise<ChatRedisClient | null> | null = null
+
+async function getChatRedisClient(): Promise<ChatRedisClient | null> {
+  if (_client !== undefined) return _client
+
+  const url = process.env.UPSTASH_REDIS_REST_URL
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN
+
+  if (!url || !token) {
+    _client = null
+    return null
+  }
+
+  if (!_clientPromise) {
+    _clientPromise = import('@upstash/redis')
+      .then((mod) => {
+        const RedisConstructor = (mod as UpstashRedisModule).Redis
+        _client = new RedisConstructor({ url, token })
+        return _client
+      })
+      .catch((err) => {
+        logger.warn('chat-history: failed to init Redis client', {
+          error: err instanceof Error ? err.message : String(err),
+        })
+        _client = null
+        return null
+      })
+      .finally(() => {
+        _clientPromise = null
+      })
+  }
+
+  return _clientPromise
+}
+
+export interface StoredChatMessage {
+  id: string
+  userId: string
+  username: string
+  message: string
+  lobbyCode: string
+  timestamp?: number
+}
+
+function lobbyKey(lobbyCode: string): string {
+  return `${CHAT_KEY_PREFIX}${lobbyCode}`
+}
+
+/**
+ * Persist a chat message. Silently no-ops if Redis is unavailable.
+ */
+export async function persistChatMessage(msg: StoredChatMessage): Promise<void> {
+  const redis = await getChatRedisClient()
+  if (!redis) return
+
+  const key = lobbyKey(msg.lobbyCode)
+  const serialized = JSON.stringify({ ...msg, timestamp: msg.timestamp ?? Date.now() })
+
+  try {
+    // LPUSH so newest is at index 0, then trim to MAX_MESSAGES
+    await redis.lpush(key, serialized)
+    await redis.ltrim(key, 0, MAX_MESSAGES - 1)
+    await redis.expire(key, TTL_SECONDS)
+  } catch (err) {
+    logger.warn('chat-history: failed to persist message', {
+      lobbyCode: msg.lobbyCode,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+/**
+ * Fetch chat history for a lobby (newest-first from Redis → returned oldest-first).
+ * Returns empty array if Redis is unavailable or key doesn't exist.
+ */
+export async function getChatHistory(lobbyCode: string): Promise<StoredChatMessage[]> {
+  const redis = await getChatRedisClient()
+  if (!redis) return []
+
+  try {
+    const raw = await redis.lrange(lobbyKey(lobbyCode), 0, MAX_MESSAGES - 1)
+    // raw is newest-first; reverse to get chronological order
+    return raw
+      .map((s) => {
+        try {
+          return JSON.parse(s) as StoredChatMessage
+        } catch {
+          return null
+        }
+      })
+      .filter((m): m is StoredChatMessage => m !== null)
+      .reverse()
+  } catch (err) {
+    logger.warn('chat-history: failed to fetch history', {
+      lobbyCode,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return []
+  }
+}

--- a/lib/socket/handlers/send-chat-message.ts
+++ b/lib/socket/handlers/send-chat-message.ts
@@ -27,6 +27,14 @@ interface SendChatMessageDependencies {
   isUserActivePlayerInLobby: (lobbyCode: string, userId: string) => Promise<boolean>
   getUserDisplayName: (user: { username?: string | null; email?: string | null } | undefined) => string
   emitWithMetadata: (room: string, event: string, data: Record<string, unknown>) => void
+  persistChatMessage?: (msg: {
+    id: string
+    userId: string
+    username: string
+    message: string
+    lobbyCode: string
+    timestamp: number
+  }) => Promise<void>
 }
 
 export function createSendChatMessageHandler({
@@ -38,6 +46,7 @@ export function createSendChatMessageHandler({
   isUserActivePlayerInLobby,
   getUserDisplayName,
   emitWithMetadata,
+  persistChatMessage,
 }: SendChatMessageDependencies) {
   return async (socket: SendChatMessageSocket, data: SendChatMessagePayload) => {
     socketMonitor.trackEvent('send-chat-message')
@@ -79,14 +88,30 @@ export function createSendChatMessageHandler({
 
       const senderUserId = socket.data.user.id
       const senderUsername = getUserDisplayName(socket.data.user)
+      const messageId = randomUUID()
+      const timestamp = Date.now()
 
       emitWithMetadata(SocketRooms.lobby(normalizedLobbyCode), SocketEvents.CHAT_MESSAGE, {
-        id: randomUUID(),
+        id: messageId,
         userId: senderUserId,
         username: senderUsername,
         message: normalizedMessage,
         lobbyCode: normalizedLobbyCode,
+        timestamp,
       })
+
+      if (persistChatMessage) {
+        persistChatMessage({
+          id: messageId,
+          userId: senderUserId,
+          username: senderUsername,
+          message: normalizedMessage,
+          lobbyCode: normalizedLobbyCode,
+          timestamp,
+        }).catch(() => {
+          // fire-and-forget; don't fail the event if Redis is down
+        })
+      }
     } catch (error) {
       logger.error('Error handling chat message', error as Error, {
         socketId: socket.id,

--- a/socket-server.ts
+++ b/socket-server.ts
@@ -23,6 +23,7 @@ import { createDisconnectSyncManager } from './lib/socket/disconnect-sync'
 import { createJoinLobbyHandler } from './lib/socket/handlers/join-lobby'
 import { createGameActionHandler } from './lib/socket/handlers/game-action'
 import { createSendChatMessageHandler } from './lib/socket/handlers/send-chat-message'
+import { persistChatMessage } from './lib/chat-history'
 import { createPlayerTypingHandler } from './lib/socket/handlers/player-typing'
 import { createConnectionLifecycleHandlers } from './lib/socket/handlers/connection-lifecycle'
 import { createLeaveLobbyHandler } from './lib/socket/handlers/leave-lobby'
@@ -707,6 +708,7 @@ const handleSendChatMessage = createSendChatMessageHandler({
   emitWithMetadata: (room, event, data) => {
     emitWithMetadata(io, room, event, data)
   },
+  persistChatMessage,
 })
 
 const handlePlayerTyping = createPlayerTypingHandler({


### PR DESCRIPTION
## Summary

- Add `lib/chat-history.ts` backed by the existing Upstash Redis instance — LPUSH/LTRIM to 50 messages, 24h TTL; degrades to no-op when Redis is unavailable
- Inject `persistChatMessage` (fire-and-forget) into `send-chat-message` socket handler so each new message is stored
- Add `GET /api/lobby/[code]/chat` endpoint (auth-guarded, requires active player) to expose the backlog
- `LobbyPageClient` fetches history on first connect and re-fetches on every reconnect, prepending new-to-client messages without duplicates

## Test plan

- [x] `npm run ci:quick` — lint + typecheck clean
- [x] 47 jest smoke tests pass
- [ ] Manual: send a few messages, disconnect/reconnect, confirm history appears
- [ ] Manual: verify no crash when Upstash env vars are absent (graceful no-op)

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)