### PR TITLE
fix(#252): redesign Rock Paper Scissors UI and unlock lobbies page

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -79,7 +79,8 @@ export default function GamesPage() {
       descriptionKey: 'games.rock_paper_scissors.description',
       players: '2',
       difficultyKey: 'games.rock_paper_scissors.difficulty',
-      status: 'coming-soon',
+      status: 'available',
+      route: '/games/rock-paper-scissors/lobbies',
       color: 'from-indigo-400 to-purple-500'
     },
     {

--- a/app/games/rock-paper-scissors/lobbies/page.tsx
+++ b/app/games/rock-paper-scissors/lobbies/page.tsx
@@ -1,84 +1,322 @@
 'use client'
 
-import { useTranslation } from 'react-i18next'
-import Link from 'next/link'
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import { io, Socket } from 'socket.io-client'
+import { getBrowserSocketUrl } from '@/lib/socket-url'
+import { resolveSocketClientAuth } from '@/lib/socket-client-auth'
+import { clientLogger } from '@/lib/client-logger'
+import { useGuest } from '@/contexts/GuestContext'
+import { fetchWithGuest } from '@/lib/fetch-with-guest'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+let socket: Socket | null = null
+
+interface Lobby {
+  id: string
+  code: string
+  name: string
+  maxPlayers: number
+  gameType: string
+  creator: {
+    username: string | null
+    email: string | null
+  }
+  games: {
+    id: string
+    status: string
+    _count: {
+      players: number
+    }
+  }[]
+}
 
 export default function RockPaperScissorsLobbiesPage() {
-    const { t } = useTranslation()
+  const router = useRouter()
+  const { data: session, status } = useSession()
+  const { isGuest, guestToken } = useGuest()
+  const [lobbies, setLobbies] = useState<Lobby[]>([])
+  const [loading, setLoading] = useState(true)
+  const [joinCode, setJoinCode] = useState('')
+  const isAuthenticated = status === 'authenticated' || isGuest
 
+  const loadLobbies = useCallback(async () => {
+    try {
+      const res = await fetchWithGuest('/api/lobby?gameType=rock_paper_scissors')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setLobbies(data.lobbies || [])
+    } catch (err) {
+      clientLogger.error('Failed to load RPS lobbies:', err)
+      setLobbies([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (status === 'unauthenticated' && !isGuest) {
+      setLoading(false)
+      return
+    }
+    if (isGuest && !guestToken) return
+    if (status !== 'authenticated' && !isGuest) return
+
+    loadLobbies()
+    let isMounted = true
+
+    const refreshInterval = setInterval(() => {
+      loadLobbies()
+    }, 5000)
+
+    const initSocket = async () => {
+      if (socket) return
+      const url = getBrowserSocketUrl()
+      const useGuestAuth = isGuest && status !== 'authenticated'
+      const socketAuth = await resolveSocketClientAuth({
+        isGuest: useGuestAuth,
+        guestToken: useGuestAuth ? guestToken : null,
+      })
+      if (!socketAuth || !isMounted) return
+
+      socket = io(url, {
+        transports: ['websocket', 'polling'],
+        reconnection: true,
+        reconnectionAttempts: 10,
+        reconnectionDelay: 1000,
+        auth: socketAuth.authPayload,
+        query: socketAuth.queryPayload,
+      })
+      socket.on('connect', () => {
+        socket?.emit('join-lobby-list')
+      })
+      socket.on('lobby-list-update', () => {
+        loadLobbies()
+      })
+    }
+    void initSocket()
+
+    return () => {
+      isMounted = false
+      clearInterval(refreshInterval)
+      if (socket?.connected) {
+        socket.emit('leave-lobby-list')
+        socket.disconnect()
+      }
+      socket = null
+    }
+  }, [status, isGuest, guestToken, loadLobbies])
+
+  const handleJoinByCode = () => {
+    if (!isAuthenticated) {
+      router.push('/')
+      return
+    }
+    if (joinCode.length === 4) {
+      router.push(`/lobby/${joinCode.toUpperCase()}`)
+    }
+  }
+
+  const displayName = (lobby: Lobby) => {
+    const activeGame = lobby.games.find((g) => g.status === 'waiting' || g.status === 'playing')
+    const playerCount = activeGame?._count?.players ?? 0
+    return `${playerCount}/${lobby.maxPlayers} players`
+  }
+
+  const getStatusBadge = (lobby: Lobby) => {
+    const activeGame = lobby.games.find((g) => g.status === 'waiting' || g.status === 'playing')
+    if (!activeGame) return null
+    if (activeGame.status === 'playing') {
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:bg-rose-900/40 dark:text-rose-300">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-rose-500" /> In game
+        </span>
+      )
+    }
     return (
-        <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-4">
-            <div className="max-w-2xl mx-auto">
-                {/* Header */}
-                <div className="mb-8">
-                    <Link href="/games" className="text-blue-400 hover:text-blue-300 mb-4 inline-block">
-                        ← {t('nav.back')}
-                    </Link>
-                </div>
-
-                {/* Game Info Card */}
-                <div className="bg-gradient-to-br from-indigo-900 to-purple-900 rounded-2xl p-8 mb-8 border border-indigo-500/30">
-                    <h1 className="text-4xl font-bold text-white mb-4">
-                        🍂 {t('games.rock_paper_scissors.name')}
-                    </h1>
-                    <p className="text-gray-300 mb-6">
-                        {t('games.rock_paper_scissors.description')}
-                    </p>
-
-                    {/* Game Rules */}
-                    <div className="bg-slate-800/50 rounded-xl p-6 border border-indigo-500/20 mb-6">
-                        <h2 className="text-xl font-bold text-indigo-300 mb-4">{t('common.rules')}</h2>
-                        <ul className="space-y-3 text-gray-300">
-                            <li className="flex items-start gap-3">
-                                <span className="text-indigo-400 font-bold">•</span>
-                                <span>{t('games.rock_paper_scissors.rule_1')}</span>
-                            </li>
-                            <li className="flex items-start gap-3">
-                                <span className="text-indigo-400 font-bold">•</span>
-                                <span>{t('games.rock_paper_scissors.rule_2')}</span>
-                            </li>
-                            <li className="flex items-start gap-3">
-                                <span className="text-indigo-400 font-bold">•</span>
-                                <span>{t('games.rock_paper_scissors.rule_3')}</span>
-                            </li>
-                            <li className="flex items-start gap-3">
-                                <span className="text-indigo-400 font-bold">•</span>
-                                <span>{t('games.rock_paper_scissors.rule_4')}</span>
-                            </li>
-                            <li className="flex items-start gap-3">
-                                <span className="text-indigo-400 font-bold">•</span>
-                                <span>{t('games.rock_paper_scissors.rule_5')}</span>
-                            </li>
-                        </ul>
-                    </div>
-
-                    {/* Coming Soon */}
-                    <div className="bg-amber-900/30 border border-amber-500/50 rounded-lg p-4 text-center">
-                        <p className="text-amber-100">{t('common.coming_soon')}</p>
-                        <p className="text-amber-200 text-sm mt-2">{t('game.in_development')}</p>
-                    </div>
-                </div>
-
-                {/* Feature Highlights */}
-                <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-                    <div className="bg-slate-800 rounded-lg p-4 text-center border border-slate-700">
-                        <div className="text-3xl mb-2">⚡</div>
-                        <p className="text-sm text-gray-300">{t('games.rock_paper_scissors.feature_quick')}</p>
-                    </div>
-                    <div className="bg-slate-800 rounded-lg p-4 text-center border border-slate-700">
-                        <div className="text-3xl mb-2">👥</div>
-                        <p className="text-sm text-gray-300">{t('games.rock_paper_scissors.feature_players')}</p>
-                    </div>
-                    <div className="bg-slate-800 rounded-lg p-4 text-center border border-slate-700">
-                        <div className="text-3xl mb-2">🎯</div>
-                        <p className="text-sm text-gray-300">{t('games.rock_paper_scissors.feature_strategy')}</p>
-                    </div>
-                    <div className="bg-slate-800 rounded-lg p-4 text-center border border-slate-700">
-                        <div className="text-3xl mb-2">🚀</div>
-                        <p className="text-sm text-gray-300">{t('games.rock_paper_scissors.feature_instant')}</p>
-                    </div>
-                </div>
-            </div>
-        </div>
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" /> Open
+      </span>
     )
+  }
+
+  const creatorName = (lobby: Lobby) =>
+    lobby.creator?.username || lobby.creator?.email?.split('@')[0] || 'Unknown'
+
+  if (status === 'loading' || loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-500">
+      <div className="mx-auto max-w-6xl px-3 pb-10 pt-16 sm:px-4 sm:pt-20">
+        {/* Breadcrumbs */}
+        <nav className="mb-5 flex items-center gap-2 text-sm text-white/75 overflow-x-auto">
+          <button onClick={() => router.push('/')} className="hover:text-white transition-colors whitespace-nowrap">
+            🏠 Home
+          </button>
+          <span>›</span>
+          <button onClick={() => router.push('/games')} className="hover:text-white transition-colors whitespace-nowrap">
+            🎮 Games
+          </button>
+          <span>›</span>
+          <span className="font-semibold text-white whitespace-nowrap">✂️ Rock Paper Scissors</span>
+        </nav>
+
+        {/* Header */}
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-extrabold text-white drop-shadow-lg sm:text-4xl">
+              🍂 Rock Paper Scissors
+            </h1>
+            <p className="mt-1 text-white/85 sm:text-base">
+              {isAuthenticated
+                ? 'Join an open lobby or create your own!'
+                : 'Browse lobbies — sign in to create or join.'}
+            </p>
+          </div>
+          <button
+            onClick={() => router.push('/games')}
+            className="w-full rounded-xl bg-white/20 px-5 py-2.5 font-semibold text-white backdrop-blur-sm transition hover:bg-white/30 sm:w-auto"
+          >
+            ← Back to Games
+          </button>
+        </div>
+
+        {!isAuthenticated && (
+          <div className="mb-5 rounded-xl border border-white/20 bg-white/10 p-4 text-white/90 backdrop-blur-sm">
+            <p className="font-semibold">Want to play?</p>
+            <p className="mt-1 text-sm">Sign in to host or join a game.</p>
+            <div className="mt-3 flex flex-col gap-2 xs:flex-row">
+              <button
+                onClick={() => router.push('/auth/login?returnUrl=/games/rock-paper-scissors/lobbies')}
+                className="rounded-lg bg-white px-4 py-2 text-sm font-bold text-indigo-600 hover:bg-indigo-50 transition-colors"
+              >
+                Sign In
+              </button>
+              <button
+                onClick={() => router.push('/auth/register?returnUrl=/games/rock-paper-scissors/lobbies')}
+                className="rounded-lg border border-white/40 px-4 py-2 text-sm font-semibold transition hover:bg-white/10"
+              >
+                Create Account
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Action cards */}
+        <div className="mb-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {/* Create lobby */}
+          <div
+            className="cursor-pointer rounded-2xl border-2 border-white/20 bg-gradient-to-br from-emerald-500 to-teal-600 p-6 shadow-xl transition-all hover:scale-[1.02] hover:shadow-2xl sm:p-8"
+            onClick={() => {
+              if (!isAuthenticated) {
+                router.push(`/auth/login?returnUrl=${encodeURIComponent('/lobby/create')}`)
+                return
+              }
+              router.push('/lobby/create?gameType=rock_paper_scissors')
+            }}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <span className="text-5xl sm:text-6xl">✨</span>
+              <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-bold text-white">
+                NEW GAME
+              </span>
+            </div>
+            <h2 className="text-2xl font-bold text-white sm:text-3xl">Create New Lobby</h2>
+            <p className="mt-2 text-white/90 sm:text-base">
+              Start a Best-of-3 or Best-of-5 match and invite a friend!
+            </p>
+            <div className="mt-4 flex items-center gap-2 font-bold text-white">
+              <span>Create Now</span>
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
+            </div>
+          </div>
+
+          {/* Quick join */}
+          <div className="rounded-2xl border-2 border-white/20 bg-white/10 p-6 shadow-lg backdrop-blur-md sm:p-8">
+            <h2 className="mb-2 text-xl font-bold text-white sm:text-2xl">🔍 Quick Join</h2>
+            <p className="mb-4 text-sm text-white/80">Have a lobby code? Enter it below.</p>
+            <div className="flex flex-col gap-2 xs:flex-row">
+              <input
+                type="text"
+                placeholder="Enter 4-digit code"
+                className="flex-1 rounded-xl border-2 border-white/30 bg-white/20 px-4 py-3 font-mono text-base text-white placeholder-white/60 backdrop-blur-sm focus:border-transparent focus:ring-2 focus:ring-white"
+                value={joinCode}
+                onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+                maxLength={4}
+                onKeyDown={(e) => e.key === 'Enter' && handleJoinByCode()}
+              />
+              <button
+                onClick={handleJoinByCode}
+                disabled={joinCode.length !== 4 || !isAuthenticated}
+                className="rounded-xl bg-white px-6 py-3 font-bold text-indigo-600 shadow-lg transition hover:scale-105 hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Join
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Lobby list */}
+        <div>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-white sm:text-xl">
+              Open Lobbies
+              {lobbies.length > 0 && (
+                <span className="ml-2 rounded-full bg-white/20 px-2.5 py-0.5 text-sm font-semibold">
+                  {lobbies.length}
+                </span>
+              )}
+            </h2>
+            <button
+              onClick={() => loadLobbies()}
+              className="rounded-lg bg-white/10 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-white/20"
+            >
+              ↻ Refresh
+            </button>
+          </div>
+
+          {lobbies.length === 0 ? (
+            <div className="rounded-2xl border border-white/20 bg-white/10 py-12 text-center text-white/80 backdrop-blur-sm">
+              <p className="text-5xl mb-3">🍂</p>
+              <p className="text-lg font-semibold">No open lobbies right now</p>
+              <p className="mt-1 text-sm text-white/60">Be the first — create a lobby above!</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {lobbies.map((lobby) => (
+                <div
+                  key={lobby.id}
+                  className="flex cursor-pointer items-center justify-between rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur-sm transition hover:bg-white/20"
+                  onClick={() => router.push(`/lobby/${lobby.code}`)}
+                >
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="truncate font-semibold text-white">{lobby.name}</p>
+                      {getStatusBadge(lobby)}
+                    </div>
+                    <p className="mt-0.5 text-xs text-white/70">
+                      {displayName(lobby)} · hosted by {creatorName(lobby)} · code:{' '}
+                      <span className="font-mono font-bold">{lobby.code}</span>
+                    </p>
+                  </div>
+                  <button className="ml-3 shrink-0 rounded-xl bg-white px-4 py-2 text-sm font-bold text-indigo-600 transition hover:bg-indigo-50">
+                    Join
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/components/RockPaperScissorsGameBoard.tsx
+++ b/components/RockPaperScissorsGameBoard.tsx
@@ -5,236 +5,343 @@ import { RockPaperScissorsGameData, RPSChoice } from '@/lib/games/rock-paper-sci
 import LoadingButton from '@/components/LoadingButton'
 
 interface RPSPlayer {
-    id: string
-    name: string
+  id: string
+  name: string
 }
 
 interface RockPaperScissorsGameBoardProps {
-    gameData: RockPaperScissorsGameData
-    playerId: string
-    playerName: string
-    players: RPSPlayer[]
-    onSubmitChoice: (choice: RPSChoice) => Promise<void>
-    isLoading?: boolean
+  gameData: RockPaperScissorsGameData
+  playerId: string
+  playerName: string
+  players: RPSPlayer[]
+  onSubmitChoice: (choice: RPSChoice) => Promise<void>
+  isLoading?: boolean
 }
 
-const CHOICES: { choice: RPSChoice; emoji: string; label: string; beats: string }[] = [
-    { choice: 'rock', emoji: '🪨', label: 'lobby.choice.rock', beats: '✂️' },
-    { choice: 'paper', emoji: '📄', label: 'lobby.choice.paper', beats: '🪨' },
-    { choice: 'scissors', emoji: '✂️', label: 'lobby.choice.scissors', beats: '📄' },
+const CHOICES: { choice: RPSChoice; emoji: string; label: string; beats: string; color: string }[] = [
+  {
+    choice: 'rock',
+    emoji: '🪨',
+    label: 'lobby.choice.rock',
+    beats: '✂️',
+    color: 'from-slate-100 to-slate-200 border-slate-300 hover:from-slate-200 hover:to-slate-300 hover:border-slate-400 dark:from-slate-700 dark:to-slate-800 dark:border-slate-600',
+  },
+  {
+    choice: 'paper',
+    emoji: '📄',
+    label: 'lobby.choice.paper',
+    beats: '🪨',
+    color: 'from-sky-50 to-blue-100 border-sky-200 hover:from-sky-100 hover:to-blue-200 hover:border-sky-300 dark:from-sky-900/40 dark:to-blue-900/40 dark:border-sky-700',
+  },
+  {
+    choice: 'scissors',
+    emoji: '✂️',
+    label: 'lobby.choice.scissors',
+    beats: '📄',
+    color: 'from-rose-50 to-pink-100 border-rose-200 hover:from-rose-100 hover:to-pink-200 hover:border-rose-300 dark:from-rose-900/40 dark:to-pink-900/40 dark:border-rose-700',
+  },
 ]
 
 const CHOICE_LABEL_BY_VALUE: Record<RPSChoice, string> = {
-    rock: 'lobby.choice.rock',
-    paper: 'lobby.choice.paper',
-    scissors: 'lobby.choice.scissors',
+  rock: 'lobby.choice.rock',
+  paper: 'lobby.choice.paper',
+  scissors: 'lobby.choice.scissors',
 }
 
 function getChoiceEmoji(choice: RPSChoice | null | undefined): string {
-    if (!choice) return '❔'
-    return CHOICES.find((entry) => entry.choice === choice)?.emoji || '❔'
+  if (!choice) return '❔'
+  return CHOICES.find((e) => e.choice === choice)?.emoji || '❔'
+}
+
+function WinPips({ filled, total }: { filled: number; total: number }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {Array.from({ length: total }).map((_, i) => (
+        <span
+          key={i}
+          className={`h-3 w-3 rounded-full border-2 transition-all ${
+            i < filled
+              ? 'border-emerald-500 bg-emerald-500'
+              : 'border-slate-300 bg-transparent dark:border-slate-600'
+          }`}
+        />
+      ))}
+    </div>
+  )
 }
 
 export default function RockPaperScissorsGameBoard({
-    gameData,
-    playerId,
-    playerName,
-    players,
-    onSubmitChoice,
-    isLoading = false,
+  gameData,
+  playerId,
+  playerName,
+  players,
+  onSubmitChoice,
+  isLoading = false,
 }: RockPaperScissorsGameBoardProps) {
-    const { t } = useTranslation()
+  const { t } = useTranslation()
 
-    const myPlayer = players.find((player) => player.id === playerId) || { id: playerId, name: playerName }
-    const opponent = players.find((player) => player.id !== playerId) || null
+  const myPlayer = players.find((p) => p.id === playerId) || { id: playerId, name: playerName }
+  const opponent = players.find((p) => p.id !== playerId) || null
 
-    const myScore = gameData.scores[playerId] || 0
-    const opponentScore = opponent ? (gameData.scores[opponent.id] || 0) : 0
-    const winsNeeded = gameData.mode === 'best-of-5' ? 3 : 2
-    const maxRounds = gameData.mode === 'best-of-5' ? 5 : 3
-    const currentRoundNumber = gameData.rounds.length + 1
+  const myScore = gameData.scores[playerId] || 0
+  const opponentScore = opponent ? gameData.scores[opponent.id] || 0 : 0
+  const winsNeeded = gameData.mode === 'best-of-5' ? 3 : 2
+  const maxRounds = gameData.mode === 'best-of-5' ? 5 : 3
+  const currentRoundNumber = Math.min(gameData.rounds.length + 1, maxRounds)
 
-    const mySubmitted = gameData.playersReady.includes(playerId)
-    const opponentSubmitted = opponent ? gameData.playersReady.includes(opponent.id) : false
-    const myCurrentChoice = (gameData.playerChoices[playerId] as RPSChoice | null | undefined) ?? null
+  const mySubmitted = gameData.playersReady.includes(playerId)
+  const opponentSubmitted = opponent ? gameData.playersReady.includes(opponent.id) : false
+  const myCurrentChoice = (gameData.playerChoices[playerId] as RPSChoice | null | undefined) ?? null
 
-    const latestRound = gameData.rounds[gameData.rounds.length - 1] || null
-    const myLatestChoice =
-        latestRound && latestRound.choices ? ((latestRound.choices[playerId] as RPSChoice | undefined) || null) : null
-    const opponentLatestChoice =
-        latestRound && latestRound.choices && opponent
-            ? ((latestRound.choices[opponent.id] as RPSChoice | undefined) || null)
-            : null
+  const latestRound = gameData.rounds[gameData.rounds.length - 1] || null
+  const myLatestChoice =
+    latestRound?.choices ? ((latestRound.choices[playerId] as RPSChoice | undefined) || null) : null
+  const opponentLatestChoice =
+    latestRound?.choices && opponent
+      ? ((latestRound.choices[opponent.id] as RPSChoice | undefined) || null)
+      : null
 
-    const canChoose = !isLoading && !mySubmitted && !gameData.gameWinner && !!opponent
+  const canChoose = !isLoading && !mySubmitted && !gameData.gameWinner && !!opponent
+  const isGameOver = !!gameData.gameWinner
+  const iWon = gameData.gameWinner === playerId
 
-    let statusTitle = t('lobby.game.makeyourChoice')
-    let statusDescription = t('lobby.game.waitingForPlayers')
+  // Determine status message
+  let statusText: string
+  let statusVariant: 'neutral' | 'waiting' | 'success' | 'danger' | 'info' = 'neutral'
 
-    if (!opponent) {
-        statusTitle = t('lobby.game.waitingForPlayers')
-        statusDescription = 'Join with one more player to start submitting moves.'
-    } else if (gameData.gameWinner) {
-        statusTitle = gameData.gameWinner === playerId ? t('lobby.game.you_won') : t('lobby.game.opponent_won')
-        statusDescription = `${t('lobby.game.final_score')}: ${myScore} - ${opponentScore}`
-    } else if (mySubmitted && !opponentSubmitted) {
-        statusTitle = t('lobby.game.waitingForOpponent')
-        statusDescription = myCurrentChoice
-            ? `You locked: ${t(CHOICE_LABEL_BY_VALUE[myCurrentChoice])}`
-            : 'Your move is submitted.'
-    } else if (mySubmitted && opponentSubmitted) {
-        statusTitle = 'Revealing round...'
-        statusDescription = 'Both choices received.'
-    } else {
-        statusTitle = t('lobby.game.makeyourChoice')
-        statusDescription = 'Pick one option below. Both players reveal simultaneously.'
-    }
+  if (!opponent) {
+    statusText = t('lobby.game.waitingForPlayers')
+    statusVariant = 'waiting'
+  } else if (isGameOver) {
+    statusText = iWon ? t('lobby.game.you_won') : t('lobby.game.opponent_won')
+    statusVariant = iWon ? 'success' : 'danger'
+  } else if (mySubmitted && opponentSubmitted) {
+    statusText = 'Revealing…'
+    statusVariant = 'info'
+  } else if (mySubmitted) {
+    statusText = t('lobby.game.waitingForOpponent')
+    statusVariant = 'waiting'
+  } else {
+    statusText = t('lobby.game.makeyourChoice')
+    statusVariant = 'neutral'
+  }
 
-    return (
-        <div className="space-y-5">
-            <section className="rounded-2xl border border-slate-200 bg-white p-4 sm:p-5 shadow-sm">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                    <p className="text-sm font-semibold text-slate-700">
-                        {t('lobby.game.round')} {Math.min(currentRoundNumber, maxRounds)} / {maxRounds}
-                    </p>
-                    <p className="text-xs text-slate-500">
-                        {t('lobby.game.best_of')}: {gameData.mode === 'best-of-3' ? '3' : '5'} • First to {winsNeeded}
-                    </p>
-                </div>
+  const statusClasses: Record<typeof statusVariant, string> = {
+    neutral: 'bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
+    waiting: 'bg-amber-50 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
+    success: 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200',
+    danger: 'bg-rose-50 text-rose-800 dark:bg-rose-900/30 dark:text-rose-200',
+    info: 'bg-blue-50 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200',
+  }
 
-                <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-                    <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3">
-                        <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700">{t('lobby.game.you')}</p>
-                        <p className="mt-1 text-lg font-bold text-emerald-900">{myPlayer.name}</p>
-                        <p className="mt-1 text-sm font-semibold text-emerald-700">
-                            {t('lobby.game.score')}: {myScore}
-                        </p>
-                    </div>
-
-                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                        <p className="text-xs font-semibold uppercase tracking-wider text-slate-600">{t('lobby.game.opponent')}</p>
-                        <p className="mt-1 text-lg font-bold text-slate-900">
-                            {opponent?.name || t('lobby.game.waitingForPlayers')}
-                        </p>
-                        <p className="mt-1 text-sm font-semibold text-slate-600">
-                            {t('lobby.game.score')}: {opponentScore}
-                        </p>
-                    </div>
-                </div>
-            </section>
-
-            <section className="rounded-2xl border border-blue-200 bg-blue-50 p-4 shadow-sm">
-                <p className="text-lg font-bold text-blue-900">{statusTitle}</p>
-                <p className="mt-1 text-sm text-blue-800">{statusDescription}</p>
-                {!gameData.gameWinner && opponent && (
-                    <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
-                        <div className="rounded-lg border border-blue-200 bg-white px-3 py-2 text-blue-800">
-                            You: {mySubmitted ? 'Ready' : 'Waiting'}
-                        </div>
-                        <div className="rounded-lg border border-blue-200 bg-white px-3 py-2 text-blue-800">
-                            {opponent.name}: {opponentSubmitted ? 'Ready' : 'Waiting'}
-                        </div>
-                    </div>
-                )}
-            </section>
-
-            {!gameData.gameWinner && (
-                <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                    <p className="text-sm font-semibold text-slate-700 mb-3">{t('lobby.game.makeyourChoice')}</p>
-                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                        {CHOICES.map(({ choice, emoji, label, beats }) => {
-                            const isSelected = myCurrentChoice === choice
-                            return (
-                                <LoadingButton
-                                    key={choice}
-                                    onClick={() => onSubmitChoice(choice)}
-                                    loading={isLoading && isSelected}
-                                    disabled={!canChoose}
-                                    className={`h-28 rounded-xl border-2 text-slate-900 transition-all ${
-                                        isSelected
-                                            ? 'border-blue-500 bg-blue-100 shadow-md'
-                                            : 'border-slate-200 bg-slate-50 hover:border-blue-300 hover:bg-blue-50'
-                                    }`}
-                                >
-                                    <span className="flex flex-col items-center justify-center gap-1">
-                                        <span className="text-3xl">{emoji}</span>
-                                        <span className="text-sm font-bold">{t(label)}</span>
-                                        <span className="text-[11px] text-slate-500">beats {beats}</span>
-                                    </span>
-                                </LoadingButton>
-                            )
-                        })}
-                    </div>
-                </section>
-            )}
-
-            {latestRound && (
-                <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                    <p className="text-sm font-semibold text-slate-700">
-                        {t('lobby.game.round')} {gameData.rounds.length} result
-                    </p>
-                    <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-                        <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                            <p className="text-xs uppercase tracking-wider text-slate-500">{myPlayer.name}</p>
-                            <p className="mt-1 text-3xl">{getChoiceEmoji(myLatestChoice)}</p>
-                            <p className="mt-1 text-sm font-semibold text-slate-700">
-                                {myLatestChoice ? t(CHOICE_LABEL_BY_VALUE[myLatestChoice]) : '—'}
-                            </p>
-                        </div>
-
-                        <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                            <p className="text-xs uppercase tracking-wider text-slate-500">
-                                {opponent?.name || t('lobby.game.opponent')}
-                            </p>
-                            <p className="mt-1 text-3xl">{getChoiceEmoji(opponentLatestChoice)}</p>
-                            <p className="mt-1 text-sm font-semibold text-slate-700">
-                                {opponentLatestChoice ? t(CHOICE_LABEL_BY_VALUE[opponentLatestChoice]) : '—'}
-                            </p>
-                        </div>
-                    </div>
-
-                    <div className="mt-3 rounded-xl bg-slate-900 px-3 py-2 text-sm font-semibold text-white">
-                        {latestRound.winner === 'draw'
-                            ? t('lobby.game.draw')
-                            : latestRound.winner === playerId
-                                ? t('lobby.game.round_won')
-                                : t('lobby.game.round_lost')}
-                    </div>
-                </section>
-            )}
-
-            {gameData.rounds.length > 0 && (
-                <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                    <p className="text-sm font-semibold text-slate-700 mb-3">{t('lobby.game.round_history')}</p>
-                    <div className="max-h-56 space-y-2 overflow-y-auto">
-                        {[...gameData.rounds].reverse().map((round, reverseIndex) => {
-                            const roundNumber = gameData.rounds.length - reverseIndex
-                            const myRoundChoice = round.choices[playerId] as RPSChoice | undefined
-                            const opponentRoundChoice = opponent
-                                ? (round.choices[opponent.id] as RPSChoice | undefined)
-                                : undefined
-                            const outcome =
-                                round.winner === 'draw'
-                                    ? t('lobby.game.draw')
-                                    : round.winner === playerId
-                                        ? t('lobby.game.win')
-                                        : t('lobby.game.loss')
-
-                            return (
-                                <div
-                                    key={`round-${roundNumber}`}
-                                    className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm"
-                                >
-                                    <span className="text-slate-600">
-                                        {t('lobby.game.round')} {roundNumber}: {getChoiceEmoji(myRoundChoice)} vs {getChoiceEmoji(opponentRoundChoice)}
-                                    </span>
-                                    <span className="font-semibold text-slate-800">{outcome}</span>
-                                </div>
-                            )
-                        })}
-                    </div>
-                </section>
-            )}
+  return (
+    <div className="space-y-4">
+      {/* Score board */}
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900 sm:p-5">
+        <div className="mb-3 flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          <span>
+            {t('lobby.game.round')} {currentRoundNumber} / {maxRounds}
+          </span>
+          <span>
+            {t('lobby.game.best_of')}: {maxRounds} · First to {winsNeeded}
+          </span>
         </div>
-    )
+
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+          {/* You */}
+          <div className="min-w-0">
+            <p className="truncate text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
+              {t('lobby.game.you')}
+            </p>
+            <p className="mt-0.5 truncate text-base font-bold text-slate-900 dark:text-white sm:text-lg">
+              {myPlayer.name}
+            </p>
+            <p className="mt-1.5 text-3xl font-black text-slate-900 dark:text-white sm:text-4xl">{myScore}</p>
+            <WinPips filled={myScore} total={winsNeeded} />
+          </div>
+
+          {/* VS */}
+          <div className="flex flex-col items-center">
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-black text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+              VS
+            </span>
+          </div>
+
+          {/* Opponent */}
+          <div className="min-w-0 text-right">
+            <p className="truncate text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              {t('lobby.game.opponent')}
+            </p>
+            <p className="mt-0.5 truncate text-base font-bold text-slate-900 dark:text-white sm:text-lg">
+              {opponent?.name || '—'}
+            </p>
+            <p className="mt-1.5 text-3xl font-black text-slate-900 dark:text-white sm:text-4xl">{opponentScore}</p>
+            <div className="flex justify-end">
+              <WinPips filled={opponentScore} total={winsNeeded} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Status banner */}
+      <div className={`rounded-xl px-4 py-3 text-sm font-semibold ${statusClasses[statusVariant]}`}>
+        <div className="flex items-center justify-between gap-3">
+          <span>{statusText}</span>
+          {!isGameOver && opponent && (
+            <div className="flex items-center gap-2 text-xs font-normal opacity-80">
+              <span
+                className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 ${
+                  mySubmitted ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' : 'bg-white/60 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+                }`}
+              >
+                {mySubmitted ? '✓' : '○'} {t('lobby.game.you')}
+              </span>
+              <span
+                className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 ${
+                  opponentSubmitted ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' : 'bg-white/60 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+                }`}
+              >
+                {opponentSubmitted ? '✓' : '○'} {opponent.name}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Choice cards */}
+      {!isGameOver && (
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900 sm:p-5">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            {t('lobby.game.makeyourChoice')}
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            {CHOICES.map(({ choice, emoji, label, beats, color }) => {
+              const isSelected = myCurrentChoice === choice
+              return (
+                <LoadingButton
+                  key={choice}
+                  onClick={() => onSubmitChoice(choice)}
+                  loading={isLoading && isSelected}
+                  disabled={!canChoose}
+                  className={`group relative h-32 rounded-2xl border-2 bg-gradient-to-br transition-all duration-150 ${
+                    isSelected
+                      ? 'scale-[1.03] border-blue-500 from-blue-50 to-indigo-100 shadow-lg dark:from-blue-900/40 dark:to-indigo-900/40'
+                      : `${color} disabled:opacity-50`
+                  }`}
+                >
+                  <span className="flex flex-col items-center justify-center gap-1.5">
+                    <span
+                      className={`text-5xl transition-transform duration-150 ${!isSelected && !mySubmitted ? 'group-hover:scale-110' : ''}`}
+                    >
+                      {emoji}
+                    </span>
+                    <span className="text-sm font-bold text-slate-800 dark:text-slate-100">{t(label)}</span>
+                    <span className="text-[11px] text-slate-500 dark:text-slate-400">
+                      beats {beats}
+                    </span>
+                  </span>
+                  {isSelected && (
+                    <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-blue-500 text-[10px] text-white">
+                      ✓
+                    </span>
+                  )}
+                </LoadingButton>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Round reveal */}
+      {latestRound && (
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900 sm:p-5">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            {t('lobby.game.round')} {gameData.rounds.length} — {latestRound.winner === 'draw' ? t('lobby.game.draw') : latestRound.winner === playerId ? t('lobby.game.round_won') : t('lobby.game.round_lost')}
+          </p>
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-center dark:border-slate-700 dark:bg-slate-800">
+              <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 truncate">
+                {myPlayer.name}
+              </p>
+              <p className="text-4xl">{getChoiceEmoji(myLatestChoice)}</p>
+              <p className="mt-1 text-xs font-semibold text-slate-700 dark:text-slate-200">
+                {myLatestChoice ? t(CHOICE_LABEL_BY_VALUE[myLatestChoice]) : '—'}
+              </p>
+            </div>
+            <div className="text-center text-xl font-black text-slate-400 dark:text-slate-500">vs</div>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-center dark:border-slate-700 dark:bg-slate-800">
+              <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 truncate">
+                {opponent?.name || t('lobby.game.opponent')}
+              </p>
+              <p className="text-4xl">{getChoiceEmoji(opponentLatestChoice)}</p>
+              <p className="mt-1 text-xs font-semibold text-slate-700 dark:text-slate-200">
+                {opponentLatestChoice ? t(CHOICE_LABEL_BY_VALUE[opponentLatestChoice]) : '—'}
+              </p>
+            </div>
+          </div>
+          <div
+            className={`mt-3 rounded-xl px-3 py-2 text-center text-sm font-bold ${
+              latestRound.winner === 'draw'
+                ? 'bg-slate-800 text-white dark:bg-slate-700'
+                : latestRound.winner === playerId
+                ? 'bg-emerald-600 text-white'
+                : 'bg-rose-600 text-white'
+            }`}
+          >
+            {latestRound.winner === 'draw'
+              ? `${t('lobby.game.draw')} — No points`
+              : latestRound.winner === playerId
+              ? `${t('lobby.game.round_won')} +1`
+              : `${t('lobby.game.round_lost')}`}
+          </div>
+        </div>
+      )}
+
+      {/* Round history */}
+      {gameData.rounds.length > 1 && (
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900 sm:p-5">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            {t('lobby.game.round_history')}
+          </p>
+          <div className="max-h-48 space-y-1.5 overflow-y-auto">
+            {[...gameData.rounds]
+              .reverse()
+              .slice(1) // skip the last round already shown above
+              .map((round, reverseIndex) => {
+                const roundNumber = gameData.rounds.length - reverseIndex - 1
+                const myRoundChoice = round.choices[playerId] as RPSChoice | undefined
+                const opponentRoundChoice = opponent
+                  ? (round.choices[opponent.id] as RPSChoice | undefined)
+                  : undefined
+                const outcome =
+                  round.winner === 'draw'
+                    ? t('lobby.game.draw')
+                    : round.winner === playerId
+                    ? t('lobby.game.win')
+                    : t('lobby.game.loss')
+                const outcomeColor =
+                  round.winner === 'draw'
+                    ? 'text-slate-600 dark:text-slate-400'
+                    : round.winner === playerId
+                    ? 'text-emerald-700 dark:text-emerald-400'
+                    : 'text-rose-700 dark:text-rose-400'
+
+                return (
+                  <div
+                    key={`round-${roundNumber}`}
+                    className="flex items-center justify-between rounded-lg border border-slate-100 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800"
+                  >
+                    <span className="text-slate-500 dark:text-slate-400">
+                      {t('lobby.game.round')} {roundNumber}: {getChoiceEmoji(myRoundChoice)} vs{' '}
+                      {getChoiceEmoji(opponentRoundChoice)}
+                    </span>
+                    <span className={`font-semibold ${outcomeColor}`}>{outcome}</span>
+                  </div>
+                )
+              })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary

- **Game board redesign**: large tactile choice cards (gradient fills, hover scale, selected indicator), WinPips score tracker, compact status banner with per-player ready badges, clearer round reveal section, condensed round history that only shows older rounds after the latest reveal
- **Lobbies page**: replaces static Coming Soon banner with a real lobby list (socket.io + 5s polling, same pattern as Yahtzee lobbies); includes Create Lobby CTA, Quick Join by code, and a live lobby grid
- **Games page**: RPS status changed from `coming-soon` → `available`, route wired to `/games/rock-paper-scissors/lobbies`

## Test plan

- [x] `npm run ci:quick` — lint + typecheck clean
- [x] 47 jest tests pass
- [ ] Manual: verify choice cards look good on mobile/desktop
- [ ] Manual: confirm lobbies list shows open RPS lobbies
- [ ] Manual: confirm RPS is no longer "Coming Soon" on /games

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)