### PR TITLE
fix(#329): align public game availability between catalog and lobby creation

### DIFF
--- a/__tests__/lib/public-game-access.test.ts
+++ b/__tests__/lib/public-game-access.test.ts
@@ -2,6 +2,7 @@ import {
   getGameLobbiesRoute,
   getLobbyCreateRoute,
   isTemporarilyUnavailableGameType,
+  getPublicRegisteredGameTypes,
 } from '@/lib/public-game-access'
 
 describe('public game access helpers', () => {
@@ -23,5 +24,14 @@ describe('public game access helpers', () => {
     expect(isTemporarilyUnavailableGameType('rock_paper_scissors')).toBe(true)
     expect(isTemporarilyUnavailableGameType('yahtzee')).toBe(false)
     expect(isTemporarilyUnavailableGameType(undefined)).toBe(false)
+  })
+
+  it('getPublicRegisteredGameTypes excludes temporarily unavailable games', () => {
+    const publicTypes = getPublicRegisteredGameTypes()
+    expect(publicTypes).not.toContain('rock_paper_scissors')
+    expect(publicTypes).toContain('yahtzee')
+    expect(publicTypes).toContain('guess_the_spy')
+    expect(publicTypes).toContain('tic_tac_toe')
+    expect(publicTypes).toContain('memory')
   })
 })

--- a/app/games/GamesClient.tsx
+++ b/app/games/GamesClient.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from '@/lib/i18n-helpers'
 import type { TranslationKeys } from '@/lib/i18n-helpers'
 import { useGuest } from '@/contexts/GuestContext'
 import { buildCurrentAuthUrl } from '@/lib/auth-redirect'
-import { getGameLobbiesRoute, isTemporarilyUnavailableGameType } from '@/lib/public-game-access'
+import { getGameLobbiesRoute, isTemporarilyUnavailableGameType, getPublicRegisteredGameTypes } from '@/lib/public-game-access'
 
 interface Game {
   id: string
@@ -34,6 +34,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
   const [selectedFilter, setSelectedFilter] = useState<'all' | 'available' | 'coming-soon'>('all')
 
   const enabled = new Set(enabledExperimental)
+  const publicRegistered = new Set(getPublicRegisteredGameTypes())
 
   const games: Game[] = [
     {
@@ -43,7 +44,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.yahtzee.description',
       players: '2-8',
       difficultyKey: 'games.yahtzee.difficulty',
-      status: 'available',
+      status: publicRegistered.has('yahtzee') ? 'available' : 'coming-soon',
       route: getGameLobbiesRoute('yahtzee') || undefined,
       color: 'from-blue-500 to-purple-600'
     },
@@ -54,7 +55,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.spy.description',
       players: '3-10',
       difficultyKey: 'games.spy.difficulty',
-      status: 'available',
+      status: publicRegistered.has('guess_the_spy') ? 'available' : 'coming-soon',
       route: getGameLobbiesRoute('guess_the_spy') || undefined,
       color: 'from-red-500 to-pink-600'
     },
@@ -65,7 +66,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.tictactoe.description',
       players: '2',
       difficultyKey: 'games.tictactoe.difficulty',
-      status: 'available',
+      status: publicRegistered.has('tic_tac_toe') ? 'available' : 'coming-soon',
       route: getGameLobbiesRoute('tic_tac_toe') || undefined,
       color: 'from-yellow-400 to-orange-500'
     },
@@ -76,7 +77,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.memory.description',
       players: '2-4',
       difficultyKey: 'games.memory.difficulty',
-      status: 'available',
+      status: publicRegistered.has('memory') ? 'available' : 'coming-soon',
       route: getGameLobbiesRoute('memory') || undefined,
       color: 'from-green-400 to-teal-500'
     },
@@ -87,7 +88,7 @@ export default function GamesClient({ enabledExperimental }: GamesClientProps) {
       descriptionKey: 'games.rock_paper_scissors.description',
       players: '2',
       difficultyKey: 'games.rock_paper_scissors.difficulty',
-      status: isTemporarilyUnavailableGameType('rock_paper_scissors') ? 'coming-soon' : 'available',
+      status: publicRegistered.has('rock_paper_scissors') ? 'available' : 'coming-soon',
       route: getGameLobbiesRoute('rock_paper_scissors') || undefined,
       color: 'from-indigo-400 to-purple-500'
     },

--- a/lib/public-game-access.ts
+++ b/lib/public-game-access.ts
@@ -1,3 +1,4 @@
+import { getAllRegisteredGameTypes } from './game-catalog'
 import type { RegisteredGameType } from './game-catalog'
 
 type LobbyRouteGameType = RegisteredGameType | 'alias' | 'liars_party'
@@ -26,6 +27,12 @@ export function getGameLobbiesRoute(gameType: string | null | undefined): string
   }
 
   return GAME_LOBBIES_ROUTES[gameType as LobbyRouteGameType] ?? null
+}
+
+export function getPublicRegisteredGameTypes(): RegisteredGameType[] {
+  return getAllRegisteredGameTypes().filter(
+    (type) => !TEMPORARILY_UNAVAILABLE_GAME_TYPES.has(type)
+  )
 }
 
 export function getLobbyCreateRoute(gameType: string | null | undefined): string | null {


### PR DESCRIPTION
## Summary
- Added `getPublicRegisteredGameTypes()` to `lib/public-game-access.ts` as the single source of truth for publicly available registered games
- Updated `GamesClient.tsx` to derive status for all 5 registered games via this helper (previously Memory was hardcoded as `available`, RPS inconsistently used `isTemporarilyUnavailableGameType` directly)
- `/lobby/create` already filtered correctly via `isTemporarilyUnavailableGameType` — no changes needed there

## Test plan
- [x] `getPublicRegisteredGameTypes` test added and passing
- [x] `npm run ci:quick` passes (no errors)
- [x] Adding a game to `TEMPORARILY_UNAVAILABLE_GAME_TYPES` now hides it in both `/games` and `/lobby/create` automatically

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)