### PR TITLE
chore(#320): align SEO canonical signals

### DIFF
--- a/app/games/alias/page.tsx
+++ b/app/games/alias/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     title: 'Alias Coming Soon - Team Word Game | Boardly',
     description:
       'Describe words to your team without saying the word itself. Race against the clock, earn points, and outlast the other team. Free, 4–16 players.',
-    url: 'https://www.boardly.online/games/alias',
+    url: 'https://boardly.online/games/alias',
     type: 'website',
   },
   twitter: {
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     description: 'Real-time team word game in your browser. Describe, guess, and score. Free, no download.',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/games/alias',
+    canonical: 'https://boardly.online/games/alias',
   },
 }
 
@@ -36,9 +36,9 @@ const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
-    { '@type': 'ListItem', position: 3, name: 'Alias', item: 'https://www.boardly.online/games/alias' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Alias', item: 'https://boardly.online/games/alias' },
   ],
 }
 
@@ -48,15 +48,15 @@ const jsonLd = {
   name: 'Alias',
   description:
     'Team word description game where players describe words to their teammates without saying the word itself, racing against a timer to score points.',
-  url: 'https://www.boardly.online/games/alias',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/games/alias',
+  image: 'https://boardly.online/opengraph-image',
   genre: ['Party Game', 'Word Game', 'Multiplayer', 'Team Game'],
   numberOfPlayers: { '@type': 'QuantitativeValue', minValue: 4, maxValue: 16 },
   playMode: 'MultiPlayer',
   applicationCategory: 'Game',
   operatingSystem: 'Any (Browser)',
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
 }
 
 export default function AliasGamePage() {

--- a/app/games/layout.tsx
+++ b/app/games/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Free Online Board Games - Play with Friends | Boardly',
+  title: 'Free Online Board Games - Play with Friends',
   description:
     'Browse and play free online multiplayer board games on Boardly. Yahtzee, Tic Tac Toe, Memory, Spy games and more. Real-time gameplay, no download, no account required.',
   keywords: [
@@ -17,11 +17,11 @@ export const metadata: Metadata = {
     title: 'Free Online Board Games - Play with Friends | Boardly',
     description:
       'Yahtzee, Tic Tac Toe, Memory, Spy and more. Free real-time multiplayer games in your browser.',
-    url: 'https://www.boardly.online/games',
+    url: 'https://boardly.online/games',
     type: 'website',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/games',
+    canonical: 'https://boardly.online/games',
   },
 }
 

--- a/app/games/liars-party/page.tsx
+++ b/app/games/liars-party/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     title: "Liar's Party Coming Soon | Boardly",
     description:
       "Make claims, vote on who's bluffing, and avoid elimination. Free social bluffing game for 4–12 players.",
-    url: 'https://www.boardly.online/games/liars-party',
+    url: 'https://boardly.online/games/liars-party',
     type: 'website',
   },
   twitter: {
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
     description: 'Real-time bluffing party game in your browser. Claim, challenge, survive. Free, no download.',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/games/liars-party',
+    canonical: 'https://boardly.online/games/liars-party',
   },
 }
 
@@ -35,9 +35,9 @@ const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
-    { '@type': 'ListItem', position: 3, name: "Liar's Party", item: 'https://www.boardly.online/games/liars-party' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: "Liar's Party", item: 'https://boardly.online/games/liars-party' },
   ],
 }
 
@@ -47,15 +47,15 @@ const jsonLd = {
   name: "Liar's Party",
   description:
     'Social bluffing party game where players make claims (true or bluff), others vote to challenge or believe, and players are eliminated after too many caught bluffs.',
-  url: 'https://www.boardly.online/games/liars-party',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/games/liars-party',
+  image: 'https://boardly.online/opengraph-image',
   genre: ['Party Game', 'Social Deduction', 'Multiplayer', 'Bluffing'],
   numberOfPlayers: { '@type': 'QuantitativeValue', minValue: 4, maxValue: 12 },
   playMode: 'MultiPlayer',
   applicationCategory: 'Game',
   operatingSystem: 'Any (Browser)',
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
 }
 
 export default function LiarsPartyGamePage() {

--- a/app/games/memory/page.tsx
+++ b/app/games/memory/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     title: 'Play Memory Card Game Online Free - Multiplayer | Boardly',
     description:
       'Flip cards, find matching pairs, beat your friends in real-time Memory. Free, 2–4 players, multiple difficulty levels.',
-    url: 'https://www.boardly.online/games/memory',
+    url: 'https://boardly.online/games/memory',
     type: 'website',
   },
   twitter: {
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     description: 'Real-time multiplayer Memory card game in your browser. Free, no download.',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/games/memory',
+    canonical: 'https://boardly.online/games/memory',
   },
 }
 
