### PR TITLE
docs(#368): document Obsidian vault workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,8 @@ reports/*.json
 !.vscode/tasks.json
 !.vscode/README.md
 .idea
+.obsidian/
+.trash/
 .DS_Store
 *.suo
 *.ntvs*
@@ -155,6 +157,7 @@ backup_*.sql
 
 # Local development files
 .codex-local/
+notes-local/
 .lefthook-local.yml
 *.bat
 *.sh

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ npm run db:rls:smoke
 - Security model details: `docs/SECURITY_MODEL.md`
 - Realtime telemetry baseline: `docs/REALTIME_TELEMETRY.md`
 - Dependency maintenance plan: `docs/DEPENDENCY_UPGRADE_PLAN.md`
+- Obsidian vault workflow: `docs/OBSIDIAN_VAULT.md`
 - Bot developer guide: `lib/bots/README.md`
 - Migrations and RLS notes: `prisma/migrations/README.md`
 - AI agent instructions: `.github/copilot-instructions.md`

--- a/docs/OBSIDIAN_VAULT.md
+++ b/docs/OBSIDIAN_VAULT.md
@@ -1,0 +1,42 @@
+# Obsidian Vault Workflow
+
+Boardly can be opened directly as an Obsidian vault. This is optional local tooling; GitHub Issues, PRs, source files, and the canonical Markdown docs remain the project source of truth.
+
+## Recommended setup
+
+1. Open the repository root (`Boardly/`) as an Obsidian vault.
+2. Keep Obsidian workspace metadata local. The root `.obsidian/` folder is ignored by git.
+3. If you want private working notes inside the workspace, put them under `notes-local/`. That folder is also ignored by git.
+4. Use standard Markdown links in committed docs, for example `[Architecture](ARCHITECTURE.md)`. Avoid Obsidian-only wikilinks in files that will be committed.
+
+## Source of truth
+
+Use committed Markdown for durable project knowledge:
+
+- `README.md` for entry-point setup and repository map.
+- `docs/README.md` for documentation navigation.
+- `docs/ARCHITECTURE.md`, `docs/OPERATIONS.md`, and `docs/SECURITY_MODEL.md` for canonical technical behavior.
+- GitHub Issues/Projects for active task tracking.
+
+Use private Obsidian notes for:
+
+- rough investigations
+- meeting notes
+- personal checklists
+- idea capture before a ticket exists
+
+When a private note becomes a real decision, move the durable part into a canonical doc or a GitHub issue.
+
+## Linking and organization
+
+- Prefer relative Markdown links for committed docs so links work in GitHub and Obsidian.
+- Keep broad navigation in `docs/README.md`.
+- Keep implementation plans in GitHub issues or PR descriptions unless they need to become long-term reference material.
+- Treat `docs/superpowers/**` as historical archive material, not current source-of-truth documentation.
+
+## Safety rules
+
+- Do not store secrets, tokens, env values, database dumps, or private user data in Obsidian notes.
+- Do not commit `.obsidian/`, `.trash/`, or `notes-local/`.
+- Before committing docs, run `git status --short` and make sure only intentional files are staged.
+- If a committed Markdown file changes, keep it valid GitHub Markdown and run markdownlint when practical.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This folder contains the canonical project documentation.
 - `docs/DEPENDENCY_UPGRADE_PLAN.md` - staged dependency maintenance plan and migration sequencing
 - `docs/PWA.md` - current PWA implementation and install/offline regression checks
 - `docs/PERFORMANCE_BUNDLE_BUDGET.md` - bundle budget policy and measurement baselines
+- `docs/OBSIDIAN_VAULT.md` - local Obsidian vault workflow and note-safety rules
 
 ## Specialized docs
 


### PR DESCRIPTION
## Summary
- Add `docs/OBSIDIAN_VAULT.md` with a lightweight Boardly + Obsidian workflow.
- Clarify canonical docs vs private local notes.
- Ignore local Obsidian metadata and private note folders.
- Link the workflow from `README.md` and `docs/README.md`.

## Verification
- `npx markdownlint --ignore node_modules --ignore .next --ignore docs/superpowers **/*.md`
- `git diff --check`
- pre-push hook: `npm run db:generate`, `npm run check:locales`, `npm run ci:quick`, smoke Jest paths

Closes #368