### PR TITLE
docs(#366): audit and refresh markdown docs

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -5,11 +5,13 @@ This directory contains shared VSCode settings for the Boardly project to ensure
 ## Files in This Directory
 
 ### `extensions.json`
-**Status**: ✅ Safe to commit
+
+**Status**: safe to commit.
 
 Recommended VSCode extensions for this project:
+
 - **ESLint** - Code linting
-- **Prettier** - Code formatting  
+- **Prettier** - Code formatting
 - **Tailwind CSS IntelliSense** - CSS class completion
 - **Prisma** - Database schema support
 - **GitHub Copilot** - AI-powered development (with MCP support)
@@ -19,28 +21,39 @@ Recommended VSCode extensions for this project:
 When you open this project, VSCode will prompt you to install recommended extensions.
 
 ### `mcp.json`
-**Status**: ✅ Safe to commit (uses environment variables for secrets)
+
+**Status**: safe to commit. It uses environment variables for secrets.
 
 Model Context Protocol (MCP) server configuration for GitHub Copilot integration.
 
 **Configured MCP Servers:**
+
 - **filesystem** - File system access for reading/writing project files
 - **postgres** - Database access via `scripts/mcp-postgres.sh` (`DATABASE_URL` from `.env`/`.env.local`)
 - **github** - GitHub API integration (requires `GITHUB_TOKEN` or `GITHUB_PERSONAL_ACCESS_TOKEN`)
 - **supabase** - Hosted Supabase MCP endpoint (`https://mcp.supabase.com/mcp`)
 - **memory** - Persistent memory across Copilot sessions
+- **stripe** - Stripe MCP integration (`STRIPE_SECRET_KEY` from environment)
+- **chrome-devtools** - Browser inspection/debugging MCP
+- **context7** - Library documentation lookup
+- **vercel-next** - Next.js development tools MCP
+- **markitdown** - URL/file to Markdown conversion
+- **playwright** - Browser automation/testing MCP
 
 **Required Setup:**
+
 1. Copy `.env.example` to `.env.local`
-2. Add your `GITHUB_TOKEN` to `.env.local` (get from https://github.com/settings/tokens)
+2. Add your `GITHUB_TOKEN` to `.env.local` (get from <https://github.com/settings/tokens>)
    - Required scopes: `repo`, `workflow`, `read:org`, `read:user`
 3. Ensure `DATABASE_URL` is set in `.env.local`
 4. Optional: keep `.env` for local overrides only
 
 ### `settings.json`
-**Status**: ✅ Safe to commit
+
+**Status**: safe to commit.
 
 Project-wide VSCode settings:
+
 - Format on save enabled
 - ESLint auto-fix on save
 - TypeScript workspace version
@@ -52,28 +65,33 @@ Project-wide VSCode settings:
 ### First Time Setup
 
 1. **Clone the repository**
+
    ```bash
    git clone <repo-url>
    cd Boardly
    ```
 
 2. **Install dependencies**
+
    ```bash
    npm install
    ```
 
 3. **Configure environment variables**
+
    ```bash
    cp .env.example .env.local
    # Edit .env.local and add your credentials
    ```
 
 4. **Install recommended extensions**
+
    - Open project in VSCode
    - Click "Install" when prompted for recommended extensions
-   - Or manually: `Ctrl+Shift+P` → "Extensions: Show Recommended Extensions"
+   - Or manually: `Ctrl+Shift+P` -> "Extensions: Show Recommended Extensions"
 
 5. **Verify MCP setup**
+
    - GitHub Copilot should now have access to:
      - File system (read/write project files)
      - PostgreSQL database (query and modify via Prisma)
@@ -83,6 +101,7 @@ Project-wide VSCode settings:
 ### Working on Multiple Machines
 
 All configuration files in this directory are committed to git, so when you:
+
 1. Clone the repo on a new machine
 2. Run `npm install`
 3. Copy `.env.example` to `.env.local` and configure
@@ -92,14 +111,16 @@ You'll have the **exact same development environment** as on your other machines
 
 ## Security Notes
 
-⚠️ **What IS committed:**
+**What is committed:**
+
 - `extensions.json` - extension recommendations (safe)
 - `settings.json` - workspace settings (no secrets)
 - `mcp.json` - MCP server wiring only (scripts/endpoints, no actual tokens)
 
-✅ **What is NOT committed:**
+**What is not committed:**
+
 - `.env`, `.env.local` - your actual secrets and API keys
-- `.vscode/*.json` (any other files) - user-specific settings
+- user-specific VSCode files outside the shared project config
 
 ## Troubleshooting
 
@@ -108,15 +129,17 @@ You'll have the **exact same development environment** as on your other machines
 **Problem**: GitHub Copilot can't access database or GitHub API
 
 **Solution**:
+
 1. Check `.env`/`.env.local` has `DATABASE_URL` and `GITHUB_TOKEN` (or `GITHUB_PERSONAL_ACCESS_TOKEN`)
 2. Restart VSCode to reload MCP servers
-3. Check Output panel → "GitHub Copilot Chat" for errors
+3. Check Output panel -> "GitHub Copilot Chat" for errors
 
 ### Extensions Not Installing
 
 **Problem**: VSCode doesn't prompt to install extensions
 
 **Solution**:
+
 1. Open Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
 2. Run "Extensions: Show Recommended Extensions"
 3. Click "Install" on each extension
@@ -126,17 +149,20 @@ You'll have the **exact same development environment** as on your other machines
 **Problem**: `mcp-postgres.sh` script fails
 
 **Solution**:
+
 1. Make script executable: `chmod +x scripts/mcp-postgres.sh`
 2. Verify `DATABASE_URL` in `.env` or `.env.local` is correct
-3. Test connection: `npm run db:studio`
+3. Test connection: `npm run db:migrate:status` or `npm run db:studio`
 
 ### Supabase MCP Fails With `unknown command "mcp" for "supabase"`
 
 **Problem**: MCP config still launches Supabase CLI command (`supabase mcp`) instead of hosted endpoint.
 
 **Solution**:
+
 1. Open `.vscode/mcp.json`
 2. Ensure Supabase server is configured as:
+
    ```jsonc
    "supabase": {
      "type": "http",

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -117,13 +117,13 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
 
-[homepage]: https://www.contributor-covenant.org
+[homepage]: <https://www.contributor-covenant.org>
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Production: <https://boardly.online>
 - Next.js app (HTTP API, auth, pages)
 - Socket.IO server (`socket-server.ts`) for real-time lobby/game events
 - Shared game engine abstractions (`lib/game-engine.ts`)
-- Game implementations (Yahtzee, Guess the Spy, Tic-Tac-Toe, Rock Paper Scissors)
+- Game implementations:
+  - Stable registered games: Yahtzee, Guess the Spy, Tic-Tac-Toe, Rock Paper Scissors, Memory
+  - Feature-flagged/experimental games: Telephone Doodle, Sketch and Guess, Liars Party, Fake Artist, Alias
 
 ## Architecture at a glance
 

--- a/docs/ALIBI_NIGHT_DESIGN.md
+++ b/docs/ALIBI_NIGHT_DESIGN.md
@@ -9,11 +9,13 @@ This spec defines a server-authoritative MVP aligned with Boardly realtime and g
 ## Round model
 
 1. Prompt/context setup
+
 - Server chooses a deterministic `roundPrompt` (location + time + incident theme) from a seeded prompt pool.
 - Server assigns one `suspectPlayerId` for the round.
 - Prompt is visible to all players.
 
-2. Alibi submission (hidden)
+1. Alibi submission (hidden)
+
 - Every active player submits one text alibi.
 - Submissions are hidden until phase end.
 - Server stores immutable per-round snapshot:
@@ -22,17 +24,20 @@ This spec defines a server-authoritative MVP aligned with Boardly realtime and g
   - `submittedAt`
   - `revision` (always `1` in MVP, no edits)
 
-3. Challenge phase
+1. Challenge phase
+
 - All revealed alibis become visible in stable order (join order).
 - Each player can issue up to `N` challenges (default `2`) targeting another player.
 - A challenge is a short contradiction question linked to target alibi ID.
 
-4. Final vote
+1. Final vote
+
 - Each player casts one vote for the most suspicious alibi/author.
 - Self-vote disabled.
 - Hidden votes until phase end, then full reveal.
 
-5. Resolution
+1. Resolution
+
 - Round points granted based on vote outcome.
 - Game advances to next round until `targetRounds` reached.
 
@@ -91,6 +96,7 @@ This spec defines a server-authoritative MVP aligned with Boardly realtime and g
 ## Scoring and tie-breaker
 
 Round scoring:
+
 - If suspect gets most votes:
   - every non-suspect who voted suspect: `+2`
   - suspect: `0`
@@ -101,6 +107,7 @@ Round scoring:
   - `+1` to challenger if target later receives at least `2` votes.
 
 Tie-breaker order:
+
 1. Higher total score
 2. More correct suspicious votes
 3. Fewer abstains/timeouts
@@ -109,26 +116,31 @@ Tie-breaker order:
 ## MVP implementation checklist
 
 Engine and state:
+
 - [ ] Add `lib/games/alibi-night-game.ts` implementing `GameEngine`.
 - [ ] Define `AlibiNightGameState` with explicit phase union + deadlines.
 - [ ] Add deterministic prompt selection helper with seeded RNG.
 
 Validation and actions:
+
 - [ ] Add `lib/validation/alibi-night.ts` for payload schema and text constraints.
 - [ ] Add `/api/game/[gameId]/alibi-night-action/route.ts` with strict phase checks.
 - [ ] Add anti-spam rate limiting integration for action endpoint.
 
 Realtime:
+
 - [ ] Broadcast state snapshots through existing socket room channel.
 - [ ] Add reconnect-safe state hydration path in lobby page hook.
 - [ ] Ensure timeout auto-actions are idempotent under reconnect races.
 
 Client UX:
+
 - [ ] Add lobby/game renderer for phase UI (submit, challenge, vote, resolution).
 - [ ] Add per-phase timer blocks and completion indicators.
 - [ ] Add localized fallback labels for auto-filled actions.
 
 Tests:
+
 - [ ] Unit tests for phase transitions and scoring matrix.
 - [ ] Validation tests for payload limits and rejection paths.
 - [ ] API tests for auth/guest action acceptance and duplicate no-op handling.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,10 +34,22 @@ All games implement `GameEngine` (`lib/game-engine.ts`) and expose:
 `prisma/schema.prisma` enum `GameType`:
 
 - `yahtzee`
-- `guess_the_spy`
 - `tic_tac_toe`
 - `rock_paper_scissors`
-- plus reserved values for future (`chess`, `uno`, `other`)
+- `memory`
+- `guess_the_spy`
+- `telephone_doodle`
+- `sketch_and_guess`
+- `liars_party`
+- `fake_artist`
+- `alias`
+- `other`
+
+The default registered runtime set is managed in `lib/game-registry.ts`:
+
+- Stable games: `yahtzee`, `guess_the_spy`, `tic_tac_toe`, `rock_paper_scissors`, `memory`
+- Experimental/feature-flagged games: `telephone_doodle`, `sketch_and_guess`, `liars_party`, `fake_artist`, `alias`
+- Bot-supported games: `yahtzee`, `tic_tac_toe`, `rock_paper_scissors`
 
 ## Realtime patterns
 
@@ -86,10 +98,12 @@ This logic is centralized in `lib/lobby-lifecycle.ts` and reused across main and
 
 Core tables (pluralized schema):
 
-- `Users`, `Bots`
-- `Lobbies`, `Games`, `Players`
-- `FriendRequests`, `Friendships`
-- NextAuth auth/session/token tables
+- Identity and preferences: `Users`, `AccountPreferences`, `Bots`
+- Auth/session: `Accounts`, `Sessions`, `VerificationTokens`, `PasswordResetTokens`, `EmailVerificationTokens`
+- Lobby/gameplay: `Lobbies`, `LobbyInvites`, `Games`, `Players`, `GameStateSnapshots`
+- Social: `FriendRequests`, `Friendships`
+- Notifications: `NotificationPreferences`, `Notifications`
+- Operations/admin: `OperationalEvents`, `OperationalAlertStates`, `AdminAuditLogs`, `Feedback`
 
 Game state is persisted as JSON in `Games.state` and treated as source of truth for replay/recovery.
 

--- a/docs/DEPENDENCY_UPGRADE_PLAN.md
+++ b/docs/DEPENDENCY_UPGRADE_PLAN.md
@@ -1,174 +1,78 @@
 # Dependency Upgrade Plan
 
-Last verified: 2026-03-13
+Last repository audit: 2026-04-22
 
-This document is the canonical dependency maintenance plan for Boardly. It separates low-risk patch waves from major framework and ORM migrations that need dedicated branches and manual smoke coverage.
+This document is the dependency maintenance plan for Boardly. It is intentionally repository-aligned: use `package.json`, `package-lock.json`, and official package release notes when preparing a new upgrade branch. Do not treat this page as a live registry of the newest package versions.
 
-Version checks in this document were verified against:
+## Current repository snapshot
 
-- current installed versions in this repository
-- `npm view <package> version`
-- `npm audit`
-- official upgrade guides from Prisma, Next.js, React, Tailwind CSS, and ESLint
+| Package group | Repo version | Status | Notes |
+| --- | --- | --- | --- |
+| `next` | `^16.1.6` | aligned | App Router + `proxy.ts`; verify any routing/runtime changes with browser smoke tests |
+| `react` + `react-dom` | `^19.2.4` | aligned | Keep React upgrades coupled to the Next.js compatibility matrix |
+| `prisma` + `@prisma/client` | `^7.4.2` | aligned | Uses `prisma.config.ts`, explicit generator output, and `@prisma/adapter-pg` |
+| `@prisma/adapter-pg` | `^7.4.2` | aligned | Runtime TLS behavior is documented in `docs/OPERATIONS.md` |
+| `socket.io` + `socket.io-client` | `^4.8.3` | aligned | Realtime upgrades require reconnect and room-broadcast smoke coverage |
+| `@sentry/nextjs` | `^10.42.0` | aligned | Verify release monitoring after bumps |
+| `resend` | `^6.9.3` | aligned | Keep email behavior smoke-tested when touched |
+| `tailwindcss` | `3.4.14` | major follow-up | Tailwind 4 needs a dedicated styling/tooling migration |
+| `zod` | `3.23.8` | major follow-up | Zod 4 touches env validation, auth validation, lobby APIs, and game payload schemas |
+| `eslint` | `^9.39.4` | watch | Flat config is already in place; future major upgrades should stay isolated |
+| `lefthook` | `^1.13.6` | major follow-up | Treat hook runner upgrades as tooling-only PRs |
 
-## Current snapshot
+## Completed migration state
 
-| Package group | Current | Latest verified | Track | Notes |
-| --- | --- | --- | --- | --- |
-| `@prisma/client` + `prisma` | `5.22.0` | `7.4.2` | major | Blocked by Prisma 7 migration work in [`lib/db.ts`](../lib/db.ts) and CLI config changes |
-| `next` | `16.1.6` | `16.1.6` | aligned | Version bump landed; remaining work is migration cleanup and verification |
-| `react` + `react-dom` | `19.2.4` | `19.2.4` | aligned | Version bump landed with the Next 16 migration wave |
-| `socket.io` + `socket.io-client` | `4.8.3` | `4.8.3` | patch | Completed on 2026-03-09 |
-| `@sentry/nextjs` | `10.42.0` | `10.42.0` | minor | Completed on 2026-03-09 |
-| `react-i18next` | `16.5.6` | `16.5.6` | minor | Completed on 2026-03-09 |
-| `i18next` | `25.8.16` | `25.8.16` | minor | Completed on 2026-03-09 |
-| `resend` | `6.9.3` | `6.9.3` | minor | Completed on 2026-03-09 |
-| `dotenv` | `17.3.1` | `17.3.1` | patch | Completed on 2026-03-09 |
-| `tailwindcss` | `3.4.14` | `4.2.1` | major | Separate migration; config and CSS pipeline change |
-| `zod` | `3.23.8` | `4.3.6` | major | Wide validation surface across auth, env, and lobby APIs |
-| `eslint` | `9.39.4` | `10.0.3` | major | Flat config is in place; ESLint 10 remains a separate toolchain wave |
-| `lefthook` | `1.13.6` | `2.1.3` | major | Separate hook config migration |
+The previous high-risk framework and ORM upgrades have landed:
 
-## Audit status
+- Prisma 7 is active.
+- Next.js 16 and React 19 are active.
+- Node.js 20.19+ is the documented local/runtime baseline.
+- Prisma client generation uses explicit output through `prisma.config.ts`.
+- Runtime DB access uses the Prisma PostgreSQL adapter path in `lib/db.ts`.
 
-`npm audit` is clean as of 2026-03-09.
+## Remaining upgrade tracks
 
-Completed on 2026-03-09:
+### Tailwind CSS 4
 
-1. Wave 0 tooling cleanup for MCP and markdown tooling (`#196`)
-2. Wave 1 low-risk runtime upgrades (`#197`)
-
-Remaining work is now limited to the major/framework waves below.
-
-## Repo-specific blockers
-
-### Prisma 7
-
-- [`lib/db.ts`](../lib/db.ts) still uses `prisma.$use(...)` middleware for retry and timeout handling. Prisma 6 deprecated middleware in favor of Client extensions and query extensions, and Prisma 7 removes more legacy paths.
-- Package scripts still hardcode `--schema prisma/schema.prisma`. Prisma 7 uses `prisma.config.ts` as the CLI configuration entry point.
-- Prisma 7 requires an explicit generator `output` path instead of relying on the old default location.
-- CI already runs Node 20, but [`docs/LOCAL_SETUP.md`](./LOCAL_SETUP.md) and [`docs/OPERATIONS.md`](./OPERATIONS.md) still state `Node.js 18+`. Those docs must be updated when the Prisma/Next upgrade actually lands.
-
-### Next 16 + React 19
-
-- [`next.config.js`](../next.config.js) contains a custom `webpack` hook. Next 16 uses Turbopack by default for `next build`, and the official upgrade guide says builds fail when a custom webpack config is still present unless the project explicitly stays on `--webpack` or migrates the config.
-- The repo now uses [`proxy.ts`](../proxy.ts), but the remaining Next 16 cleanup still needs deliberate verification under the Node.js proxy runtime.
-- The async request API migration is mostly in good shape already:
-  - `params` and `searchParams` are already typed as `Promise<...>` in many App Router files
-  - `cookies()` usage in [`lib/next-auth.ts`](../lib/next-auth.ts) is already awaited
-- There are no App Router parallel route slots (`app/@...`) in the current tree, so the new `default.js` requirement is not a blocker here.
-
-### Tailwind 4
-
-- The repo currently uses [`tailwind.config.ts`](../tailwind.config.ts), [`postcss.config.js`](../postcss.config.js), and `@tailwind base/components/utilities` in [`app/globals.css`](../app/globals.css).
-- Tailwind 4 changes the configuration and PostCSS integration model, so this should stay isolated from the Next 16 migration.
+- Current project still uses `tailwind.config.ts`, `postcss.config.js`, and `@tailwind base/components/utilities` in `app/globals.css`.
+- Tailwind 4 changes the CSS/config/PostCSS model, so keep it separate from app runtime changes.
+- Verification should include representative desktop/mobile screenshots for lobby, games, auth pages, admin pages, and shared UI primitives.
 
 ### Zod 4
 
-- `zod` is used in auth, env validation, lobby routes, and multiple game validators.
-- The repo also relies on `ZodError` formatting and helper mapping in [`lib/validation/auth.ts`](../lib/validation/auth.ts) and [`lib/error-handler.ts`](../lib/error-handler.ts).
-- Recommended path: move to the latest `3.25.x` first, then evaluate `4.x` in a separate PR.
+- `zod` is used across env parsing, auth validation, lobby/game APIs, and game-specific validators.
+- Audit `ZodError` formatting and helper mappings before upgrading.
+- Recommended path: land compatibility cleanup first, then upgrade in a dedicated PR with focused API/auth/game validation tests.
 
-### ESLint 10 and Lefthook 2
+### Tooling majors
 
-- The repo now uses flat ESLint config in [`eslint.config.mjs`](../eslint.config.mjs) on ESLint 9 to stay compatible with `eslint-config-next@16`.
-- ESLint 10 is still a separate follow-up because it should be validated independently from the Next 16 migration wave.
-- Lefthook 2 should be treated as a separate hook-config migration, not bundled into app-runtime changes.
+- ESLint upgrades should be tested with `npm run lint`, `npm run typecheck`, and the Next.js ESLint compatibility matrix.
+- Lefthook upgrades should be limited to hook installation/config behavior and verified with `npm run hooks:pre-commit` and `npm run hooks:pre-push`.
 
-## Recommended execution order
+## Upgrade workflow
 
-### Wave 0: development tooling audit cleanup
+For each upgrade wave:
 
-Status: completed on 2026-03-09 via `#196`
+1. Create a dedicated branch from `develop` and link the ticket in the commit message.
+2. Check current installed versions with `npm outdated` or targeted `npm view <package> version`.
+3. Read official release/upgrade notes for breaking changes.
+4. Keep unrelated dependency bumps out of the same PR unless they are required by the upgrade.
+5. Update docs only when behavior, commands, runtime requirements, or environment expectations change.
 
-Scope:
+## Verification gate
 
-- update MCP server packages that still pull old `@modelcontextprotocol/sdk`
-- update `markdownlint-cli`
-- re-run `npm audit`
+Use the gate that matches the risk level:
 
-Reason:
-
-- this clears current local tooling advisories without touching app runtime behavior
-
-### Wave 1: low-risk runtime patch and minor upgrades
-
-Status: completed on 2026-03-09 via `#197`
-
-Scope:
-
-- `socket.io` + `socket.io-client` `4.8.1 -> 4.8.3`
-- `@sentry/nextjs` `10.27.0 -> 10.42.0`
-- `react-i18next` `16.3.5 -> 16.5.6`
-- `i18next` `25.6.3 -> 25.8.15`
-- `resend` `6.1.3 -> 6.9.3`
-- `dotenv` `17.2.3 -> 17.3.1`
-
-Reason:
-
-- these are the safest updates and should happen before any major migration
-
-### Wave 2: Prisma 5 -> 7 preparation and upgrade
-
-Scope:
-
-- replace `prisma.$use(...)` middleware in [`lib/db.ts`](../lib/db.ts) with Prisma Client extensions / query extensions
-- add `prisma.config.ts`
-- add explicit client generator `output`
-- upgrade `prisma` and `@prisma/client`
-- update local docs from Node 18+ to the actual required minimum once the upgrade is confirmed
-
-Reason:
-
-- Prisma touches the entire persistence layer and must be isolated from framework upgrades
-
-### Wave 3: Next 16 + React 19
-
-Scope:
-
-- run the official Next 16 codemod
-- decide whether to keep `next build --webpack` temporarily or migrate the custom webpack logic in [`next.config.js`](../next.config.js)
-- keep [`proxy.ts`](../proxy.ts) aligned with Next 16 Node.js proxy runtime behavior during verification
-- upgrade `next`, `react`, `react-dom`, `@types/react`, and `@types/react-dom`
-
-Reason:
-
-- Next 16 and React 19 should move together; the official guide treats them as one upgrade step
-
-### Wave 4: isolated major migrations
-
-Scope:
-
-- `tailwindcss` 3 -> 4
-- `zod` 3 -> 4
-- `eslint` 8 -> 10
-- `lefthook` 1 -> 2
-
-Reason:
-
-- each of these changes a different part of the toolchain and should not be bundled into the ORM or framework waves
-
-## Verification gate for every wave
-
-Run the smallest gate that still matches the risk level. For Prisma and Next waves, do the full gate.
-
-- `npm install`
-- `npm audit`
-- `npm run ci:quick`
-- `npm test`
-- `npm run ready:build-test`
-- manual smoke: register, login, guest join, create lobby, start game, reconnect once, finish game
-
-For the Next 16 wave, add:
-
-- `npm run dev:all`
-- browser smoke of key routes in a real browser
-- focused check of admin pages, auth pages, and lobby/game flow
+- Small patch/minor dependency: `npm run ci:quick` and relevant tests.
+- Prisma/DB dependency: `npm run db:validate`, `npm run db:generate`, `npm run db:rls:smoke`, `npm run check:db`, plus relevant API smoke coverage.
+- Next/React/runtime dependency: `npm run ci:quick`, `npm test`, `npm run ready:build-test`, plus browser smoke for register/login, guest join, create lobby, start game, reconnect, finish game.
+- Styling/tooling dependency: `npm run lint`, `npm run typecheck`, relevant UI checks, and hook commands if hook config changed.
 
 ## Official references
 
-- Prisma ORM 7 upgrade guide: <https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-7>
-- Next.js 16 upgrade guide: <https://nextjs.org/docs/app/guides/upgrading/version-16>
-- React 19 release post: <https://react.dev/blog/2024/12/05/react-19>
-- Tailwind CSS v4 upgrade guide: <https://tailwindcss.com/docs/upgrade-guide>
-- ESLint migration guide: <https://eslint.org/docs/latest/use/configure/migration-guide>
+- Prisma ORM upgrade guides: <https://www.prisma.io/docs/orm/more/upgrade-guides>
+- Next.js upgrade guides: <https://nextjs.org/docs/app/guides/upgrading>
+- React release blog: <https://react.dev/blog>
+- Tailwind CSS upgrade guide: <https://tailwindcss.com/docs/upgrade-guide>
+- Zod release notes: <https://github.com/colinhacks/zod/releases>
+- ESLint migration guides: <https://eslint.org/docs/latest/use/migrate-to-latest-version>

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -78,9 +78,10 @@ Recommended:
 - hosted `DATABASE_URL` note: if your provider ships `sslmode=require` without a CA bundle, Boardly now enables libpq-compatible TLS semantics at runtime unless `MCP_POSTGRES_CA_CERT_PATH` is configured for strict `verify-full`
 - `BOT_UX_DELAY_MS` or `BOT_UX_DELAY_SCALE` + `BOT_UX_DELAY_MIN_MS` + `BOT_UX_DELAY_MAX_MS` (optional bot UX timing controls)
 - `ANALYTICS_ALLOWED_USER_IDS` / `ANALYTICS_ALLOWED_EMAILS` (restrict analytics endpoints)
-- `OPS_ALERT_WEBHOOK_URL` (alerts channel webhook)
+- `OPS_ALERT_WEBHOOK_URL` (Discord webhook for reliability alerts)
 - `OPS_ALERT_WINDOW_MINUTES`, `OPS_ALERT_BASELINE_DAYS`, `OPS_ALERT_REPEAT_MINUTES`
 - `OPS_RUNBOOK_BASE_URL` (optional absolute runbook links in alert payloads)
+- `GITHUB_ALERT_TOKEN` / `GITHUB_ALERT_REPO` (optional GitHub issue creation/closure for reliability alerts; repo format is `owner/repo`)
 - `CLEANUP_GUEST_DAYS` (optional guest retention window, defaults to `3`)
 - `REPLAY_RETENTION_DAYS` (optional replay retention window for finished/abandoned/cancelled games, defaults to `90`)
 - `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` (optional shared rate-limit backend for production; when absent, app falls back to in-memory limiter)
@@ -237,7 +238,8 @@ Check:
 
 Check:
 
-- `OPS_ALERT_WEBHOOK_URL` is configured and valid
+- `OPS_ALERT_WEBHOOK_URL` is configured as a Discord webhook and valid
+- if GitHub issue automation is enabled, `GITHUB_ALERT_TOKEN` and `GITHUB_ALERT_REPO` are configured
 - cron auth header includes `Bearer ${CRON_SECRET}` for `/api/cron/reliability-alerts` (no `NEXTAUTH_SECRET` fallback)
 - if using GitHub Actions scheduling, `RELIABILITY_ALERTS_CRON_URL` and `CRON_SECRET` repo secrets are configured
 - `OperationalEvents` contains recent `rejoin_timeout` / `auth_refresh_failed` / `move_apply_timeout`
@@ -248,7 +250,7 @@ Check:
 Check response headers for representative routes (for example `/games`, `/lobby`, `/auth/login`):
 
 - `Content-Security-Policy` `script-src` includes `'self'` and trusted script origins
-- `Content-Security-Policy` `script-src` includes `'unsafe-inline'` (required by current Next.js 15 bootstrap output)
+- `Content-Security-Policy` `script-src` includes `'unsafe-inline'` (required by current Next.js App Router bootstrap output)
 - `Content-Security-Policy` does not include `'unsafe-eval'` in `script-src`
 
 Example:

--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -1,6 +1,8 @@
 # PWA Support (Issue #44)
 
-Updated: 2026-02-25
+Updated: 2026-04-22
+
+Issue #44 shipped and was closed on 2026-02-25. This page now tracks the current PWA implementation and regression checks.
 
 ## Implemented
 
@@ -36,7 +38,7 @@ This regenerates:
 - `public/icons/icon-maskable-512.png`
 - `public/splash/apple-splash-*.png`
 
-## Manual QA Checklist (Required Before Closing #44)
+## Manual QA Checklist
 
 - Android Chrome: install prompt appears and app installs
 - iOS Safari: "Add to Home Screen" works and splash screen is shown on launch

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ This folder contains the canonical project documentation.
 - `docs/SECURITY_MODEL.md` - auth boundaries, RLS posture, secrets policy
 - `docs/REALTIME_TELEMETRY.md` - reconnect telemetry events, dashboards, SLOs, alerts
 - `docs/DEPENDENCY_UPGRADE_PLAN.md` - staged dependency maintenance plan and migration sequencing
+- `docs/PWA.md` - current PWA implementation and install/offline regression checks
+- `docs/PERFORMANCE_BUNDLE_BUDGET.md` - bundle budget policy and measurement baselines
 
 ## Specialized docs
 
@@ -27,9 +29,20 @@ This folder contains the canonical project documentation.
 - `SECURITY.md` - vulnerability reporting policy
 - `CODE_OF_CONDUCT.md` - community standards
 - `.github/copilot-instructions.md` - AI-agent execution guide for this repo
+- `.github/PULL_REQUEST_TEMPLATE.md` - PR checklist used by GitHub
+- `.github/ISSUE_TEMPLATE/*.md` - issue templates used by GitHub
+- `.vscode/README.md` - optional local MCP/tooling setup notes
+
+## Historical archives
+
+- `docs/superpowers/specs/**` and `docs/superpowers/plans/**` are historical planning artifacts.
+- Use them for context only; do not treat them as current implementation instructions.
+- Canonical behavior should be confirmed in the core docs, `prisma/schema.prisma`, package scripts, and source code.
+- Archival docs can contain old URLs, old command snippets, and old roadmap assumptions.
 
 ## Documentation rules
 
 - Keep docs short and source-of-truth oriented.
 - Prefer one canonical page per topic instead of status snapshots.
 - Remove or merge historical writeups once decisions are absorbed.
+- Canonical docs should pass markdownlint; archival docs are excluded unless they are being actively refreshed.

--- a/docs/REALTIME_TELEMETRY.md
+++ b/docs/REALTIME_TELEMETRY.md
@@ -32,17 +32,19 @@ This document defines the production reliability telemetry path, alert rules, KP
 
 ## Alert Delivery
 
-Set webhook channel and alert windows in env:
+Set alert delivery and alert windows in env:
 
-- `OPS_ALERT_WEBHOOK_URL`
+- `OPS_ALERT_WEBHOOK_URL` (Discord webhook)
 - `OPS_ALERT_WINDOW_MINUTES` (default: `10`)
 - `OPS_ALERT_BASELINE_DAYS` (default: `7`)
 - `OPS_ALERT_REPEAT_MINUTES` (default: `60`)
 - `OPS_RUNBOOK_BASE_URL` (optional; used to build absolute runbook links)
+- `GITHUB_ALERT_TOKEN` / `GITHUB_ALERT_REPO` (optional; create and close GitHub issues for alert state transitions)
 
-Supported channels: Slack/Discord/Teams webhook endpoints.
+Webhook payloads are sent as Discord embeds. If GitHub alert env vars are configured, the first trigger for an alert state opens a GitHub issue and alert resolution closes that issue.
 
 Scheduler note:
+
 - Vercel Hobby only supports cron jobs that run once per day.
 - Use the GitHub Actions scheduler (`.github/workflows/reliability-alerts-cron.yml`) for 10-minute reliability alert checks on Hobby.
 - Vercel cron for `/api/cron/reliability-alerts` is only suitable on plans that support sub-daily cron intervals.
@@ -51,17 +53,20 @@ Scheduler note:
 
 Rules are evaluated in `evaluateReliabilityAlerts()` (`lib/operational-metrics.ts`) and dispatched by `runReliabilityAlertCycle()` (`lib/reliability-alerts.ts`).
 
-1. `rejoin_timeout` spike
+### `rejoin_timeout` spike
+
 - Severity: `critical`
 - Condition: current window count >= `max(2, baseline_per_window * 3)`
 - Window: `OPS_ALERT_WINDOW_MINUTES`
 
-1. `auth_refresh_failed` ratio
+### `auth_refresh_failed` ratio
+
 - Severity: `warning`
 - Condition: `auth_refresh_failed / reconnect_cycles >= 2%` for windows with >= 5 reconnect cycles
 - Window: `OPS_ALERT_WINDOW_MINUTES`
 
-1. `move_apply_timeout` spike or latency breach
+### `move_apply_timeout` spike or latency breach
+
 - Severity: `warning` (count spike), `critical` (latency breach)
 - Condition A: current timeout count >= `max(3, baseline_per_window * 3)`
 - Condition B: `move_submit_applied` p95 > `MOVE_APPLY_TARGET_MS` (`800ms`)
@@ -97,21 +102,18 @@ Baseline is computed from the previous `baselineDays` window (default 7 days), s
 
 ## Runbook
 
-<a id="runbook-rejoin-timeout"></a>
 ### If `rejoin_timeout` breaches
 
 - Check Socket.IO service health and deploy/cold-start windows
 - Check lobby join ACK behavior in `useSocketConnection` and socket room authorization
 - Check DB latency on lobby/member queries
 
-<a id="runbook-auth-refresh-failed"></a>
 ### If `auth_refresh_failed` breaches
 
 - Check `/api/socket/token` status trend (`401`/`403`/`5xx`)
 - Check auth secret/session validity (`NEXTAUTH_SECRET`, provider state)
 - Check token refresh path in `useSocketConnection` (`token_fetch`, `socket_auth_payload`)
 
-<a id="runbook-move-apply-timeout"></a>
 ### If `move_apply_timeout` breaches
 
 - Check `/api/game/[gameId]/state` p95 and DB lock/contention

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -21,7 +21,7 @@
 ### Browser CSP layer
 
 - Production CSP keeps `script-src` locked to `'self'` plus explicit trusted domains, and disallows `'unsafe-eval'`.
-- Production currently allows `'unsafe-inline'` to support Next.js 15 app-router bootstrap scripts on statically rendered routes.
+- Production currently allows `'unsafe-inline'` to support current Next.js App Router bootstrap scripts on statically rendered routes.
 - Development keeps relaxed script directives only where needed for local tooling/HMR.
 
 ### Database safety layer (RLS)

--- a/lib/bots/README.md
+++ b/lib/bots/README.md
@@ -6,20 +6,20 @@ The bot system is designed to be **modular and game-agnostic**. Each game can ha
 
 ```text
 lib/bots/
-├── core/                         # Universal bot infrastructure
-│   ├── base-bot.ts              # Abstract base class
-│   ├── bot-types.ts             # Shared types and interfaces
-│   ├── bot-executor.ts          # Universal bot turn executor
-│   ├── bot-factory.ts           # Factory for creating bot instances
-│   └── bot-helpers.ts           # Utility functions (isBot, getBotDifficulty)
-├── yahtzee/                     # Yahtzee-specific bots
-│   ├── yahtzee-bot.ts          # YahtzeeBot (extends BaseBot)
-│   ├── yahtzee-bot-ai.ts       # Pure AI decision logic
-│   └── yahtzee-bot-executor.ts # Turn execution with visual feedback
-├── spy/                         # Future: Guess the Spy bots
-├── uno/                         # Future: Uno bots
-└── index.ts                     # Barrel exports
+|-- core/                         # Universal bot infrastructure
+|   |-- base-bot.ts               # Abstract base class
+|   |-- bot-types.ts              # Shared types and interfaces
+|   |-- bot-executor.ts           # Universal bot turn executor
+|   |-- bot-factory.ts            # Factory for creating bot instances
+|   |-- bot-helpers.ts            # Utility functions (isBot, getBotDifficulty)
+|   `-- bot-ux-timing.ts          # Configurable bot delay helpers
+|-- rock-paper-scissors/          # Rock Paper Scissors bot
+|-- tic-tac-toe/                  # Tic-Tac-Toe bot
+|-- yahtzee/                      # Yahtzee bot
+`-- index.ts                      # Barrel exports
 ```
+
+Current bot-supported games are `yahtzee`, `tic_tac_toe`, and `rock_paper_scissors`. Other registered game types can still run without bots until a game-specific bot/executor is added.
 
 ## Key Concepts
 
@@ -227,15 +227,14 @@ export class SpyBotExecutor {
 
 ### Step 4: Register in Bot Factory
 
-Add your bot to `lib/bots/core/bot-factory.ts`:
+Add your bot to `lib/bots/core/bot-factory.ts`. The factory receives `RegisteredGameType` from `lib/game-registry.ts`; only add cases for games that have a real bot implementation:
 
 ```typescript
 import { SpyBot } from '../spy/spy-bot'
-
-export type GameType = 'yahtzee' | 'guess_the_spy' | 'uno' | 'chess' | 'other'
+import type { RegisteredGameType } from '@/lib/game-registry'
 
 export function createBot<T extends GameEngine>(
-    gameType: GameType,
+    gameType: RegisteredGameType,
     gameEngine: T,
     difficulty: BotDifficulty = 'medium'
 ): BaseBot<T, any> {
@@ -374,9 +373,12 @@ model Bots {
   id         String   @id @default(cuid())
   userId     String   @unique
   user       Users    @relation(fields: [userId], references: [id], onDelete: Cascade)
-  botType    String   // 'yahtzee', 'spy', 'uno', 'chess'
+  botType    String   @default("yahtzee") // "yahtzee", "tic_tac_toe", "rock_paper_scissors", etc.
   difficulty String   @default("medium") // 'easy', 'medium', 'hard'
-  createdAt  DateTime @default(now())
+  createdAt  DateTime @default(now()) @db.Timestamptz(3)
+
+  @@index([userId])
+  @@index([botType])
 }
 ```
 
@@ -576,5 +578,5 @@ File issues or discuss in team chat. This system is designed to make adding game
 
 ---
 
-**Last Updated**: February 2026  
-**Version**: 2.0 (Modular Architecture)
+**Last Updated**: April 2026
+**Version**: 2.1 (Modular Architecture)

--- a/prisma/migrations/README.md
+++ b/prisma/migrations/README.md
@@ -1,111 +1,180 @@
 # Prisma Migrations
 
-This directory contains all database migrations for the Boardly project.
+This directory contains the database migration history for Boardly.
 
-## Migration Timeline
+The migration SQL files are the source of truth. This README is an orientation index for humans and should be updated when a migration adds a new domain area, security posture, or operational workflow.
 
-### 20260212000000_init
+## Migration timeline
 
-Complete initial schema - Squashed from all previous migrations for clean state
+### Historical pre-baseline migrations
 
-Creates the full Boardly database schema:
+The `202512...` migrations are retained because they are part of the applied history in existing environments. They cover early user profile/statistics work, game lifecycle fields, friend codes, cleanup of unused models, spy locations, and guest tracking fields.
 
-#### Enums
+### `20260212000000_init`
 
-- GameStatus (waiting, playing, finished, abandoned, cancelled)
-- GameType (yahtzee, tic_tac_toe, rock_paper_scissors, chess, guess_the_spy, uno, other)
+Squashed baseline schema for the modern Boardly database.
 
-#### Core Tables
+Main domains:
 
-- Users (with friendCode, isGuest, lastActiveAt for guest/social features)
-- Bots (platform, name, skill, stats, userId for bot player system)
-- Accounts (OAuth provider accounts)
-- Sessions (user sessions)
-- VerificationTokens, PasswordResetTokens, EmailVerificationTokens
+- Users, auth/session tables, and verification/reset tokens
+- Bots as a one-to-one relation from `Users`
+- Lobbies, games, players, and game lifecycle state
+- Friend requests, friendships, lobby invites, and spy locations
+- Core enums for game status and game type
 
-#### Game Tables
+### `20260212000001_enable_rls`
 
-- Lobbies (with turnTimer for timed games)
-- Games (with gameType enum, abandonedAt for game lifecycle)
-- Players (with finalScore, placement, isWinner, yahtzeeStats & yahtzeeData)
+Initial Row Level Security setup.
 
-#### Social Features
+- Adds helper functions for current-user/auth checks.
+- Enables RLS on application tables.
+- Grants app roles and baseline access policies.
 
-- FriendRequests (sender/receiver with status tracking)
-- Friendships (user1/user2 with timestamps)
-- SpyLocations (game locations with activity flags)
+### `20260216000000_add_lobby_invites`
 
-All tables use proper plural names with indexes and foreign key constraints.
+Adds lobby invite storage and supporting social invite indexes.
 
-### 20260212000001_enable_rls
+### `20260218...` RLS cleanup and repair
 
-Complete RLS setup:
+Supabase linter and baseline policy repair migrations:
 
-- Helper functions: get_current_user_id(), is_authenticated()
-- Enabled RLS on all 13 tables
-- Created policies for secure multi-tenant access
-- Performance indexes: idx_players_userid_gameid, idx_games_lobbyid, idx_lobbies_creatorid, idx_bots_userid
-- Granted permissions to authenticated and service_role roles
+- `20260218000000_rls_linter_cleanup`
+- `20260218010000_rls_baseline_policy_repair`
 
-### 20260218000000_rls_linter_cleanup
+These migrations tighten helper functions, service-role policies, `_prisma_migrations` RLS handling, and baseline app access policies.
 
-Supabase linter hardening pass:
+### `20260221000000_add_operational_observability_tables`
 
-- Added helper function `is_service_role()`
-- Updated helper functions with stable + fixed `search_path`
-- Enabled RLS on `public._prisma_migrations`
-- Removed legacy `Service role full access` policies
-- Scoped service policies to `TO service_role` with explicit checks
-- Consolidated FriendRequests RLS policies to reduce permissive-policy fanout
+Adds operational reliability storage:
 
-### 20260218010000_rls_baseline_policy_repair
+- `OperationalEvents`
+- `OperationalAlertStates`
 
-Baseline policy restoration:
+These tables back reconnect/move-latency telemetry, alert dedupe, and KPI reporting.
 
-- Recreates missing baseline policies used by app flows and smoke-checks:
-  - `Users can view own profile`
-  - `Users can view public info`
-  - `Anyone can view bots`
-  - `Anyone can view lobbies`
-  - `Players can view their games`
-  - `Users can view players in their games`
-- Uses explicit roles and `(select public.get_current_user_id())` pattern.
+### `20260225...` lobby spectators and notification foundations
 
-### 20260221000000_add_operational_observability_tables
+Adds spectator support and notification preference/storage tables:
 
-Operational observability storage:
+- `20260225000100_add_lobby_spectators`
+- `20260225000300_add_notification_preferences`
+- `20260225000400_add_notifications_table`
 
-- Adds `OperationalEvents` table for persisted reliability telemetry.
-- Adds `OperationalAlertStates` table for alert deduplication/escalation state.
-- Adds indexes for event/time and game/time slices used by KPI/alert queries.
+### `20260226...` notification, auth, and social hardening
 
-## Row Level Security (RLS)
+Hardens notification RLS, auth foreign-key indexes, social pair integrity, and `Users` select policies:
 
-All tables have RLS enabled with appropriate policies:
+- `20260226213000_harden_notifications_ops_rls_and_auth_fk_indexes`
+- `20260226223500_enforce_social_pair_integrity`
+- `20260226231000_consolidate_users_select_policies`
 
-- Service role has full access for backend operations
-- Users can only access their own data
-- Game-related data is accessible based on participation
-- Social features respect privacy boundaries
+### `20260227...` admin, memory, and replay snapshots
 
-## Running Migrations
+Adds admin role/suspension fields, the `memory` game type, and replay/state snapshot storage:
+
+- `20260227101500_add_users_role_and_suspended_columns`
+- `20260227193000_add_memory_game_type`
+- `20260227201000_add_game_replay_snapshots`
+
+### `20260228004500_harden_rls_enums_timestamptz_admin_audit`
+
+Adds admin audit logging and hardens RLS/enums/timestamp usage.
+
+### `20260309...` game schema expansion
+
+`20260309121500_harden_games_schema_and_expand_game_types` expands supported game metadata and game type values for newer party-game work.
+
+### `20260310...` profile and email fields
+
+Adds pending-email and public-profile identifiers:
+
+- `20260310174000_add_pending_email_to_users`
+- `20260310183000_add_public_profile_id`
+
+### `20260311...` in-app notification refinements
+
+Adds/refines in-app notification preference fields:
+
+- `20260311101500_add_in_app_notifications`
+- `20260311124500_add_in_app_notification_preference`
+
+### `20260312...` account preferences
+
+Adds account preferences, profile visibility, and online-status preference fields:
+
+- `20260312110000_add_account_preferences`
+- `20260312123000_add_show_online_status_to_account_preferences`
+
+### `20260325...` match timing and game type cleanup
+
+Adds match timing metadata and removes old `chess`/`uno` enum values:
+
+- `20260325000000_add_match_timing_metadata`
+- `20260325120000_remove_chess_uno_from_gametype`
+
+### `20260328...` feedback
+
+`20260328000000_add_feedback_table` adds user feedback storage.
+
+### `20260331...` onboarding
+
+`20260331000000_add_onboarding_fields` adds onboarding completion/skip fields.
+
+### `20260402...` account preferences and feedback RLS
+
+`20260402000000_enable_rls_account_preferences_feedback` enables RLS and policies for the account preferences and feedback tables.
+
+### `20260403...` alias
+
+`20260403000000_add_alias_game_type` adds the `alias` game type.
+
+### `20260422...` alert GitHub issue links
+
+`20260422000000_add_github_issue_number_to_alert_states` adds `githubIssueNumber` to `OperationalAlertStates` so reliability alerts can open/close linked GitHub issues.
+
+## Row Level Security
+
+RLS is part of the database safety model:
+
+- Service role has backend access for trusted server operations.
+- Users are scoped to their own identity, preferences, notifications, and social data where appropriate.
+- Game and lobby data is scoped through creator/member/player relationships.
+- Operational/admin tables use service/admin-oriented policies.
+
+Use `npm run db:rls:smoke` after changing any RLS policy, helper function, or table that is covered by RLS.
+
+## Running migrations
 
 ### Development
+
+Create new migrations with Prisma's development command when a schema change needs migration SQL:
 
 ```bash
 npx prisma migrate dev
 ```
 
-### Production
+For local schema sync without creating a migration:
 
 ```bash
-npx prisma migrate deploy
+npm run db:push
 ```
 
-### RLS Smoke Tests
+### Production or deploy-style local checks
+
+```bash
+npm run db:migrate
+```
+
+`npm run db:migrate` prepares the required RLS roles before running `prisma migrate deploy`.
+
+Check migration status:
+
+```bash
+npm run db:migrate:status
+```
+
+### RLS smoke tests
 
 ```bash
 npm run db:rls:smoke
 ```
-
-This runs comprehensive checks to ensure RLS is properly configured on all tables.

--- a/public/sounds/README.md
+++ b/public/sounds/README.md
@@ -13,6 +13,7 @@ This directory should contain the following sound files for the game:
 ## Sound Sources
 
 You can find free sound effects at:
+
 - [Freesound.org](https://freesound.org/)
 - [Mixkit](https://mixkit.co/free-sound-effects/)
 - [Zapsplat](https://www.zapsplat.com/)
@@ -20,6 +21,7 @@ You can find free sound effects at:
 ## Notes
 
 - All files should be in MP3 format for broad browser compatibility
-- Keep file sizes small (< 100KB each) for fast loading
+- Keep file sizes small, around 100 KiB or less where practical, for fast loading
 - Volume levels should be normalized across all files
 - Sound effects should be short (< 2 seconds)
+- Keep attribution details in `CREDITS.txt` when a source requires credit


### PR DESCRIPTION
## Summary
- Refresh canonical docs against the current Prisma schema, game registry, package versions, operational alert flow, and MCP setup.
- Mark `docs/superpowers/**` as historical archive material instead of canonical implementation guidance.
- Rewrite the dependency upgrade and migration README pages so they reflect the current Prisma 7 / Next 16 / React 19 state.

## Verification
- `npx markdownlint --ignore node_modules --ignore .next --ignore docs/superpowers **/*.md`
- custom npm script reference check across canonical Markdown files
- `git diff --check`
- `npm run ci:quick`
- pre-push hook: `npm run db:generate`, `npm run check:locales`, `npm run ci:quick`, smoke Jest paths

Closes #366