### PR TITLE
fix(guides): mobile header layout — reduce h1 size and fix spacing

### DIFF
--- a/app/guides/best-free-multiplayer-browser-games/page.tsx
+++ b/app/guides/best-free-multiplayer-browser-games/page.tsx
@@ -95,10 +95,10 @@ export default function BestBrowserGamesGuide() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
 
           {/* Breadcrumb */}
-          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
+          <nav className="mb-6 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
             <Link href="/" className="hover:text-white transition-colors">Home</Link>
             <span>/</span>
             <Link href="/guides" className="hover:text-white transition-colors">Guides</Link>
@@ -107,9 +107,9 @@ export default function BestBrowserGamesGuide() {
           </nav>
 
           {/* Header */}
-          <header className="mb-12">
-            <div className="text-6xl mb-4">🎮</div>
-            <h1 className="text-4xl md:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight">
+          <header className="mb-8 sm:mb-12">
+            <div className="text-5xl sm:text-6xl mb-4">🎮</div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight break-words">
               Best Free Multiplayer Browser Games in 2025
             </h1>
             <p className="text-white/70 text-sm">4 min read · All games free on Boardly · No download required</p>

--- a/app/guides/how-to-play-spy-game-online/page.tsx
+++ b/app/guides/how-to-play-spy-game-online/page.tsx
@@ -56,10 +56,10 @@ export default function HowToPlaySpyGuide() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <div className="min-h-screen bg-gradient-to-br from-red-500 via-pink-600 to-purple-700">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
 
           {/* Breadcrumb */}
-          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
+          <nav className="mb-6 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
             <Link href="/" className="hover:text-white transition-colors">Home</Link>
             <span>/</span>
             <Link href="/guides" className="hover:text-white transition-colors">Guides</Link>
@@ -68,9 +68,9 @@ export default function HowToPlaySpyGuide() {
           </nav>
 
           {/* Header */}
-          <header className="mb-12">
-            <div className="text-6xl mb-4">🕵️</div>
-            <h1 className="text-4xl md:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight">
+          <header className="mb-8 sm:mb-12">
+            <div className="text-5xl sm:text-6xl mb-4">🕵️</div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight break-words">
               How to Play Guess the Spy Online
             </h1>
             <p className="text-white/70 text-sm">4 min read · Free to play on Boardly · 3–10 players</p>

--- a/app/guides/how-to-play-yahtzee-online/page.tsx
+++ b/app/guides/how-to-play-yahtzee-online/page.tsx
@@ -55,10 +55,10 @@ export default function HowToPlayYahtzeeGuide() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
 
           {/* Breadcrumb */}
-          <nav className="mb-8 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
+          <nav className="mb-6 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
             <Link href="/" className="hover:text-white transition-colors">Home</Link>
             <span>/</span>
             <Link href="/guides" className="hover:text-white transition-colors">Guides</Link>
@@ -67,9 +67,9 @@ export default function HowToPlayYahtzeeGuide() {
           </nav>
 
           {/* Header */}
-          <header className="mb-12">
-            <div className="text-6xl mb-4">🎲</div>
-            <h1 className="text-4xl md:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight">
+          <header className="mb-8 sm:mb-12">
+            <div className="text-5xl sm:text-6xl mb-4">🎲</div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight break-words">
               How to Play Yahtzee Online with Friends
             </h1>
             <p className="text-white/70 text-sm">5 min read · Free to play on Boardly</p>


### PR DESCRIPTION
## Problem
On narrow mobile screens (320–375px), the `text-4xl` h1 in guide pages was too large, causing the header to visually overlap the first content card below it.

## Fix
- `text-4xl md:text-5xl` → `text-2xl sm:text-3xl md:text-4xl lg:text-5xl` on all 3 guide h1s
- Added `break-words` to prevent horizontal overflow
- `py-16` → `py-8 sm:py-12 md:py-16` for better breathing room on mobile
- `mb-12` on header → `mb-8 sm:mb-12`

Affects: `/guides/how-to-play-yahtzee-online`, `/guides/how-to-play-spy-game-online`, `/guides/best-free-multiplayer-browser-games`

🤖 Generated with [Claude Code](https://claude.com/claude-code)