@@ -36,9 +36,9 @@ const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
-    { '@type': 'ListItem', position: 3, name: 'Memory', item: 'https://www.boardly.online/games/memory' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Memory', item: 'https://boardly.online/games/memory' },
   ],
 }
 
@@ -48,8 +48,8 @@ const jsonLd = {
   name: 'Memory Card Game',
   description:
     'Multiplayer card-matching game where players flip pairs of cards trying to find matches. The player with the most matched pairs wins.',
-  url: 'https://www.boardly.online/games/memory',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/games/memory',
+  image: 'https://boardly.online/opengraph-image',
   genre: ['Puzzle', 'Memory', 'Multiplayer'],
   numberOfPlayers: {
     '@type': 'QuantitativeValue',
@@ -67,7 +67,7 @@ const jsonLd = {
   publisher: {
     '@type': 'Organization',
     name: 'Boardly',
-    url: 'https://www.boardly.online',
+    url: 'https://boardly.online',
   },
 }
 

--- a/app/games/spy/page.tsx
+++ b/app/games/spy/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     title: 'Play Guess the Spy Online Free - Social Deduction | Boardly',
     description:
       'One player is the spy with no clue of the location. Can they bluff their way through questioning? Free, 3–10 players, real-time.',
-    url: 'https://www.boardly.online/games/spy',
+    url: 'https://boardly.online/games/spy',
     type: 'website',
   },
   twitter: {
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     description: 'Real-time social deduction game in your browser. Find the spy — or be the spy. Free, no download.',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/games/spy',
+    canonical: 'https://boardly.online/games/spy',
   },
 }
 
@@ -36,9 +36,9 @@ const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
-    { '@type': 'ListItem', position: 3, name: 'Guess the Spy', item: 'https://www.boardly.online/games/spy' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Guess the Spy', item: 'https://boardly.online/games/spy' },
   ],
 }
 
@@ -48,8 +48,8 @@ const jsonLd = {
   name: 'Guess the Spy',
   description:
     'Social deduction party game where most players share a secret location while one player — the spy — tries to blend in without knowing where they are.',
-  url: 'https://www.boardly.online/games/spy',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/games/spy',
+  image: 'https://boardly.online/opengraph-image',
   genre: ['Social Deduction', 'Party Game', 'Multiplayer'],
   numberOfPlayers: {
     '@type': 'QuantitativeValue',
@@ -67,7 +67,7 @@ const jsonLd = {
   publisher: {
     '@type': 'Organization',
     name: 'Boardly',
-    url: 'https://www.boardly.online',
+    url: 'https://boardly.online',
   },
 }
 

--- a/app/games/tic-tac-toe/page.tsx
+++ b/app/games/tic-tac-toe/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     title: 'Play Tic Tac Toe Online Free - Multiplayer | Boardly',
     description:
       'Challenge friends or AI in real-time Tic Tac Toe. Free, no download, 2 players. Start a match instantly!',
-    url: 'https://www.boardly.online/games/tic-tac-toe',
+    url: 'https://boardly.online/games/tic-tac-toe',
     type: 'website',
   },
   twitter: {
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     description: 'Real-time multiplayer Tic Tac Toe in your browser. Free, no account needed.',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/games/tic-tac-toe',
+    canonical: 'https://boardly.online/games/tic-tac-toe',
   },
 }
 
@@ -36,9 +36,9 @@ const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
-    { '@type': 'ListItem', position: 3, name: 'Tic Tac Toe', item: 'https://www.boardly.online/games/tic-tac-toe' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Tic Tac Toe', item: 'https://boardly.online/games/tic-tac-toe' },
   ],
 }
 
@@ -48,8 +48,8 @@ const jsonLd = {
   name: 'Tic Tac Toe',
   description:
     'Classic 3×3 grid strategy game where two players alternate placing X and O marks, aiming to get three in a row.',
-  url: 'https://www.boardly.online/games/tic-tac-toe',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/games/tic-tac-toe',
+  image: 'https://boardly.online/opengraph-image',
   genre: ['Strategy', 'Puzzle', 'Multiplayer'],
   numberOfPlayers: {
     '@type': 'QuantitativeValue',
@@ -67,7 +67,7 @@ const jsonLd = {
   publisher: {
     '@type': 'Organization',
     name: 'Boardly',
-    url: 'https://www.boardly.online',
+    url: 'https://boardly.online',
   },
 }
 

--- a/app/games/yahtzee/page.tsx
+++ b/app/games/yahtzee/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     title: 'Play Yahtzee Online Free - Multiplayer Dice Game | Boardly',
     description:
       'Roll dice, score combinations, and beat your friends in real-time Yahtzee. Free, no download, 1–4 players.',
-    url: 'https://www.boardly.online/games/yahtzee',
+    url: 'https://boardly.online/games/yahtzee',
     type: 'website',
   },
   twitter: {
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     description: 'Real-time multiplayer Yahtzee in your browser. Free, no download required.',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/games/yahtzee',
+    canonical: 'https://boardly.online/games/yahtzee',
   },
 }
 
