### PR TITLE
[codex] Align public game availability lists

### DIFF
--- a/__tests__/lib/public-game-access.test.ts
+++ b/__tests__/lib/public-game-access.test.ts
@@ -1,0 +1,27 @@
+import {
+  getPublicAvailableGameTypes,
+  isPublicAvailableGameType,
+} from '@/lib/public-game-access'
+
+describe('public game access', () => {
+  it('returns the stable public game types by default', () => {
+    expect(getPublicAvailableGameTypes({ aliasEnabled: false })).toEqual([
+      'yahtzee',
+      'guess_the_spy',
+      'tic_tac_toe',
+      'rock_paper_scissors',
+      'memory',
+    ])
+  })
+
+  it('includes alias only when its public flag is enabled', () => {
+    expect(getPublicAvailableGameTypes({ aliasEnabled: true })).toContain('alias')
+    expect(getPublicAvailableGameTypes({ aliasEnabled: false })).not.toContain('alias')
+  })
+
+  it('recognizes only public game types as selectable', () => {
+    expect(isPublicAvailableGameType('rock_paper_scissors', { aliasEnabled: false })).toBe(true)
+    expect(isPublicAvailableGameType('alias', { aliasEnabled: true })).toBe(true)
+    expect(isPublicAvailableGameType('liars_party', { aliasEnabled: true })).toBe(false)
+  })
+})

--- a/app/games/GamesClient.tsx
+++ b/app/games/GamesClient.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from '@/lib/i18n-helpers'
 import type { TranslationKeys } from '@/lib/i18n-helpers'
 import { useGuest } from '@/contexts/GuestContext'
 import { buildCurrentAuthUrl } from '@/lib/auth-redirect'
+import type { PublicGameType } from '@/lib/public-game-access'
 
 interface Game {
   id: string
@@ -21,18 +22,17 @@ interface Game {
 }
 
 interface GamesClientProps {
-  // IDs of experimental games that are currently enabled via feature flags
-  enabledExperimental: string[]
+  availableGameTypes: PublicGameType[]
 }
 
-export default function GamesClient({ enabledExperimental }: GamesClientProps) {
+export default function GamesClient({ availableGameTypes }: GamesClientProps) {
   const router = useRouter()
   const { data: session, status } = useSession()
   const { isGuest } = useGuest()
   const { t } = useTranslation()
   const [selectedFilter, setSelectedFilter] = useState<'all' | 'available' | 'coming-soon'>('all')
 
-  const enabled = new Set(enabledExperimental)
+  const available = new Set(availableGameTypes)
 
   const games: Game[] = [
     {
@@ -42,7 +42,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.yahtzee.description',
       players: '2-8',
       difficultyKey: 'games.yahtzee.difficulty',
-      status: 'available',
+      status: available.has('yahtzee') ? 'available' : 'coming-soon',
       route: '/lobby/create?gameType=yahtzee',
       color: 'from-blue-500 to-purple-600'
     },
@@ -53,7 +53,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.spy.description',
       players: '3-10',
       difficultyKey: 'games.spy.difficulty',
-      status: 'available',
+      status: available.has('guess_the_spy') ? 'available' : 'coming-soon',
       route: '/lobby/create?gameType=guess_the_spy',
       color: 'from-red-500 to-pink-600'
     },
@@ -64,7 +64,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.tictactoe.description',
       players: '2',
       difficultyKey: 'games.tictactoe.difficulty',
-      status: 'available',
+      status: available.has('tic_tac_toe') ? 'available' : 'coming-soon',
       route: '/lobby/create?gameType=tic_tac_toe',
       color: 'from-yellow-400 to-orange-500'
     },
@@ -75,7 +75,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.memory.description',
       players: '2-4',
       difficultyKey: 'games.memory.difficulty',
-      status: 'available',
+      status: available.has('memory') ? 'available' : 'coming-soon',
       route: '/games/memory/lobbies',
       color: 'from-green-400 to-teal-500'
     },
@@ -86,7 +86,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.rock_paper_scissors.description',
       players: '2',
       difficultyKey: 'games.rock_paper_scissors.difficulty',
-      status: 'available',
+      status: available.has('rock_paper_scissors') ? 'available' : 'coming-soon',
       route: '/games/rock-paper-scissors/lobbies',
       color: 'from-indigo-400 to-purple-500'
     },
