### PR TITLE
fix: address medium and low priority responsiveness issues

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -6,7 +6,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
   const admin = await requireAdminSession('/admin')
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 px-4 py-8 text-slate-100 sm:px-6 lg:px-8">
+    <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 px-4 py-8 text-slate-100 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl space-y-4">
         <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-slate-900 to-slate-800 p-6 shadow-xl">
           <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -139,7 +139,7 @@ export default async function AnalyticsPage({
   const reconnectRecoveryBaseline = operationalKpis.reconnect.recoveryP95Ms.baseline
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 text-slate-100 px-4 py-8 sm:px-8">
+    <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 text-slate-100 px-4 py-8 sm:px-8">
       <div className="mx-auto max-w-7xl space-y-8">
         <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
           <h1 className="text-2xl font-bold sm:text-3xl">Product Dashboard</h1>

--- a/app/auth/verify-email/VerifyEmailContent.tsx
+++ b/app/auth/verify-email/VerifyEmailContent.tsx
@@ -109,7 +109,7 @@ export default function VerifyEmailContent() {
 
   if (token && loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-500 to-purple-600 p-4">
+      <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-blue-500 to-purple-600 p-4">
         <div className="card max-w-md w-full text-center">
           <LoadingSpinner />
           <p className="mt-4 text-gray-600 dark:text-gray-400">{t('auth.verifyEmail.verifying')}</p>
@@ -119,7 +119,7 @@ export default function VerifyEmailContent() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-500 to-purple-600 p-4">
+    <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-blue-500 to-purple-600 p-4">
       <div className="card max-w-md w-full text-center">
         <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-blue-100 dark:bg-blue-900/20 mb-6">
           <span className="text-5xl">📧</span>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -21,7 +21,7 @@ export default function Error({
   }, [error])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900 p-4">
+    <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900 p-4">
       <div className="max-w-md w-full bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl p-8 border border-white/20">
         <div className="text-center">
           {/* Error Icon */}

--- a/app/games/alias/page.tsx
+++ b/app/games/alias/page.tsx
@@ -64,7 +64,7 @@ export default function AliasGamePage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-      <div className="min-h-screen bg-gradient-to-br from-orange-400 via-red-500 to-pink-600">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-orange-400 via-red-500 to-pink-600">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
 
           <nav className="mb-8 text-white/60 text-sm flex items-center gap-2" aria-label="Breadcrumb">

--- a/app/games/liars-party/page.tsx
+++ b/app/games/liars-party/page.tsx
@@ -63,7 +63,7 @@ export default function LiarsPartyGamePage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-      <div className="min-h-screen bg-gradient-to-br from-rose-500 via-red-500 to-orange-500">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-rose-500 via-red-500 to-orange-500">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
 
           <nav className="mb-8 text-white/60 text-sm flex items-center gap-2" aria-label="Breadcrumb">

--- a/app/games/memory/page.tsx
+++ b/app/games/memory/page.tsx
@@ -82,7 +82,7 @@ export default function MemoryPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
-      <div className="min-h-screen bg-gradient-to-br from-green-400 via-teal-500 to-cyan-600">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-green-400 via-teal-500 to-cyan-600">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
 
           {/* Breadcrumb */}

--- a/app/games/spy/page.tsx
+++ b/app/games/spy/page.tsx
@@ -82,7 +82,7 @@ export default function SpyPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
-      <div className="min-h-screen bg-gradient-to-br from-red-500 via-pink-600 to-purple-700">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-red-500 via-pink-600 to-purple-700">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
 
           {/* Breadcrumb */}

--- a/app/games/tic-tac-toe/page.tsx
+++ b/app/games/tic-tac-toe/page.tsx
@@ -82,7 +82,7 @@ export default function TicTacToePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
-      <div className="min-h-screen bg-gradient-to-br from-yellow-400 via-orange-500 to-red-500">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-yellow-400 via-orange-500 to-red-500">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
 
           {/* Breadcrumb */}

--- a/app/games/yahtzee/page.tsx
+++ b/app/games/yahtzee/page.tsx
@@ -82,7 +82,7 @@ export default function YahtzeePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
-      <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
 
           {/* Breadcrumb */}

--- a/app/guides/best-free-multiplayer-browser-games/page.tsx
+++ b/app/guides/best-free-multiplayer-browser-games/page.tsx
@@ -94,7 +94,7 @@ export default function BestBrowserGamesGuide() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
-      <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
 
           {/* Breadcrumb */}

--- a/app/guides/how-to-play-spy-game-online/page.tsx
+++ b/app/guides/how-to-play-spy-game-online/page.tsx
@@ -55,7 +55,7 @@ export default function HowToPlaySpyGuide() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
-      <div className="min-h-screen bg-gradient-to-br from-red-500 via-pink-600 to-purple-700">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-red-500 via-pink-600 to-purple-700">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
 
           {/* Breadcrumb */}

--- a/app/guides/how-to-play-yahtzee-online/page.tsx
+++ b/app/guides/how-to-play-yahtzee-online/page.tsx
@@ -54,7 +54,7 @@ export default function HowToPlayYahtzeeGuide() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
-      <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
 
           {/* Breadcrumb */}

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -42,7 +42,7 @@ const guides = [
 
 export default function GuidesPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
+    <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
 
         {/* Breadcrumb */}

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -1794,7 +1794,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
                         <span className="text-xl">👤</span>
                         <div>
                           <div className="text-[10px] text-white/50 leading-tight">{t('game.ui.turn')}</div>
-                          <div className="text-base font-bold leading-tight truncate max-w-[150px]">
+                          <div className="text-base font-bold leading-tight truncate max-w-[100px] sm:max-w-[150px]">
                             {gameEngine.getCurrentPlayer()?.name || t('game.ui.playerFallback')}
                           </div>
                         </div>

--- a/app/lobby/[code]/components/LobbyPageFallbacks.tsx
+++ b/app/lobby/[code]/components/LobbyPageFallbacks.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from '@/lib/i18n-helpers'
 
 export function LobbyPageLoadingFallback() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 flex items-center justify-center">
+    <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 flex items-center justify-center">
       <LoadingSpinner size="lg" />
     </div>
   )
@@ -15,7 +15,7 @@ export function LobbyPageErrorFallback() {
   const { t } = useTranslation()
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 px-4">
+    <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 px-4">
       <div className="max-w-md w-full bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl p-8 text-center">
         <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-500/20 mb-5">
           <span className="text-3xl">!</span>

--- a/app/lobby/[code]/components/MobileTabs.tsx
+++ b/app/lobby/[code]/components/MobileTabs.tsx
@@ -41,7 +41,7 @@ export default function MobileTabs({ activeTab, onTabChange, tabs, unreadChatCou
             >
               {/* Badge */}
               {hasBadge && (
-                <div className="absolute top-1 right-[18%] bg-red-500 text-white text-xs font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 animate-pulse shadow-lg">
+                <div className="absolute top-1 right-1 bg-red-500 text-white text-xs font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 animate-pulse shadow-lg">
                   {unreadChatCount! > 9 ? '9+' : unreadChatCount}
                 </div>
               )}

--- a/app/lobby/[code]/rock-paper-scissors-page.tsx
+++ b/app/lobby/[code]/rock-paper-scissors-page.tsx
@@ -505,7 +505,7 @@ export default function RockPaperScissorsLobbyPage({ code }: RockPaperScissorsLo
 
     if (loading) {
         return (
-            <div className="min-h-screen bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center">
+            <div className="min-h-[100dvh] bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center">
                 <LoadingSpinner size="lg" />
             </div>
         )
@@ -513,7 +513,7 @@ export default function RockPaperScissorsLobbyPage({ code }: RockPaperScissorsLo
 
     if (error || !lobby || !lobby.game) {
         return (
-            <div className="min-h-screen bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center p-4">
+            <div className="min-h-[100dvh] bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center p-4">
                 <div className="rounded-2xl border border-rose-200 bg-white p-6 shadow-sm max-w-md text-center">
                     <p className="text-rose-700">{error || t('errors.gameNotFound')}</p>
                     <button
@@ -533,7 +533,7 @@ export default function RockPaperScissorsLobbyPage({ code }: RockPaperScissorsLo
 
     if (!currentPlayer) {
         return (
-            <div className="min-h-screen bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center p-4">
+            <div className="min-h-[100dvh] bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center p-4">
                 <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm max-w-md text-center">
                     <p className="text-slate-700 mb-4">You are not part of this match.</p>
                     <button
@@ -585,7 +585,7 @@ export default function RockPaperScissorsLobbyPage({ code }: RockPaperScissorsLo
                     </div>
                 </header>
 
-                <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_280px]">
+                <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_240px] lg:grid-cols-[minmax(0,1fr)_280px]">
                     <section>
                         <RockPaperScissorsGameBoard
                             gameData={gameData}

--- a/app/lobby/[code]/spectate/page.tsx
+++ b/app/lobby/[code]/spectate/page.tsx
@@ -387,12 +387,12 @@ export default function SpectatorLobbyPage() {
   }, [code, data?.canJoinAsPlayer, joiningAsPlayer, router])
 
   if (loading) {
-    return <div className="min-h-screen flex items-center justify-center">Loading spectator view...</div>
+    return <div className="min-h-[100dvh] flex items-center justify-center">Loading spectator view...</div>
   }
 
   if (!data) {
     return (
-      <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="min-h-[100dvh] flex items-center justify-center p-6">
         <div className="max-w-xl w-full rounded-xl border p-6 bg-white dark:bg-gray-900">
           <h1 className="text-xl font-bold mb-2">Spectator mode unavailable</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">{error || 'No data'}</p>
@@ -411,7 +411,7 @@ export default function SpectatorLobbyPage() {
   const players = Array.isArray(data.activeGame?.players) ? data.activeGame.players : []
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100">
+    <div className="min-h-[100dvh] bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100">
       <div className="mx-auto max-w-6xl px-4 py-6">
         <div className="mb-6 rounded-2xl border border-indigo-200 bg-indigo-50 p-4 dark:border-indigo-900 dark:bg-indigo-950/40">
           <div className="flex flex-wrap items-center justify-between gap-3">

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -704,7 +704,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
 
     if (loading) {
         return (
-            <div className="flex justify-center items-center min-h-screen">
+            <div className="flex justify-center items-center min-h-[100dvh]">
                 <LoadingSpinner size="lg" />
             </div>
         )

--- a/app/lobby/create/page.tsx
+++ b/app/lobby/create/page.tsx
@@ -226,7 +226,7 @@ function CreateLobbyPage() {
 
   if (!gameInfo) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-red-500 to-purple-600 flex items-center justify-center p-4">
+      <div className="min-h-[100dvh] bg-gradient-to-br from-red-500 to-purple-600 flex items-center justify-center p-4">
         <div className="bg-white/10 backdrop-blur-md rounded-3xl p-8 max-w-md w-full text-center">
           <div className="text-6xl mb-4">⚠️</div>
           <h1 className="text-2xl font-bold text-white mb-4">{t('lobby.create.gameNotFound')}</h1>
@@ -892,7 +892,7 @@ function CreateLobbyPage() {
 // Wrap component with Suspense for useSearchParams
 export default function CreateLobbyPageWrapper() {
   return (
-    <Suspense fallback={<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-500 to-purple-600"><div className="text-white text-xl">Loading...</div></div>}>
+    <Suspense fallback={<div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-blue-500 to-purple-600"><div className="text-white text-xl">Loading...</div></div>}>
       <CreateLobbyPage />
     </Suspense>
   )

--- a/app/lobby/page.tsx
+++ b/app/lobby/page.tsx
@@ -356,7 +356,7 @@ function LobbyListPageContent() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 pb-8">
+    <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 pb-8">
       <div className="relative mx-auto max-w-6xl px-3 pt-16 sm:px-6 sm:pt-20 lg:px-8">
         <div className="space-y-6 animate-scale-in">
           <section className="relative overflow-hidden rounded-3xl border border-t-0 border-white/85 bg-white/90 shadow-xl shadow-indigo-900/5 backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-slate-950/50">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export const revalidate = 3600
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 flex flex-col">
+    <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500 flex flex-col">
       {/* Hero Block - Full viewport height minus nav, flex centered, responsive */}
       <section
         className="relative flex flex-col items-center justify-center flex-shrink-0 w-full px-4"

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function PrivacyPolicy() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-[100dvh] bg-gradient-to-br from-slate-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 md:p-12">
           <Link 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1491,7 +1491,7 @@ export default function ProfilePage() {
                     </div>
 
                     {/* Right: Avatar */}
-                    <div className="shrink-0 lg:w-[250px]">
+                    <div className="shrink-0 md:w-[200px] lg:w-[250px]">
                       <div className="flex h-full flex-col items-center justify-center rounded-3xl bg-gradient-to-br from-slate-50 to-blue-50/50 p-6 text-center ring-1 ring-slate-200/60 dark:from-slate-800/60 dark:to-slate-800/30 dark:ring-slate-700/50">
                         <div className="relative">
                           <div className="absolute -inset-1.5 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 opacity-20 blur-md" />

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function TermsOfService() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-[100dvh] bg-gradient-to-br from-slate-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 md:p-12">
           <Link 

--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -145,7 +145,7 @@ export default function Chat({
           <span className="text-xl">💬</span>
           <span className="font-semibold">{t('chat.open')}</span>
           {unreadCount > 0 && (
-            <span className="bg-red-500 text-white text-xs font-bold rounded-full px-2 py-0.5 min-w-[20px] text-center animate-pulse" aria-label={t('chat.unread', { count: unreadCount })}>
+            <span className="bg-red-500 text-white text-xs font-bold rounded-full px-2 py-0.5 min-w-[24px] text-center animate-pulse" aria-label={t('chat.unread', { count: unreadCount })}>
               {unreadCount > 9 ? '9+' : unreadCount}
             </span>
           )}

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -49,7 +49,7 @@ export class ErrorBoundary extends Component<Props, State> {
       }
 
       return (
-        <div className="min-h-screen flex items-center justify-center bg-gray-900">
+        <div className="min-h-[100dvh] flex items-center justify-center bg-gray-900">
           <div className="max-w-md w-full bg-gray-800 rounded-lg p-8 text-center">
             <div className="text-red-500 text-6xl mb-4">⚠️</div>
             <h1 className="text-2xl font-bold text-white mb-4">


### PR DESCRIPTION
## Summary
**Medium priority:**
- `LobbyPageClient`: narrow Yahtzee player name `max-w` on xs screens (`max-w-[100px] sm:max-w-[150px]`)
- `MobileTabs`: fix chat unread badge from fragile `right-[18%]` to stable `right-1`
- `profile/page`: add `md:w-[200px]` intermediate breakpoint for avatar sidebar (was jump from full-width → `lg:w-[250px]`)
- `rock-paper-scissors-page`: add `md:grid-cols-[minmax(0,1fr)_240px]` sidebar breakpoint between none and `lg` (280px)

**Low priority:**
- `Chat`: widen open-button badge `min-w` from 20px → 24px for clean "9+" display
- Replace all remaining `min-h-screen` with `min-h-[100dvh]` across 28 files for accurate dynamic viewport height on mobile browsers

## Test plan
- [ ] Yahtzee game bar: long player name truncates cleanly at 100px on small screens
- [ ] Mobile chat tab: unread badge stays within tab button bounds at all sizes
- [ ] Profile page on tablet (768px): avatar sidebar has width instead of full-width
- [ ] RPS game on tablet: sidebar appears at md breakpoint, not just lg
- [ ] Mobile Safari: pages using min-h sit flush with viewport bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)