@@ -36,9 +36,9 @@ const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://www.boardly.online/games' },
-    { '@type': 'ListItem', position: 3, name: 'Yahtzee', item: 'https://www.boardly.online/games/yahtzee' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Games', item: 'https://boardly.online/games' },
+    { '@type': 'ListItem', position: 3, name: 'Yahtzee', item: 'https://boardly.online/games/yahtzee' },
   ],
 }
 
@@ -48,8 +48,8 @@ const jsonLd = {
   name: 'Yahtzee',
   description:
     'Classic dice-rolling game where players compete to score the highest by filling 13 scoring categories across five dice rolls.',
-  url: 'https://www.boardly.online/games/yahtzee',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/games/yahtzee',
+  image: 'https://boardly.online/opengraph-image',
   genre: ['Dice Game', 'Strategy', 'Multiplayer'],
   numberOfPlayers: {
     '@type': 'QuantitativeValue',
@@ -67,7 +67,7 @@ const jsonLd = {
   publisher: {
     '@type': 'Organization',
     name: 'Boardly',
-    url: 'https://www.boardly.online',
+    url: 'https://boardly.online',
   },
 }
 

--- a/app/guides/best-free-multiplayer-browser-games/page.tsx
+++ b/app/guides/best-free-multiplayer-browser-games/page.tsx
@@ -18,11 +18,11 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Best Free Multiplayer Browser Games 2025 | Boardly',
     description: 'Top free browser games you can play with friends right now — no download, no account required.',
-    url: 'https://www.boardly.online/guides/best-free-multiplayer-browser-games',
+    url: 'https://boardly.online/guides/best-free-multiplayer-browser-games',
     type: 'article',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/guides/best-free-multiplayer-browser-games',
+    canonical: 'https://boardly.online/guides/best-free-multiplayer-browser-games',
   },
 }
 
@@ -31,21 +31,21 @@ const articleJsonLd = {
   '@type': 'Article',
   headline: 'Best Free Multiplayer Browser Games in 2025 — No Download Required',
   description: 'A curated list of the best free multiplayer games you can play in any browser with friends instantly.',
-  url: 'https://www.boardly.online/guides/best-free-multiplayer-browser-games',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/guides/best-free-multiplayer-browser-games',
+  image: 'https://boardly.online/opengraph-image',
   datePublished: '2025-01-01',
-  dateModified: new Date().toISOString().split('T')[0],
-  author: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
-  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+  dateModified: '2026-04-22',
+  author: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
 }
 
 const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://www.boardly.online/guides' },
-    { '@type': 'ListItem', position: 3, name: 'Best Free Multiplayer Browser Games 2025', item: 'https://www.boardly.online/guides/best-free-multiplayer-browser-games' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://boardly.online/guides' },
+    { '@type': 'ListItem', position: 3, name: 'Best Free Multiplayer Browser Games 2025', item: 'https://boardly.online/guides/best-free-multiplayer-browser-games' },
   ],
 }
 

--- a/app/guides/how-to-play-spy-game-online/page.tsx
+++ b/app/guides/how-to-play-spy-game-online/page.tsx
@@ -18,11 +18,11 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'How to Play Guess the Spy Online | Boardly',
     description: 'Complete guide to Guess the Spy — rules, strategy for both sides, and tips for a great game night.',
-    url: 'https://www.boardly.online/guides/how-to-play-spy-game-online',
+    url: 'https://boardly.online/guides/how-to-play-spy-game-online',
     type: 'article',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/guides/how-to-play-spy-game-online',
+    canonical: 'https://boardly.online/guides/how-to-play-spy-game-online',
   },
 }
 
@@ -31,21 +31,21 @@ const articleJsonLd = {
   '@type': 'Article',
   headline: 'How to Play Guess the Spy Online — Rules & Strategy Guide',
   description: 'Complete guide to the social deduction game Guess the Spy — rules, tips for both sides, and how to host a great game.',
-  url: 'https://www.boardly.online/guides/how-to-play-spy-game-online',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/guides/how-to-play-spy-game-online',
+  image: 'https://boardly.online/opengraph-image',
   datePublished: '2025-01-01',
-  dateModified: new Date().toISOString().split('T')[0],
-  author: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
-  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+  dateModified: '2026-04-22',
+  author: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
 }
 
 const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://www.boardly.online/guides' },