@@ -97,7 +97,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.alias.description',
       players: '4-16',
       difficultyKey: 'games.alias.difficulty',
-      status: enabled.has('alias') ? 'available' : 'coming-soon',
+      status: available.has('alias') ? 'available' : 'coming-soon',
       route: '/games/alias/lobbies',
       color: 'from-orange-400 to-red-500'
     },
@@ -108,7 +108,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.liars_party.description',
       players: '4-12',
       difficultyKey: 'games.liars_party.difficulty',
-      status: enabled.has('liars-party') ? 'available' : 'coming-soon',
+      status: 'coming-soon',
       route: '/games/liars-party/lobbies',
       color: 'from-rose-500 to-orange-500'
     },
@@ -149,7 +149,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.guess_my_drawing.description',
       players: '3-10',
       difficultyKey: 'games.guess_my_drawing.difficulty',
-      status: enabled.has('guess-my-drawing') ? 'available' : 'coming-soon',
+      status: 'coming-soon',
       route: '/games/sketch-and-guess/lobbies',
       color: 'from-cyan-500 to-blue-600'
     },
@@ -160,7 +160,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.fake_artist.description',
       players: '4-10',
       difficultyKey: 'games.fake_artist.difficulty',
-      status: enabled.has('fake-artist') ? 'available' : 'coming-soon',
+      status: 'coming-soon',
       route: '/games/fake-artist/lobbies',
       color: 'from-fuchsia-500 to-violet-600'
     },
@@ -171,7 +171,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.telephone_doodle.description',
       players: '3-12',
       difficultyKey: 'games.telephone_doodle.difficulty',
-      status: enabled.has('telephone-doodle') ? 'available' : 'coming-soon',
+      status: 'coming-soon',
       route: '/games/telephone-doodle/lobbies',
       color: 'from-sky-500 to-indigo-600'
     },

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -1,23 +1,11 @@
 import {
-  isAliasEnabled,
-  isLiarsPartyEnabled,
-  isTelephoneDoodleEnabled,
-  isSketchAndGuessEnabled,
-  isFakeArtistEnabled,
-} from '@/lib/feature-flags'
+  getPublicAvailableGameTypes,
+  type PublicGameType,
+} from '@/lib/public-game-access'
 import GamesClient from './GamesClient'
 
-// Server component — reads feature flags at request time and passes them to the client.
-// This ensures experimental games only appear as "available" when their flag is on,
-// and that flag is controlled per-environment in Vercel (not hardcoded in the UI).
 export default function GamesPage() {
-  const enabledExperimental: string[] = []
+  const availableGameTypes: PublicGameType[] = getPublicAvailableGameTypes()
 
-  if (isAliasEnabled()) enabledExperimental.push('alias')
-  if (isLiarsPartyEnabled()) enabledExperimental.push('liars-party')
-  if (isTelephoneDoodleEnabled()) enabledExperimental.push('telephone-doodle')
-  if (isSketchAndGuessEnabled()) enabledExperimental.push('guess-my-drawing')
-  if (isFakeArtistEnabled()) enabledExperimental.push('fake-artist')
-
-  return <GamesClient enabledExperimental={enabledExperimental} />
+  return <GamesClient availableGameTypes={availableGameTypes} />
 }

--- a/app/lobby/create/page.tsx
+++ b/app/lobby/create/page.tsx
@@ -8,8 +8,6 @@ import { useGuest } from '@/contexts/GuestContext'
 import { fetchWithGuest } from '@/lib/fetch-with-guest'
 import { clientLogger } from '@/lib/client-logger'
 import { useTranslation } from '@/lib/i18n-helpers'
