### PR TITLE
fix: prevent body-level scroll on game lobby pages

### DIFF
--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -300,7 +300,7 @@ export default function AliasPage({ code }: AliasPageProps) {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-[calc(100dvh-4rem)] items-center justify-center">
         <LoadingSpinner />
       </div>
     )
@@ -315,7 +315,7 @@ export default function AliasPage({ code }: AliasPageProps) {
   if (resolvedStatus === 'waiting' || !data || data.phase === 'team_assignment') {
     const { team1, team2 } = computePreviewTeams(players)
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-4" data-testid="alias-waiting-room">
+      <div className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-8 p-4" data-testid="alias-waiting-room">
         <h1 className="text-3xl font-bold">{t('games.alias.name')}</h1>
         <div className="flex gap-8">
           <div className="flex min-w-[120px] flex-col gap-2 rounded-xl border p-4">
@@ -359,7 +359,7 @@ export default function AliasPage({ code }: AliasPageProps) {
       return (
         <>
           {socket && <ReactionOverlay socket={socket} lobbyCode={code} />}
-          <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4" data-testid="alias-describer-screen">
+          <div className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4" data-testid="alias-describer-screen">
             <div className="text-sm text-muted-foreground">{t('alias.wordsProgress', { current: data.currentCardIndex, total: 10 })}</div>
             <div className="text-5xl font-bold">{data.currentCard?.[data.currentCardIndex] ?? ''}</div>
             <div className="text-sm">+{guessed} / -{skipped}</div>
@@ -392,7 +392,7 @@ export default function AliasPage({ code }: AliasPageProps) {
     return (
       <>
         {socket && <ReactionOverlay socket={socket} lobbyCode={code} />}
-        <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4" data-testid="alias-guesser-screen">
+        <div className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4" data-testid="alias-guesser-screen">
           <div className="text-xl font-semibold">{currentTeam.name}</div>
           <div className="text-muted-foreground">{t('alias.isDescribing', { name: describerPlayer?.name ?? describerId })}</div>
           <div className="text-2xl font-mono font-bold">{t('alias.timeLeft', { seconds: remaining })}</div>
@@ -408,7 +408,7 @@ export default function AliasPage({ code }: AliasPageProps) {
     return (
       <>
         {socket && <ReactionOverlay socket={socket} lobbyCode={code} />}
-        <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4" data-testid="alias-turn-results-screen">
+        <div className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4" data-testid="alias-turn-results-screen">
           <h2 className="text-2xl font-bold">{t('alias.turnResults')}</h2>
           <div className="flex flex-col gap-1 max-h-64 overflow-y-auto">
             {result.wordResults.map((r, i) => (
@@ -451,7 +451,7 @@ export default function AliasPage({ code }: AliasPageProps) {
       ? t('alias.tie')
       : t('alias.wins', { team: winner?.name ?? '' })
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4" data-testid="alias-game-over-screen">
+      <div className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4" data-testid="alias-game-over-screen">
         <h2 className="text-4xl font-bold">{winMessage}</h2>
         <div className="flex gap-8">
           {data.teams.map(team => (
@@ -476,7 +476,7 @@ export default function AliasPage({ code }: AliasPageProps) {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex min-h-[calc(100dvh-4rem)] items-center justify-center">
       <LoadingSpinner />
     </div>
   )

--- a/app/lobby/[code]/liars-party-page.tsx
+++ b/app/lobby/[code]/liars-party-page.tsx
@@ -64,7 +64,7 @@ function WaitingScreen({ players, data, rules, isHost, isStarting, onStart, onLe
 
   return (
     <div
-      className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
+      className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
       data-testid="liars-party-waiting-room"
     >
       <h1 className="text-3xl font-bold text-white drop-shadow">🎭 Liar&apos;s Party</h1>
@@ -139,7 +139,7 @@ function ClaimScreen({ data, players, currentUserId, isMoveSubmitting, timerRema
 
   return (
     <div
-      className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
+      className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
       data-testid="liars-party-claim-screen"
     >
       <div className="text-white/80 text-sm font-mono">
@@ -207,7 +207,7 @@ function EliminatedClaimScreen({ data, players, currentUserId, timerRemaining, t
 
   return (
     <div
-      className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
+      className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
       data-testid="liars-party-eliminated-claim-screen"
     >
       <div
@@ -243,7 +243,7 @@ function ChallengeScreen({ data, players, currentUserId, isMoveSubmitting, timer
 
   return (
     <div
-      className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
+      className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
       data-testid="liars-party-challenge-screen"
     >
       <div className="text-white/80 text-sm font-mono">
@@ -304,7 +304,7 @@ function EliminatedChallengeScreen({ data, currentUserId, timerRemaining, t }: E
 
   return (
     <div
-      className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
+      className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
       data-testid="liars-party-eliminated-challenge-screen"
     >
       <div
@@ -346,7 +346,7 @@ function RevealScreen({ data, players, isHost, isMoveSubmitting, onAdvanceRound,
 
   return (
     <div
-      className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500 overflow-y-auto"
+      className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500 overflow-y-auto"
       data-testid="liars-party-reveal-screen"
     >
       <div className="text-white/80 text-sm font-mono">
@@ -442,7 +442,7 @@ function GameOverScreen({ data, players, isHost, isStarting, onPlayAgain, onBack
 
   return (
     <div
-      className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
+      className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-6 p-4 bg-gradient-to-br from-rose-500 to-orange-500"
       data-testid="liars-party-game-over-screen"
     >
       <div className="text-5xl">🎭</div>
@@ -743,7 +743,7 @@ export default function LiarsPartyPage({ code }: LiarsPartyPageProps) {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-[calc(100dvh-4rem)] items-center justify-center">
         <LoadingSpinner />
       </div>
     )
@@ -876,7 +876,7 @@ export default function LiarsPartyPage({ code }: LiarsPartyPageProps) {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex min-h-[calc(100dvh-4rem)] items-center justify-center">
       <LoadingSpinner />
     </div>
   )

--- a/app/lobby/[code]/rock-paper-scissors-page.tsx
+++ b/app/lobby/[code]/rock-paper-scissors-page.tsx
@@ -548,7 +548,8 @@ export default function RockPaperScissorsLobbyPage({ code }: RockPaperScissorsLo
     }
 
     return (
-        <div className="min-h-screen bg-gradient-to-b from-sky-50 via-white to-indigo-50 px-4 py-5 sm:px-6 sm:py-8">
+        <div className="h-[calc(100dvh-4rem)] overflow-y-auto">
+        <div className="bg-gradient-to-b from-sky-50 via-white to-indigo-50 px-4 py-5 sm:px-6 sm:py-8 min-h-full">
             <div className="mx-auto max-w-5xl space-y-5">
                 <header className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
                     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -628,6 +629,7 @@ export default function RockPaperScissorsLobbyPage({ code }: RockPaperScissorsLo
             {lobby.status === 'playing' && socket && (
                 <ReactionOverlay socket={socket} lobbyCode={code} />
             )}
+        </div>
         </div>
     )
 }

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -779,6 +779,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
     const draws = match?.draws ?? 0
 
     return (
+        <div className="h-[calc(100dvh-4rem)] overflow-y-auto">
         <div className="container mx-auto px-4 py-8 max-w-6xl">
             {/* Header */}
             <div className="mb-8">
@@ -949,6 +950,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
             {resolvedStatus === 'playing' && socket && (
                 <ReactionOverlay socket={socket} lobbyCode={code} />
             )}
+        </div>
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- Replace `min-h-screen` with `min-h-[calc(100dvh-4rem)]` in `liars-party-page.tsx` and `alias-page.tsx` to prevent body-level scroll
- Wrap `tic-tac-toe-page.tsx` main return in `h-[calc(100dvh-4rem)] overflow-y-auto` container
- Replace `min-h-screen` with `min-h-full` + outer `h-[calc(100dvh-4rem)] overflow-y-auto` wrapper in `rock-paper-scissors-page.tsx`

## Test plan
- [ ] Tic-tac-toe game page: no body scroll on large screens
- [ ] Rock-paper-scissors game page: no body scroll on large screens
- [ ] Liar's Party game page: no body scroll on large screens
- [ ] Alias game page: no body scroll on large screens
- [ ] All pages still scroll correctly when content overflows (internal scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)