-    { '@type': 'ListItem', position: 3, name: 'How to Play Guess the Spy Online', item: 'https://www.boardly.online/guides/how-to-play-spy-game-online' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://boardly.online/guides' },
+    { '@type': 'ListItem', position: 3, name: 'How to Play Guess the Spy Online', item: 'https://boardly.online/guides/how-to-play-spy-game-online' },
   ],
 }
 

--- a/app/guides/how-to-play-yahtzee-online/page.tsx
+++ b/app/guides/how-to-play-yahtzee-online/page.tsx
@@ -17,11 +17,11 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'How to Play Yahtzee Online with Friends | Boardly',
     description: 'Complete Yahtzee guide — rules, scoring categories, strategy tips. Free multiplayer in your browser.',
-    url: 'https://www.boardly.online/guides/how-to-play-yahtzee-online',
+    url: 'https://boardly.online/guides/how-to-play-yahtzee-online',
     type: 'article',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/guides/how-to-play-yahtzee-online',
+    canonical: 'https://boardly.online/guides/how-to-play-yahtzee-online',
   },
 }
 
@@ -30,21 +30,21 @@ const articleJsonLd = {
   '@type': 'Article',
   headline: 'How to Play Yahtzee Online with Friends — Complete Guide',
   description: 'Step-by-step guide to playing Yahtzee online — rules, scoring, and strategy tips.',
-  url: 'https://www.boardly.online/guides/how-to-play-yahtzee-online',
-  image: 'https://www.boardly.online/opengraph-image',
+  url: 'https://boardly.online/guides/how-to-play-yahtzee-online',
+  image: 'https://boardly.online/opengraph-image',
   datePublished: '2025-01-01',
-  dateModified: new Date().toISOString().split('T')[0],
-  author: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
-  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://www.boardly.online' },
+  dateModified: '2026-04-22',
+  author: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
 }
 
 const breadcrumbJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BreadcrumbList',
   itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.boardly.online' },
-    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://www.boardly.online/guides' },
-    { '@type': 'ListItem', position: 3, name: 'How to Play Yahtzee Online', item: 'https://www.boardly.online/guides/how-to-play-yahtzee-online' },
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://boardly.online/guides' },
+    { '@type': 'ListItem', position: 3, name: 'How to Play Yahtzee Online', item: 'https://boardly.online/guides/how-to-play-yahtzee-online' },
   ],
 }
 

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -8,11 +8,11 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Board Game Guides & Tips | Boardly',
     description: 'Step-by-step guides for playing board games online with friends.',
-    url: 'https://www.boardly.online/guides',
+    url: 'https://boardly.online/guides',
     type: 'website',
   },
   alternates: {
-    canonical: 'https://www.boardly.online/guides',
+    canonical: 'https://boardly.online/guides',
   },
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,13 +34,13 @@ const Header = dynamic(() => import('@/components/Header'), {
 })
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://www.boardly.online'),
+  metadataBase: new URL('https://boardly.online'),
   title: {
-    default: 'Boardly - Play Board Games Online with Friends',
+    default: 'Boardly - Free Online Board Games with Friends',
     template: '%s | Boardly'
   },
-  description: 'Play popular board games online with friends in real-time. Join Yahtzee and more multiplayer games. Free, no download required. Create lobbies, invite friends, and start playing instantly!',
-  keywords: ['board games', 'online games', 'multiplayer games', 'yahtzee online', 'play with friends', 'browser games', 'free online games', 'real-time games', 'boardly'],
+  description: 'Play free online board games and tabletop-style games with friends in real time. Join Yahtzee, Tic Tac Toe, Memory, Guess the Spy and more. No download required.',
+  keywords: ['free online board games', 'online board games with friends', 'multiplayer board games', 'tabletop games online', 'browser games', 'yahtzee online', 'tic tac toe online', 'memory game online', 'boardly'],
   authors: [{ name: 'Boardly' }],
   creator: 'Boardly',
   publisher: 'Boardly',