-import type { SupportedCatalogGameType } from '@/lib/game-catalog'
-import { isSupportedGameType } from '@/lib/game-catalog'
 import { showToast } from '@/lib/i18n-toast'
 import {
   trackLobbyCreateRequest,
@@ -17,8 +15,13 @@ import {
 } from '@/lib/analytics'
 import { markPendingLobbyCreateMetric } from '@/lib/lobby-create-metrics'
 import { buildCurrentAuthUrl } from '@/lib/auth-redirect'
+import {
+  getPublicAvailableGameTypes,
+  isPublicAvailableGameType,
+  type PublicGameType,
+} from '@/lib/public-game-access'
 
-type GameType = SupportedCatalogGameType
+type GameType = PublicGameType
 type MemoryDifficulty = 'easy' | 'medium' | 'hard'
 
 type GameSettings = {
@@ -45,9 +48,8 @@ type GameInfo = {
   settings: GameSettings // Game-specific settings configuration
 }
 
-// Game info with settings configuration for each game
-// Keyed by SupportedCatalogGameType; experimental entries only shown when feature flag is on
-const GAME_INFO: Record<string, GameInfo> = {
+// Game info for games that are publicly selectable in the create-lobby flow.
+const GAME_INFO: Record<GameType, GameInfo> = {
   yahtzee: {
     name: 'Yahtzee',
     emoji: '🎲',
@@ -134,31 +136,14 @@ const GAME_INFO: Record<string, GameInfo> = {
       hasGameModes: false,
     },
   },
-  liars_party: {
-    name: "Liar's Party",
-    emoji: '🎭',
-    description: '', // Set via i18n
-    gradient: 'from-rose-600 via-pink-500 to-orange-400',
-    translationKey: 'liars_party',
-    allowedPlayers: [4, 5, 6, 7, 8, 9, 10, 11, 12],
-    defaultMaxPlayers: 8,
-    settings: {
-      hasTurnTimer: false,
-      hasGameModes: false,
-    },
-  },
 }
-
-const TEMPORARILY_UNAVAILABLE_GAME_TYPES = new Set<string>(['rock_paper_scissors'])
 
 function isSelectableGameType(value: string | null | undefined): value is GameType {
   if (typeof value !== 'string' || !(value in GAME_INFO)) {
     return false
   }
-  if (!isSupportedGameType(value)) {
-    return false
-  }
-  return !TEMPORARILY_UNAVAILABLE_GAME_TYPES.has(value)
+
+  return isPublicAvailableGameType(value)
 }
 
 
@@ -174,6 +159,9 @@ function CreateLobbyPage() {
   const { isGuest } = useGuest()
 
   const requestedGameType = searchParams.get('gameType')
+  const availableGameTypes = getPublicAvailableGameTypes().filter(
+    (gameType): gameType is GameType => gameType in GAME_INFO
+  )
   const [selectedGameType, setSelectedGameType] = useState<GameType>(
     isSelectableGameType(requestedGameType) ? requestedGameType : 'yahtzee'
   )
@@ -404,24 +392,27 @@ function CreateLobbyPage() {
           <div className="bg-white/10 backdrop-blur-md rounded-2xl shadow-2xl border-2 border-white/20 flex flex-col md:flex-row md:gap-0 gap-4 overflow-visible md:overflow-hidden w-full md:h-[80vh] md:max-h-[800px]">
             {/* 1. Game Type Selector - clean scrollable list */}
             <div className="md:w-1/4 w-full flex flex-col overflow-visible md:overflow-y-auto bg-white/5 border-b-2 md:border-b-0 md:border-r-2 border-white/10 order-1">
-              {Object.entries(GAME_INFO)
-                .filter(([key]) => !TEMPORARILY_UNAVAILABLE_GAME_TYPES.has(key as GameType))
-                .sort(([, a], [, b]) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
-                .map(([key, info]) => (
-                <button
-                  key={key}
-                  type="button"
-                  onClick={() => setSelectedGameType(key as GameType)}
-                  className={`flex items-center gap-3 px-4 py-5 h-20 w-full font-semibold transition-all border-b border-white/10 last:border-b-0 ${selectedGameType === key
-                    ? 'bg-white text-blue-600 shadow-lg'
-                    : 'text-white hover:bg-white/10'
-                    }`}
-                  aria-label={t('lobby.create.selectGame', { name: info.name })}
-                >
-                  <span className="text-3xl flex-shrink-0">{info.emoji}</span>
-                  <span className="text-left text-base md:text-lg font-bold">{info.name}</span>
-                </button>
-              ))}
+              {[...availableGameTypes]
+                .sort((a, b) => GAME_INFO[a].name.localeCompare(GAME_INFO[b].name, undefined, { sensitivity: 'base' }))
+                .map((gameType) => {
+                  const info = GAME_INFO[gameType]
+
+                  return (
+                    <button
+                      key={gameType}
+                      type="button"
+                      onClick={() => setSelectedGameType(gameType)}
+                      className={`flex items-center gap-3 px-4 py-5 h-20 w-full font-semibold transition-all border-b border-white/10 last:border-b-0 ${selectedGameType === gameType
+                        ? 'bg-white text-blue-600 shadow-lg'
+                        : 'text-white hover:bg-white/10'
+                        }`}
+                      aria-label={t('lobby.create.selectGame', { name: info.name })}
+                    >
+                      <span className="text-3xl flex-shrink-0">{info.emoji}</span>
+                      <span className="text-left text-base md:text-lg font-bold">{info.name}</span>
+                    </button>
+                  )
+                })}
             </div>
             {/* 2. Form */}
             <form onSubmit={handleSubmit} className="md:w-2/4 w-full p-4 md:p-6 space-y-2.5 md:space-y-3 flex flex-col order-3 md:order-2 overflow-visible md:overflow-y-auto max-h-none">

--- a/lib/public-game-access.ts
+++ b/lib/public-game-access.ts
@@ -1,0 +1,32 @@
+import { isAliasEnabled } from './feature-flags'
+
+const ALWAYS_PUBLIC_GAME_TYPES = [
+  'yahtzee',
+  'guess_the_spy',
+  'tic_tac_toe',
+  'rock_paper_scissors',
+  'memory',
+] as const
+
+export type PublicGameType = (typeof ALWAYS_PUBLIC_GAME_TYPES)[number] | 'alias'
+
+interface PublicGameAvailabilityOptions {
+  aliasEnabled?: boolean
+}
+
+export function getPublicAvailableGameTypes(
+  options: PublicGameAvailabilityOptions = {}
+): PublicGameType[] {
+  const aliasEnabled = options.aliasEnabled ?? isAliasEnabled()
+
+  return aliasEnabled
+    ? [...ALWAYS_PUBLIC_GAME_TYPES, 'alias']
+    : [...ALWAYS_PUBLIC_GAME_TYPES]
+}
+
+export function isPublicAvailableGameType(
+  value: string,
+  options: PublicGameAvailabilityOptions = {}
+): value is PublicGameType {
+  return getPublicAvailableGameTypes(options).includes(value as PublicGameType)
+}


### PR DESCRIPTION
## Summary
Align the public game availability rules used by the games catalog and the lobby creation flow.

## What changed
- added a shared helper for the publicly available game list
- switched `/games` to use that shared list when deciding which games are marked as available
- switched `/lobby/create` to use the same shared list for selectable games
- restored `rock_paper_scissors` in the create flow when it is part of the public game set
- kept non-public or incomplete public-entry games as `coming soon` in the catalog
- added tests for the shared availability helper

## Root cause
The games catalog and the create-lobby page had separate availability logic, so their public game lists drifted apart over time.

## Impact
Users now see one consistent set of publicly available games across the catalog and lobby creation flow, which avoids dead-end or misleading game availability states.

## Validation
- `__tests__/lib/public-game-access.test.ts`
- `npx eslint app/games/GamesClient.tsx app/games/page.tsx app/lobby/create/page.tsx lib/public-game-access.ts __tests__/lib/public-game-access.test.ts`
- `npm run ci:quick`
- pre-push hook:
  - `npm run db:generate`
  - `npm run check:locales`
  - targeted Jest smoke tests

Fixes #329