### PR TITLE
Mobile UX improvements: emoji bar toggle, invite onboarding skip, RPS removal, MobileTabs layout fix

### DIFF
--- a/app/api/quick-play/route.ts
+++ b/app/api/quick-play/route.ts
@@ -7,6 +7,7 @@ import { getRequestAuthUser } from '@/lib/request-auth'
 import { apiLogger } from '@/lib/logger'
 import { createGameEngine } from '@/lib/game-registry'
 import { hasBotSupport, getBotSupportedGameTypes, isSupportedGameType } from '@/lib/game-catalog'
+import { isTemporarilyUnavailableGameType } from '@/lib/public-game-access'
 import { generateLobbyCode } from '@/lib/lobby'
 import { toPersistedGameType } from '@/lib/game-type-storage'
 import { toPersistedGameStateInput } from '@/lib/persisted-game-state'
@@ -101,6 +102,10 @@ export async function POST(req: NextRequest) {
 
   if (!hasBotSupport(gameType)) {
     return NextResponse.json({ error: 'Bot support required for Quick Play' }, { status: 400 })
+  }
+
+  if (isTemporarilyUnavailableGameType(gameType)) {
+    return NextResponse.json({ error: 'This game is temporarily unavailable' }, { status: 400 })
   }
 
   log.info('Quick play request', { userId: user.id, gameType })

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -1951,7 +1951,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
                 >
                   {/* Game Tab */}
                   <MobileTabPanel id="game" activeTab={mobileActiveTab}>
-                    <div className="h-full min-h-0 p-4 pb-[var(--mobile-tabs-offset)]">
+                    <div className="h-full min-h-0 p-4">
                       <GameBoard
                         gameEngine={gameEngine}
                         game={game}
@@ -2040,7 +2040,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
                     <div
                       className="min-h-full"
                       style={{
-                        height: 'calc(100% - var(--mobile-tabs-offset))',
+                        height: '100%',
                       }}
                     >
                       <Chat

--- a/app/lobby/[code]/components/MobileTabPanel.tsx
+++ b/app/lobby/[code]/components/MobileTabPanel.tsx
@@ -26,7 +26,6 @@ export default function MobileTabPanel({ id, activeTab, children }: MobileTabPan
         overflowX: 'hidden',
         WebkitOverflowScrolling: 'touch',
         overscrollBehavior: 'contain',
-        paddingBottom: 'var(--mobile-tabs-offset)',
       }}
     >
       <div className="h-full min-h-0">

