### PR TITLE
fix(#279): remove duplicate player count and fix waiting room viewport overflow

### DIFF
--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -1643,7 +1643,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
           />
 
           {/* Scrollable content area */}
-          <div className="flex-1 overflow-y-auto px-1">
+          <div className="flex-1 min-h-0 overflow-y-auto px-1">
             <WaitingRoom
               game={game}
               lobby={lobby}

--- a/app/lobby/[code]/components/WaitingRoom.tsx
+++ b/app/lobby/[code]/components/WaitingRoom.tsx
@@ -99,22 +99,17 @@ export default function WaitingRoom({
     <div className="max-w-5xl mx-auto w-full px-1 py-4 space-y-4">
       {/* Players section — merged status + player list */}
       <section className="rounded-2xl border border-white/20 bg-white/10 backdrop-blur-xl p-5 sm:p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2.5">
-            <h2 className="text-base font-bold text-white">{t('game.ui.playersInLobbyTitle')}</h2>
-            <span
-              className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
-                canStartImmediately
-                  ? 'border-emerald-300/40 bg-emerald-500/20 text-emerald-200'
-                  : 'border-amber-300/40 bg-amber-500/20 text-amber-200'
-              }`}
-            >
-              <span>{canStartImmediately ? '🟢' : '🟡'}</span>
-              <span>{canStartImmediately ? t('game.ui.readyToStart') : t('game.ui.waiting')}</span>
-            </span>
-          </div>
-          <span className="text-sm font-semibold text-white/60">
-            {playerCount}/{maxPlayers}
+        <div className="flex items-center gap-2.5 mb-4">
+          <h2 className="text-base font-bold text-white">{t('game.ui.playersInLobbyTitle')}</h2>
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
+              canStartImmediately
+                ? 'border-emerald-300/40 bg-emerald-500/20 text-emerald-200'
+                : 'border-amber-300/40 bg-amber-500/20 text-amber-200'
+            }`}
+          >
+            <span>{canStartImmediately ? '🟢' : '🟡'}</span>
+            <span>{canStartImmediately ? t('game.ui.readyToStart') : t('game.ui.waiting')}</span>
           </span>
         </div>
 


### PR DESCRIPTION
## Summary
- Remove duplicate `{playerCount}/{maxPlayers}` counter from WaitingRoom section header — already shown in the LobbyInfo stats grid
- Add `min-h-0` to `flex-1 overflow-y-auto` wrapper so the waiting room content is properly bounded by the `h-[calc(100vh-64px)]` container and doesn't overflow the viewport

Fixes #279

## Test plan
- [ ] Open a lobby in the waiting room — player count appears only once (in the header stats grid)
- [ ] On a typical laptop screen the waiting room fits within the viewport without scrolling the page
- [ ] Scroll within the waiting room player list works when there are many players

🤖 Generated with [Claude Code](https://claude.com/claude-code)