@@ -52,18 +52,21 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://www.boardly.online',
-    title: 'Boardly - Play Board Games Online with Friends',
-    description: 'Play popular board games online with friends in real-time. Join Yahtzee and more multiplayer games. Free, no download required.',
+    url: 'https://boardly.online',
+    title: 'Boardly - Free Online Board Games with Friends',
+    description: 'Play free online board games and tabletop-style games with friends in real time. No download required.',
     siteName: 'Boardly',
     // Images are auto-generated from opengraph-image.tsx
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Boardly - Play Board Games Online with Friends',
-    description: 'Play popular board games online with friends in real-time. Free, no download required.',
+    title: 'Boardly - Free Online Board Games with Friends',
+    description: 'Play free online board games with friends in real time. No download required.',
     // Images are auto-generated from twitter-image.tsx
     creator: '@boardly',
+  },
+  alternates: {
+    canonical: '/',
   },
   robots: {
     index: true,
@@ -90,23 +93,15 @@ export default function RootLayout({
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name: 'Boardly',
-    description: 'Play popular board games online with friends in real-time',
-    url: 'https://www.boardly.online',
-    potentialAction: {
-      '@type': 'SearchAction',
-      target: {
-        '@type': 'EntryPoint',
-        urlTemplate: 'https://www.boardly.online/lobby?search={search_term_string}'
-      },
-      'query-input': 'required name=search_term_string'
-    },
+    description: 'Play free online board games and tabletop-style games with friends in real time.',
+    url: 'https://boardly.online',
     publisher: {
       '@type': 'Organization',
       name: 'Boardly',
-      url: 'https://www.boardly.online',
+      url: 'https://boardly.online',
       logo: {
         '@type': 'ImageObject',
-        url: 'https://www.boardly.online/logo.png'
+        url: 'https://boardly.online/icons/icon-512.png'
       }
     }
   }

--- a/app/lobby/[code]/layout.tsx
+++ b/app/lobby/[code]/layout.tsx
@@ -46,6 +46,10 @@ export async function generateMetadata({
   return {
     title,
     description,
+    robots: {
+      index: false,
+      follow: false,
+    },
     openGraph: {
       title,
       description,

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -133,7 +133,7 @@ export default async function Image() {
               fontWeight: '500',
             }}
           >
-            www.boardly.online
+            boardly.online
           </div>
         </div>
       </div>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -9,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/api/', '/auth/verify-email', '/auth/reset-password'],
       },
     ],
-    sitemap: 'https://www.boardly.online/sitemap.xml',
+    sitemap: 'https://boardly.online/sitemap.xml',
   }
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,80 +1,81 @@
 import { MetadataRoute } from 'next'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://www.boardly.online'
+  const baseUrl = 'https://boardly.online'
+  const lastModified = new Date('2026-04-22T00:00:00.000Z')
 
   return [
     {
       url: baseUrl,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'daily',
       priority: 1,
     },
     {
       url: `${baseUrl}/games`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'weekly',
       priority: 0.9,
     },
-    // Game landing pages — primary SEO targets
+    // Game landing pages - primary SEO targets
     {
       url: `${baseUrl}/games/yahtzee`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.9,
     },
     {
       url: `${baseUrl}/games/tic-tac-toe`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.9,
     },
     {
       url: `${baseUrl}/games/memory`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.85,
     },
     {
       url: `${baseUrl}/games/spy`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.85,
     },
-    // Guides — long-tail content
+    // Guides - long-tail content
     {
       url: `${baseUrl}/guides`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'weekly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/guides/how-to-play-yahtzee-online`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/guides/how-to-play-spy-game-online`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.75,
     },
     {
       url: `${baseUrl}/guides/best-free-multiplayer-browser-games`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.75,
     },
     {
       url: `${baseUrl}/privacy`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'yearly',
       priority: 0.3,
     },
     {
       url: `${baseUrl}/terms`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'yearly',
       priority: 0.3,
     },

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -133,7 +133,7 @@ export default async function Image() {
               fontWeight: '500',
             }}
           >
-            www.boardly.online
+            boardly.online
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Align public metadata, canonicals, sitemap, robots, Open Graph, and JSON-LD URLs on the live canonical host: `https://boardly.online`.
- Improve the homepage SEO title/description around free online board games with friends.
- Mark dynamic lobby URLs as `noindex,nofollow` so ephemeral rooms do not compete with stable public landing pages.
- Stabilize sitemap and guide `dateModified` values for truthful SEO signals.

## Verification
- `npm run ci:quick`
- Pre-push hook: `npm run db:generate`, `npm run check:locales`, `npm run ci:quick`, and targeted Jest smoke tests.
- Checked built `sitemap.xml`/`robots.txt` output before deleting stale `.next` artifacts.

## Note
- `npm run build` compiled and generated static pages, but local Windows standalone file tracing failed on chunk filenames containing `node:` (`EINVAL copyfile`). This is unrelated to these SEO changes and was also what created stale `.next` types locally.

Closes #320