--- a/app/lobby/[code]/components/MobileTabs.tsx
+++ b/app/lobby/[code]/components/MobileTabs.tsx
@@ -20,7 +20,7 @@ interface MobileTabsProps {
 
 export default function MobileTabs({ activeTab, onTabChange, tabs, unreadChatCount }: MobileTabsProps) {
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white/10 backdrop-blur-xl border-t border-white/20 shadow-lg z-40 md:hidden pb-[max(env(safe-area-inset-bottom),0.25rem)]">
+    <div className="flex-shrink-0 w-full bg-white/10 backdrop-blur-xl border-t border-white/20 shadow-lg md:hidden pb-[max(env(safe-area-inset-bottom),0.25rem)]">
       <div className="grid grid-cols-4 gap-0">
         {tabs.map((tab) => {
           const isActive = activeTab === tab.id

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -30,7 +30,6 @@ export default function Footer() {
               {[
                 { label: 'Yahtzee', href: '/games/yahtzee' },
                 { label: 'Tic-Tac-Toe', href: '/games/tic-tac-toe' },
-                { label: 'Rock Paper Scissors', href: '/games/rock-paper-scissors' },
                 { label: 'Guess the Spy', href: '/games/spy' },
                 { label: 'Memory', href: '/games/memory' },
               ].map((link) => (

--- a/components/HomePage/QuickPlayButton.tsx
+++ b/components/HomePage/QuickPlayButton.tsx
@@ -10,7 +10,6 @@ import { showToast } from '@/lib/i18n-toast'
 const BOT_SUPPORTED_GAMES = [
   { type: 'yahtzee', emoji: '🎲', label: 'Yahtzee', players: '1–4' },
   { type: 'tic_tac_toe', emoji: '❌', label: 'Tic Tac Toe', players: '2' },
-  { type: 'rock_paper_scissors', emoji: '🍂', label: 'Rock Paper Scissors', players: '2' },
 ] as const
 
 type GameType = (typeof BOT_SUPPORTED_GAMES)[number]['type']

--- a/components/LobbyFilters.tsx
+++ b/components/LobbyFilters.tsx
@@ -131,7 +131,6 @@ export default function LobbyFilters({ filters, onFiltersChange, embedded = fals
               <option value="yahtzee">{t('games.yahtzee.title', 'Yahtzee')}</option>
               <option value="guess_the_spy">{t('games.spy.name', 'Guess the Spy')}</option>
               <option value="tic_tac_toe">{t('games.tictactoe.name', 'Tic-Tac-Toe')}</option>
-              <option value="rock_paper_scissors">{t('games.rock_paper_scissors.name', 'Rock Paper Scissors')}</option>
               <option value="memory">{t('games.memory.name', 'Memory')}</option>
             </select>
           </div>

--- a/components/ReactionOverlay.tsx
+++ b/components/ReactionOverlay.tsx
@@ -33,6 +33,7 @@ interface ReactionOverlayProps {
 export function ReactionOverlay({ socket, lobbyCode }: ReactionOverlayProps) {
   const [reactions, setReactions] = useState<FloatingReaction[]>([])
   const [disabledEmoji, setDisabledEmoji] = useState<AllowedEmoji | null>(null)
+  const [collapsed, setCollapsed] = useState(false)
   const lastSentAtRef = useRef<number>(0)
 
   useEffect(() => {
@@ -92,8 +93,8 @@ export function ReactionOverlay({ socket, lobbyCode }: ReactionOverlayProps) {
 
       {/* Reaction bar */}
       <div className="fixed bottom-[4.5rem] md:bottom-6 left-1/2 z-30 -translate-x-1/2">
-        <div className="flex gap-1 rounded-full bg-black/50 px-3 py-2 backdrop-blur-sm">
-          {ALLOWED_EMOJIS.map((emoji) => (
+        <div className="flex items-center gap-1 rounded-full bg-black/50 px-2 py-1.5 backdrop-blur-sm">
+          {!collapsed && ALLOWED_EMOJIS.map((emoji) => (
             <button
               key={emoji}
               onClick={() => sendReaction(emoji)}
@@ -106,6 +107,13 @@ export function ReactionOverlay({ socket, lobbyCode }: ReactionOverlayProps) {
               {emoji}
             </button>
           ))}
+          <button
+            onClick={() => setCollapsed((v) => !v)}
+            aria-label={collapsed ? 'Show reactions' : 'Hide reactions'}
+            className="rounded-full w-7 h-7 flex items-center justify-center text-white/60 hover:text-white hover:bg-white/10 transition-all duration-150 text-sm ml-0.5"
+          >
+            {collapsed ? '😊' : '✕'}
+          </button>
         </div>
       </div>
     </>

--- a/components/ReactionOverlay.tsx
+++ b/components/ReactionOverlay.tsx
@@ -92,7 +92,7 @@ export function ReactionOverlay({ socket, lobbyCode }: ReactionOverlayProps) {
       ))}
 
       {/* Reaction bar */}
-      <div className="fixed bottom-[4.5rem] md:bottom-6 left-1/2 z-30 -translate-x-1/2">
+      <div className="fixed bottom-6 left-1/2 z-30 -translate-x-1/2">
         <div className="flex items-center gap-1 rounded-full bg-black/50 px-2 py-1.5 backdrop-blur-sm">
           {!collapsed && ALLOWED_EMOJIS.map((emoji) => (
             <button

--- a/contexts/OnboardingContext.tsx
+++ b/contexts/OnboardingContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
 import { useSession } from 'next-auth/react'
+import { usePathname } from 'next/navigation'
 import { useGuest } from '@/contexts/GuestContext'
 
 const GUEST_ONBOARDING_KEY = 'boardly_onboarding'
@@ -17,10 +18,12 @@ const OnboardingContext = createContext<OnboardingContextType | undefined>(undef
 export function OnboardingProvider({ children }: { children: ReactNode }) {
   const { status } = useSession()
   const { isGuest } = useGuest()
+  const pathname = usePathname()
   const [showModal, setShowModal] = useState(false)
 
   useEffect(() => {
     if (status === 'loading') return
+    if (pathname.startsWith('/lobby/')) return
 
     if (status === 'authenticated') {
       fetch('/api/onboarding/status', { cache: 'no-store' })
@@ -36,7 +39,14 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
       const stored = localStorage.getItem(GUEST_ONBOARDING_KEY)
       if (!stored) setShowModal(true)
     }
-  }, [status, isGuest])
+  }, [status, isGuest, pathname])
+
+  // Hide modal if user navigates into a lobby (e.g. via invite link)
+  useEffect(() => {
+    if (pathname.startsWith('/lobby/')) {
+      setShowModal(false)
+    }
+  }, [pathname])
 
   const completeOnboarding = useCallback(async () => {
     if (status === 'authenticated') {


### PR DESCRIPTION
## Summary

- **Fix iOS bookmark icon** — removed dark edges on Home Screen icon, full-bleed gradient SVGs + new apple-touch-icon.png
- **Yahtzee mobile UX** — fixed scorecard scroll, "hurry up" overlay, Memory game scroll removed
- **Remove Rock Paper Scissors** from Quick Play picker, footer, lobby filters, and API guard
- **Skip onboarding on invite links** — users arriving via `/lobby/` routes no longer see the onboarding modal
- **Emoji reaction bar** — added collapse/expand toggle (✕/😊), reverted hardcoded position raise
- **MobileTabs layout fix** — bottom nav was `fixed z-40` and overlaid game content; now a `flex-shrink-0` flow child so content naturally stops above it

## Test plan

- [ ] Play Yahtzee on mobile — bottom nav does not overlap dice/scorecard
- [ ] Scorecard tab scrolls to all categories
- [ ] Reaction bar collapses and expands with ✕/😊 button
- [ ] Joining a lobby via invite link skips onboarding modal
- [ ] Rock Paper Scissors absent from Quick Play and filters
- [ ] iOS Home Screen icon has no black edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)