### PR TITLE
fix: resolve high-priority responsiveness bugs

### DIFF
--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -1688,12 +1688,12 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
           className="flex flex-col overflow-hidden bg-gray-50 dark:bg-gray-900"
           style={{
             position: 'fixed' as const,
-            top: '5rem', // 80px / 16 = 5rem (header height)
+            top: '4rem',
             left: 0,
+            right: 0,
             bottom: 0,
-            width: '100vw',
-            maxWidth: '100vw',
-            height: 'calc(100dvh - 5rem)', // Dynamic viewport height for mobile with fallback
+            width: '100%',
+            height: 'calc(100dvh - 4rem)',
             overscrollBehavior: 'none',
           }}
         >

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -317,14 +317,14 @@ export default function AliasPage({ code }: AliasPageProps) {
     return (
       <div className="flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center gap-8 p-4" data-testid="alias-waiting-room">
         <h1 className="text-3xl font-bold">{t('games.alias.name')}</h1>
-        <div className="flex gap-8">
-          <div className="flex min-w-[120px] flex-col gap-2 rounded-xl border p-4">
+        <div className="flex gap-4 sm:gap-8">
+          <div className="flex min-w-[80px] sm:min-w-[120px] flex-col gap-2 rounded-xl border p-3 sm:p-4">
             <h2 className="text-center font-semibold">{t('alias.team1')}</h2>
-            {team1.map(p => <div key={p.id} className="text-center text-sm">{p.name}</div>)}
+            {team1.map(p => <div key={p.id} className="text-center text-sm truncate max-w-[100px] sm:max-w-[140px]">{p.name}</div>)}
           </div>
-          <div className="flex min-w-[120px] flex-col gap-2 rounded-xl border p-4">
+          <div className="flex min-w-[80px] sm:min-w-[120px] flex-col gap-2 rounded-xl border p-3 sm:p-4">
             <h2 className="text-center font-semibold">{t('alias.team2')}</h2>
-            {team2.map(p => <div key={p.id} className="text-center text-sm">{p.name}</div>)}
+            {team2.map(p => <div key={p.id} className="text-center text-sm truncate max-w-[100px] sm:max-w-[140px]">{p.name}</div>)}
           </div>
         </div>
         <p className="text-sm text-muted-foreground">{t('alias.teamPreviewNote')}</p>


### PR DESCRIPTION
## Summary
- **LobbyPageClient**: replace `width: '100vw'` / `maxWidth: '100vw'` with `width: '100%'` + `right: 0` on the fixed Yahtzee game viewport — prevents horizontal overflow/scroll on mobile; also corrects `top` offset from `5rem` (wrong) to `4rem` (64px actual header height)
- **alias-page**: shrink team box `min-w` from 120px to 80px on xs screens (120px on `sm+`) and add `truncate` + responsive `max-w` for player names to prevent overflow on 320px devices

## Test plan
- [ ] Yahtzee game on mobile: no horizontal scroll bar
- [ ] Alias waiting room on 320px: two team boxes fit side-by-side without overflow
- [ ] Long player names in Alias team boxes are truncated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)