### PR TITLE
feat: redesign Yahtzee scorecard categories UI

### DIFF
--- a/components/Scorecard.tsx
+++ b/components/Scorecard.tsx
@@ -26,24 +26,18 @@ const categoryIcons: Record<YahtzeeCategory, string> = {
   fours: '⚃',
   fives: '⚄',
   sixes: '⚅',
-  onePair: '👥',
-  twoPairs: '👥👥',
-  threeOfKind: '🎲',
-  fourOfKind: '🎲🎲',
+  onePair: '🎭',
+  twoPairs: '🃏',
+  threeOfKind: '🔺',
+  fourOfKind: '💎',
   fullHouse: '🏠',
   smallStraight: '📈',
-  largeStraight: '📊',
+  largeStraight: '🚀',
   yahtzee: '🎯',
-  chance: '🎲',
+  chance: '🌀',
 }
 
-// Category state classification for enhanced visual feedback
 type CategoryState = 'high-value' | 'low-value' | 'sacrifice' | 'filled' | 'disabled'
-
-interface CategoryStateInfo {
-  state: CategoryState
-  potentialScore: number | null
-}
 
 function getCategoryState(
   category: YahtzeeCategory,
@@ -51,69 +45,37 @@ function getCategoryState(
   currentDice: number[],
   canSelectCategory: boolean,
   isCurrentPlayer: boolean
-): CategoryStateInfo {
-  const isFilled = scorecard[category] !== undefined
-  
-  if (isFilled) {
-    return { state: 'filled', potentialScore: null }
-  }
-  
-  if (!canSelectCategory || !isCurrentPlayer) {
-    return { state: 'disabled', potentialScore: null }
-  }
-  
-  const potentialScore = currentDice.length > 0 
-    ? calculateScore(currentDice, category) 
-    : null
-  
-  if (potentialScore === null) {
-    return { state: 'disabled', potentialScore: null }
-  }
-  
-  if (potentialScore === 0) {
-    return { state: 'sacrifice', potentialScore: 0 }
-  }
-  
-  if (potentialScore >= 20) {
-    return { state: 'high-value', potentialScore }
-  }
-  
+): { state: CategoryState; potentialScore: number | null } {
+  if (scorecard[category] !== undefined) return { state: 'filled', potentialScore: null }
+  if (!canSelectCategory || !isCurrentPlayer) return { state: 'disabled', potentialScore: null }
+
+  const potentialScore = currentDice.length > 0 ? calculateScore(currentDice, category) : null
+  if (potentialScore === null) return { state: 'disabled', potentialScore: null }
+  if (potentialScore === 0) return { state: 'sacrifice', potentialScore: 0 }
+  if (potentialScore >= 20) return { state: 'high-value', potentialScore }
   return { state: 'low-value', potentialScore }
 }
 
-// Styling configuration for each category state
-const stateStyles: Record<CategoryState, { container: string; score: string; icon: string | null }> = {
-  'high-value': {
-    container: 'bg-gradient-to-r from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20 hover:from-green-100 hover:to-emerald-100 dark:hover:from-green-900/30 dark:hover:to-emerald-900/30 border-l-4 border-green-500 hover:border-green-600 cursor-pointer transition-all duration-200 hover:shadow-lg hover:translate-x-0.5',
-    score: 'text-green-600 dark:text-green-400 font-bold text-base',
-    icon: '⭐'
-  },
-  'low-value': {
-    container: 'bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-blue-900/10 dark:to-cyan-900/10 hover:from-blue-100 hover:to-cyan-100 dark:hover:from-blue-900/20 dark:hover:to-cyan-900/20 border-l-4 border-blue-400 hover:border-blue-500 cursor-pointer transition-all duration-200 hover:shadow-lg hover:translate-x-0.5',
-    score: 'text-blue-600 dark:text-blue-400 font-semibold',
-    icon: null
-  },
-  'sacrifice': {
-    container: 'bg-gradient-to-r from-gray-50 to-slate-50 dark:from-gray-900/10 dark:to-slate-900/10 hover:from-gray-100 hover:to-slate-100 dark:hover:from-gray-900/20 dark:hover:to-slate-900/20 border-l-4 border-gray-400 hover:border-gray-500 cursor-pointer transition-all duration-200 hover:shadow-md hover:translate-x-0.5',
-    score: 'text-gray-600 dark:text-gray-400 font-semibold',
-    icon: null
-  },
-  'filled': {
-    container: 'bg-gradient-to-r from-gray-100 to-slate-100 dark:from-gray-800 dark:to-slate-800 border-l-4 border-gray-300 dark:border-gray-600 cursor-default opacity-80',
-    score: 'text-green-600 dark:text-green-400 font-bold',
-    icon: '✓'
-  },
-  'disabled': {
-    container: 'bg-gray-50 dark:bg-gray-900/50 cursor-not-allowed opacity-40',
-    score: 'text-gray-400',
-    icon: null
-  }
+const rowBase =
+  'group w-full flex items-center gap-2 px-2.5 sm:px-3 rounded-xl border-l-[3px] min-h-[44px] sm:min-h-[40px] transition-all duration-150 focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:outline-none'
+
+const rowVariants: Record<CategoryState, string> = {
+  'high-value':
+    'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/50 hover:bg-emerald-100 dark:hover:bg-emerald-900/60 hover:shadow-md hover:shadow-emerald-100 dark:hover:shadow-emerald-950 cursor-pointer',
+  'low-value':
+    'border-blue-400 bg-blue-50/70 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/50 hover:shadow-sm cursor-pointer',
+  sacrifice:
+    'border-amber-400 bg-amber-50/60 dark:bg-amber-950/30 hover:bg-amber-100/80 dark:hover:bg-amber-900/40 hover:shadow-sm cursor-pointer',
+  filled:
+    'border-slate-200 dark:border-slate-700 bg-slate-50/80 dark:bg-slate-800/50 cursor-default',
+  disabled:
+    'border-transparent bg-transparent opacity-30 cursor-not-allowed',
 }
 
-const Scorecard = React.memo(function Scorecard({ 
-  scorecard, 
-  currentDice, 
-  onSelectCategory, 
+const Scorecard = React.memo(function Scorecard({
+  scorecard,
+  currentDice,
+  onSelectCategory,
   canSelectCategory,
   isCurrentPlayer,
   isLoading = false,
@@ -121,9 +83,10 @@ const Scorecard = React.memo(function Scorecard({
   onBackToMyCards,
   showBackButton = false,
   onGoToCurrentTurn,
-  showCurrentTurnButton = false
+  showCurrentTurnButton = false,
 }: ScorecardProps) {
   const { t } = useTranslation()
+
   const upperSection: YahtzeeCategory[] = ['ones', 'twos', 'threes', 'fours', 'fives', 'sixes']
   const lowerSection: YahtzeeCategory[] = [
     'onePair',
@@ -137,6 +100,12 @@ const Scorecard = React.memo(function Scorecard({
     'chance',
   ]
 
+  const upperTotal = upperSection.reduce((sum, cat) => sum + (scorecard[cat] ?? 0), 0)
+  const bonus = upperTotal >= 63 ? 35 : 0
+  const lowerTotal = lowerSection.reduce((sum, cat) => sum + (scorecard[cat] ?? 0), 0)
+  const total = upperTotal + bonus + lowerTotal
+  const bonusProgress = Math.min(100, (upperTotal / 63) * 100)
+
   const renderCategory = (category: YahtzeeCategory) => {
     const { state, potentialScore } = getCategoryState(
       category,
@@ -145,13 +114,12 @@ const Scorecard = React.memo(function Scorecard({
       canSelectCategory,
       isCurrentPlayer
     )
-    
-    const styles = stateStyles[state]
     const filledScore = scorecard[category]
-      const categoryLabel = t(`yahtzee.categories.${category}`)
-      const icon = categoryIcons[category]
-    
-    const handleCategoryClick = () => {
+    const label = t(`yahtzee.categories.${category}`)
+    const icon = categoryIcons[category]
+    const isYahtzeePerfect = category === 'yahtzee' && potentialScore === 50
+
+    const handleClick = () => {
       if (state === 'filled' || state === 'disabled' || isLoading) return
       sounds.play('click', { force: true })
       onSelectCategory(category)
@@ -160,130 +128,196 @@ const Scorecard = React.memo(function Scorecard({
     return (
       <button
         key={category}
-        onClick={handleCategoryClick}
+        onClick={handleClick}
         disabled={state === 'filled' || state === 'disabled' || isLoading}
-        aria-label={`${categoryLabel}: ${state === 'filled' ? `Scored ${filledScore} points` : potentialScore !== null ? `Score ${potentialScore} points` : 'Not available'}`}
-        aria-disabled={state === 'filled' || state === 'disabled'}
-        className={`group relative w-full flex items-center justify-between transition-all ${styles.container} ${isLoading ? 'opacity-50 cursor-wait' : ''} focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none shadow-md hover:shadow-lg`}
-        style={{ padding: 'clamp(6px, 0.6vh, 12px) clamp(10px, 1vw, 16px)', borderRadius: 'clamp(10px, 1vw, 16px)' }}
+        aria-label={`${label}: ${
+          state === 'filled'
+            ? `${t('yahtzee.ui.scored')} ${filledScore}`
+            : potentialScore !== null
+            ? `+${potentialScore}`
+            : t('yahtzee.ui.notAvailable')
+        }`}
+        className={`${rowBase} ${rowVariants[state]} ${isLoading ? 'opacity-50 cursor-wait' : ''}`}
       >
-        <span className="font-semibold flex items-center flex-1 min-w-0" style={{ fontSize: 'clamp(11px, 0.85vw, 14px)', gap: 'clamp(4px, 0.4vw, 8px)' }}>
-          <span className="shrink-0" style={{ fontSize: 'clamp(12px, 0.95vw, 16px)' }}>{icon}</span>
-          <span className="truncate">{categoryLabel}</span>
+        {/* Icon */}
+        <span className="text-base sm:text-lg shrink-0 leading-none">{icon}</span>
+
+        {/* Label */}
+        <span className="flex-1 text-left text-xs sm:text-[11.5px] font-medium text-gray-700 dark:text-gray-200 truncate leading-tight">
+          {label}
         </span>
-        
-        <div className="flex items-center shrink-0" style={{ gap: 'clamp(8px, 0.8vw, 14px)', marginLeft: 'clamp(10px, 1vw, 16px)' }}>
+
+        {/* Score indicator */}
+        <div className="shrink-0 ml-1 flex items-center">
           {isLoading ? (
-            <svg className="animate-spin text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" style={{ width: 'clamp(14px, 1.2vw, 20px)', height: 'clamp(14px, 1.2vw, 20px)' }}>
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-            </svg>
+            <span className="w-4 h-4 rounded-full border-2 border-gray-300 border-t-blue-500 animate-spin" />
           ) : state === 'filled' ? (
-            <>
-              <span className="opacity-75" style={{ fontSize: 'clamp(11px, 0.85vw, 14px)' }}>{styles.icon}</span>
-              <span className={`${styles.score} font-bold`} style={{ fontSize: 'clamp(14px, 1.1vw, 18px)' }}>{filledScore}</span>
-            </>
-          ) : state !== 'disabled' && potentialScore !== null ? (
-            <>
-              <span className={`${styles.score} group-hover:scale-110 transition-all font-bold`} style={{ fontSize: 'clamp(14px, 1.1vw, 18px)' }}>
-                +{potentialScore}
+            <span className="flex items-center gap-1">
+              <span className="text-[10px] text-emerald-500 font-bold">✓</span>
+              <span className="text-sm font-bold text-emerald-600 dark:text-emerald-400 min-w-[1.5rem] text-right">
+                {filledScore}
               </span>
-              {category === 'yahtzee' && potentialScore === 50 && (
-                <span className="animate-bounce" style={{ fontSize: 'clamp(16px, 1.3vw, 24px)' }}>🎯</span>
-              )}
-            </>
+            </span>
+          ) : state === 'high-value' ? (
+            <span
+              className={`flex items-center gap-0.5 bg-emerald-500 text-white text-xs font-bold px-2 py-0.5 rounded-full shadow-sm transition-shadow group-hover:shadow-md group-hover:shadow-emerald-200 dark:group-hover:shadow-emerald-900 ${
+                isYahtzeePerfect ? 'animate-pulse bg-gradient-to-r from-emerald-500 to-cyan-500' : ''
+              }`}
+            >
+              {isYahtzeePerfect && <span className="mr-0.5">🎯</span>}
+              +{potentialScore}
+            </span>
+          ) : state === 'low-value' ? (
+            <span className="text-sm font-semibold text-blue-600 dark:text-blue-400 min-w-[1.5rem] text-right">
+              +{potentialScore}
+            </span>
+          ) : state === 'sacrifice' ? (
+            <span className="text-[11px] font-bold text-amber-600 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/50 px-1.5 py-0.5 rounded-md">
+              0
+            </span>
           ) : (
-            <span className={`${styles.score} opacity-50`} style={{ fontSize: 'clamp(14px, 1.1vw, 18px)' }}>—</span>
+            <span className="text-gray-300 dark:text-gray-600 text-sm w-5 text-center">—</span>
           )}
         </div>
       </button>
     )
   }
 
-  const upperTotal = upperSection.reduce((sum, cat) => sum + (scorecard[cat] ?? 0), 0)
-  const bonus = upperTotal >= 63 ? 35 : 0
-  const lowerTotal = lowerSection.reduce((sum, cat) => sum + (scorecard[cat] ?? 0), 0)
-  const total = upperTotal + bonus + lowerTotal
+  const hasHeader = playerName || showBackButton || showCurrentTurnButton
 
   return (
-    <div className={`min-h-full sm:h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl border border-gray-200 dark:border-gray-700 overflow-x-hidden sm:overflow-hidden ${
-      !isCurrentPlayer ? 'opacity-90' : ''
-    }`} style={{ borderRadius: 'clamp(12px, 1.2vw, 24px)' }}>
-      {/* TWO COLUMN LAYOUT - ADAPTIVE WITH SCROLL - Single column on mobile */}
-      <div className="flex-1 overflow-visible sm:overflow-hidden" style={{ padding: 'clamp(10px, 1vw, 20px)' }}>
-        <div className="min-h-full sm:h-full grid grid-cols-1 sm:grid-cols-2 scorecard-columns" style={{ gap: 'clamp(8px, 0.8vw, 20px)' }}>
-          {/* LEFT COLUMN: Upper Section */}
-          <div className="flex flex-col min-h-0">
-            <div className="flex items-center justify-between flex-shrink-0" style={{ marginBottom: 'clamp(6px, 0.6vh, 10px)', gap: 'clamp(6px, 0.6vw, 12px)' }}>
-              <div className="flex items-center" style={{ gap: 'clamp(4px, 0.4vw, 8px)' }}>
-                <span style={{ fontSize: 'clamp(14px, 1.1vw, 20px)' }}>🎯</span>
-                <h3 className="font-bold text-blue-600 dark:text-blue-400" style={{ fontSize: 'clamp(10px, 0.8vw, 13px)' }}>
-                  {t('yahtzee.categories.upperSection')}
-                </h3>
-              </div>
-              {/* Bonus inline */}
-              <div className="flex items-center bg-gradient-to-r from-yellow-50 to-amber-50 dark:from-yellow-900/20 dark:to-amber-900/20 rounded-lg border border-yellow-300 dark:border-yellow-700" style={{ gap: 'clamp(3px, 0.3vw, 6px)', padding: 'clamp(3px, 0.3vh, 6px) clamp(5px, 0.5vw, 9px)' }}>
-                <span style={{ fontSize: 'clamp(9px, 0.7vw, 12px)' }}>🎁</span>
-                <span className="font-semibold text-yellow-800 dark:text-yellow-300" style={{ fontSize: 'clamp(9px, 0.7vw, 11px)' }}>
-                  {bonus > 0 ? `+${bonus}` : `${upperTotal}/63`}
-                </span>
-                {bonus > 0 && <span className="text-green-500" style={{ fontSize: 'clamp(10px, 0.8vw, 14px)' }}>✓</span>}
-              </div>
+    <div
+      className={`h-full flex flex-col bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 overflow-hidden ${
+        !isCurrentPlayer ? 'opacity-90' : ''
+      }`}
+    >
+      {/* Player / navigation header */}
+      {hasHeader && (
+        <div className="flex-shrink-0 flex items-center justify-between px-3 sm:px-4 py-2 border-b border-gray-100 dark:border-gray-800 bg-gray-50/80 dark:bg-gray-800/50 gap-2">
+          {playerName && (
+            <span className="text-xs sm:text-sm font-semibold text-gray-700 dark:text-gray-100 truncate flex-1 min-w-0">
+              {playerName}
+            </span>
+          )}
+          {showBackButton && onBackToMyCards && (
+            <button
+              onClick={() => {
+                sounds.play('click', { force: true })
+                onBackToMyCards()
+              }}
+              className="ml-auto shrink-0 text-xs font-semibold text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 transition-colors"
+            >
+              ← {t('yahtzee.actions.myCards')}
+            </button>
+          )}
+          {showCurrentTurnButton && onGoToCurrentTurn && (
+            <button
+              onClick={() => {
+                sounds.play('click', { force: true })
+                onGoToCurrentTurn()
+              }}
+              className="ml-auto shrink-0 text-xs font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+            >
+              {t('yahtzee.actions.currentTurn')} →
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Two-column body — each column scrolls independently on small viewports */}
+      <div className="flex-1 min-h-0 grid grid-cols-1 sm:grid-cols-2 overflow-y-auto sm:overflow-hidden divide-y sm:divide-y-0 sm:divide-x divide-gray-100 dark:divide-gray-800">
+        {/* ── Upper section ── */}
+        <div className="flex flex-col min-h-0 px-2.5 sm:px-3 pt-2.5 pb-2 sm:overflow-y-auto">
+          {/* Section header */}
+          <div className="flex-shrink-0 flex items-center gap-2 mb-2">
+            <span className="text-sm">🎯</span>
+            <h3 className="text-[10px] font-black uppercase tracking-widest text-blue-600 dark:text-blue-400">
+              {t('yahtzee.categories.upperSection')}
+            </h3>
+          </div>
+
+          {/* Bonus progress */}
+          <div className="flex-shrink-0 mb-2.5 px-0.5">
+            <div className="flex items-center justify-between mb-1 gap-2">
+              <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400">
+                {t('yahtzee.ui.bonusProgress', { current: upperTotal, target: 63 })}
+              </span>
+              <span
+                className={`text-[10px] font-bold shrink-0 transition-colors ${
+                  bonus > 0
+                    ? 'text-emerald-600 dark:text-emerald-400'
+                    : 'text-amber-600 dark:text-amber-400'
+                }`}
+              >
+                {bonus > 0 ? `+35 🎁` : `${63 - upperTotal} to go`}
+              </span>
             </div>
-            
-            <div className="flex-1 flex flex-col min-h-0">
-              {/* Categories - full height */}
-              <div className="flex-1 overflow-visible sm:overflow-y-auto overflow-x-hidden pr-1 min-h-0 flex flex-col justify-start sm:justify-evenly" style={{ gap: 'clamp(4px, 0.4vh, 8px)' }}>
-                {upperSection.map(renderCategory)}
-              </div>
+            <div className="h-1.5 w-full rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${
+                  bonus > 0
+                    ? 'bg-gradient-to-r from-emerald-400 to-emerald-500'
+                    : bonusProgress > 60
+                    ? 'bg-gradient-to-r from-yellow-400 to-amber-500'
+                    : 'bg-gradient-to-r from-blue-400 to-cyan-400'
+                }`}
+                style={{ width: `${bonusProgress}%` }}
+              />
             </div>
           </div>
 
-          {/* RIGHT COLUMN: Lower Section */}
-          <div className="flex flex-col min-h-0">
-            <div className="flex items-center justify-between flex-shrink-0" style={{ marginBottom: 'clamp(6px, 0.6vh, 10px)', gap: 'clamp(6px, 0.6vw, 12px)' }}>
-              <div className="flex items-center" style={{ gap: 'clamp(4px, 0.4vw, 8px)' }}>
-                <span style={{ fontSize: 'clamp(14px, 1.1vw, 20px)' }}>🎲</span>
-                <h3 className="font-bold text-purple-600 dark:text-purple-400" style={{ fontSize: 'clamp(10px, 0.8vw, 13px)' }}>
-                  {t('yahtzee.categories.lowerSection')}
-                </h3>
-              </div>
-              {/* Back to My Cards button */}
-              {showBackButton && onBackToMyCards && (
-                <button
-                  onClick={() => {
-                    sounds.play('click', { force: true })
-                    onBackToMyCards()
-                  }}
-                  className="bg-purple-500 hover:bg-purple-600 text-white rounded-md transition-colors font-semibold"
-                  style={{ fontSize: 'clamp(9px, 0.7vw, 11px)', padding: 'clamp(3px, 0.3vh, 6px) clamp(6px, 0.6vw, 10px)' }}
-                >
-                  ← {t('yahtzee.actions.myCards')}
-                </button>
+          {/* Upper categories */}
+          <div className="flex flex-col gap-1 sm:justify-evenly sm:flex-1">
+            {upperSection.map(renderCategory)}
+          </div>
+
+          {/* Upper subtotal */}
+          <div className="flex-shrink-0 flex items-center justify-between mt-2 pt-2 border-t border-gray-100 dark:border-gray-800 px-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+              Subtotal
+            </span>
+            <span className="text-sm font-bold text-gray-600 dark:text-gray-300">
+              {upperTotal}
+              {bonus > 0 && (
+                <span className="ml-1 text-xs text-emerald-500 font-semibold">+35</span>
               )}
-              {/* Current Turn button */}
-              {showCurrentTurnButton && onGoToCurrentTurn && (
-                <button
-                  onClick={() => {
-                    sounds.play('click', { force: true })
-                    onGoToCurrentTurn()
-                  }}
-                  className="bg-blue-500 hover:bg-blue-600 text-white rounded-md transition-colors font-semibold"
-                  style={{ fontSize: 'clamp(9px, 0.7vw, 11px)', padding: 'clamp(3px, 0.3vh, 6px) clamp(6px, 0.6vw, 10px)' }}
-                >
-                  {t('yahtzee.actions.currentTurn')} →
-                </button>
-              )}
-            </div>
-            
-            <div className="flex-1 flex flex-col min-h-0">
-              {/* Categories - full height */}
-              <div className="flex-1 overflow-visible sm:overflow-y-auto overflow-x-hidden pr-1 min-h-0 flex flex-col justify-start sm:justify-evenly" style={{ gap: 'clamp(4px, 0.4vh, 8px)' }}>
-                {lowerSection.map(renderCategory)}
-              </div>
-            </div>
+            </span>
           </div>
         </div>
+
+        {/* ── Lower section ── */}
+        <div className="flex flex-col min-h-0 px-2.5 sm:px-3 pt-2.5 pb-2 sm:overflow-y-auto">
+          {/* Section header */}
+          <div className="flex-shrink-0 flex items-center gap-2 mb-2">
+            <span className="text-sm">🎲</span>
+            <h3 className="text-[10px] font-black uppercase tracking-widest text-purple-600 dark:text-purple-400">
+              {t('yahtzee.categories.lowerSection')}
+            </h3>
+          </div>
+
+          {/* Lower categories */}
+          <div className="flex flex-col gap-1 sm:justify-evenly sm:flex-1">
+            {lowerSection.map(renderCategory)}
+          </div>
+
+          {/* Lower subtotal */}
+          <div className="flex-shrink-0 flex items-center justify-between mt-2 pt-2 border-t border-gray-100 dark:border-gray-800 px-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+              Subtotal
+            </span>
+            <span className="text-sm font-bold text-gray-600 dark:text-gray-300">{lowerTotal}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Total score footer */}
+      <div className="flex-shrink-0 flex items-center justify-between px-4 py-2.5 border-t border-gray-100 dark:border-gray-700 bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-950/40 dark:to-purple-950/40">
+        <span className="text-xs font-black uppercase tracking-widest text-gray-500 dark:text-gray-400">
+          Total
+        </span>
+        <span className="text-xl font-black text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-purple-600 dark:from-blue-400 dark:to-purple-400">
+          {total}
+        </span>
       </div>
     </div>
   )

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -847,6 +847,9 @@ const en = {
       host: 'Host',
       perTurn: 'per turn',
       timeLimit: 'Time limit',
+      scored: 'Scored',
+      notAvailable: 'Not available',
+      bonusProgress: '{{current}}/63 for bonus',
     },
   },
   chat: {

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -846,7 +846,10 @@ const no = {
       waitingForHost: 'Venter på at verten skal starte...',
       host: 'Vert',
       perTurn: 'per tur',
-      timeLimit: 'Tidsgrense'
+      timeLimit: 'Tidsgrense',
+      scored: 'Scoret',
+      notAvailable: 'Ikke tilgjengelig',
+      bonusProgress: '{{current}}/63 for bonus',
     }
   },
   chat: {

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -846,7 +846,10 @@ const ru = {
       waitingForHost: 'Ожидание запуска хостом...',
       host: 'Хост',
       perTurn: 'на ход',
-      timeLimit: 'Лимит времени'
+      timeLimit: 'Лимит времени',
+      scored: 'Набрано',
+      notAvailable: 'Недоступно',
+      bonusProgress: '{{current}}/63 для бонуса',
     }
   },
   chat: {

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -849,6 +849,9 @@ const uk: Translation = {
       host: 'Хост',
       perTurn: 'на хід',
       timeLimit: 'Ліміт часу',
+      scored: 'Зараховано',
+      notAvailable: 'Недоступно',
+      bonusProgress: '{{current}}/63 до бонусу',
     },
   },
   chat: {


### PR DESCRIPTION
## Summary
- **State-based row styling**: 3px left accent border as primary visual indicator — emerald (high-value ≥20pts), blue (low-value), amber (sacrifice/0pts), slate (filled), transparent (disabled)
- **Bonus progress bar**: animated bar under upper section header, shifts from blue → yellow → green as you approach 63 points; shows remaining points needed or "+35 🎁" when earned
- **Score badges**: high-value shows rounded emerald pill; filled shows ✓ + score in green; sacrifice shows orange "0" badge; Yahtzee 50pt row pulses with cyan gradient + 🎯
- **Subtotals + total footer**: each column has a subtotal row; gradient footer shows grand total
- **Clean header bar**: player name + back/current-turn navigation buttons when viewing another player's scorecard
- **Responsive layout**: two-column (upper/lower) on sm+, single scrollable column on mobile with 44px min touch targets
- **Removed all clamp() inline styles** — replaced with proper Tailwind responsive classes
- **New locale keys**: `yahtzee.ui.scored`, `yahtzee.ui.notAvailable`, `yahtzee.ui.bonusProgress` added to all 4 languages

## Test plan
- [ ] Desktop: scorecard renders in 2 columns, both sections visible without scroll
- [ ] Mobile: single column, all categories accessible with comfortable touch targets
- [ ] High-value category (≥20pts): emerald pill badge visible, scales on hover
- [ ] Sacrifice category (0pts): amber "0" badge shown
- [ ] Filled category: score shown with ✓, row is non-interactive
- [ ] Yahtzee with 5-of-a-kind: row pulses with cyan gradient
- [ ] Bonus progress bar animates correctly as upper section fills
- [ ] Viewing another player's scorecard: header bar shows player name + back button

🤖 Generated with [Claude Code](https://claude.com/claude-code)