### PR TITLE
fix(#372): tolerate reliability alert schema lag

### DIFF
--- a/__tests__/lib/reliability-alerts.test.ts
+++ b/__tests__/lib/reliability-alerts.test.ts
@@ -1,0 +1,128 @@
+// @ts-nocheck
+
+import { runReliabilityAlertCycle } from '@/lib/reliability-alerts'
+import { prisma } from '@/lib/db'
+import { evaluateReliabilityAlerts } from '@/lib/operational-metrics'
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    operationalAlertStates: {
+      findMany: jest.fn(),
+      upsert: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/operational-metrics', () => ({
+  evaluateReliabilityAlerts: jest.fn(),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockEvaluateReliabilityAlerts =
+  evaluateReliabilityAlerts as jest.MockedFunction<typeof evaluateReliabilityAlerts>
+
+function breachedRule(overrides = {}) {
+  return {
+    alertKey: 'rejoin_timeout',
+    breached: true,
+    severity: 'critical',
+    currentValue: 3,
+    thresholdValue: 2,
+    baselineValue: 0,
+    unit: 'count',
+    summary: 'Reconnect timeouts breached',
+    windowMinutes: 10,
+    runbookPath: '/docs/REALTIME_TELEMETRY.md#rejoin_timeout',
+    ...overrides,
+  }
+}
+
+describe('runReliabilityAlertCycle', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn()
+    mockPrisma.operationalAlertStates.findMany.mockResolvedValue([])
+    mockPrisma.operationalAlertStates.upsert.mockResolvedValue({ id: 'state-1' })
+    mockPrisma.operationalAlertStates.update.mockResolvedValue({ id: 'state-1' })
+    mockEvaluateReliabilityAlerts.mockResolvedValue({
+      generatedAt: '2026-04-22T12:00:00.000Z',
+      windowMinutes: 10,
+      baselineDays: 7,
+      rules: [breachedRule()],
+    })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('falls back when githubIssueNumber column is missing', async () => {
+    const missingColumnError = Object.assign(
+      new Error(
+        'Invalid `prisma.operationalAlertStates.findMany()` invocation: The column `(not available)` does not exist in the current database.'
+      ),
+      {
+        code: 'P2022',
+        meta: {
+          modelName: 'OperationalAlertStates',
+          column: 'githubIssueNumber',
+        },
+      }
+    )
+
+    mockPrisma.operationalAlertStates.findMany
+      .mockRejectedValueOnce(missingColumnError)
+      .mockResolvedValueOnce([])
+
+    const result = await runReliabilityAlertCycle({
+      githubToken: 'github-token',
+      githubRepo: 'owner/repo',
+    })
+
+    expect(result.triggered.map((rule) => rule.alertKey)).toEqual(['rejoin_timeout'])
+    expect(mockPrisma.operationalAlertStates.findMany).toHaveBeenCalledTimes(2)
+    expect(mockPrisma.operationalAlertStates.findMany.mock.calls[0][0].select).toHaveProperty(
+      'githubIssueNumber',
+      true
+    )
+    expect(mockPrisma.operationalAlertStates.findMany.mock.calls[1][0].select).not.toHaveProperty(
+      'githubIssueNumber'
+    )
+    expect(global.fetch).not.toHaveBeenCalled()
+
+    const upsertArgs = mockPrisma.operationalAlertStates.upsert.mock.calls[0][0]
+    expect(upsertArgs.create).not.toHaveProperty('githubIssueNumber')
+    expect(upsertArgs.update).not.toHaveProperty('githubIssueNumber')
+  })
+
+  it('creates and persists a GitHub issue number when the column is available', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 123 }),
+    })
+
+    await runReliabilityAlertCycle({
+      githubToken: 'github-token',
+      githubRepo: 'owner/repo',
+    })
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/owner/repo/issues',
+      expect.objectContaining({ method: 'POST' })
+    )
+
+    const upsertArgs = mockPrisma.operationalAlertStates.upsert.mock.calls[0][0]
+    expect(upsertArgs.create.githubIssueNumber).toBe(123)
+    expect(upsertArgs.update.githubIssueNumber).toBe(123)
+  })
+})

--- a/lib/reliability-alerts.ts
+++ b/lib/reliability-alerts.ts
@@ -33,6 +33,32 @@ function isMissingOperationalAlertStatesTableError(error: unknown): boolean {
   return typeof meta?.table === 'string' && meta.table.includes('OperationalAlertStates')
 }
 
+function isMissingOperationalAlertStatesGithubIssueColumnError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  if (!('code' in error) || (error as { code?: unknown }).code !== 'P2022') return false
+
+  const meta = (error as { meta?: { modelName?: unknown; column?: unknown } }).meta
+  const maybeMessage = 'message' in error ? error.message : undefined
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof maybeMessage === 'string'
+        ? maybeMessage
+        : ''
+
+  const targetsOperationalAlertStates =
+    meta?.modelName === 'OperationalAlertStates' ||
+    message.includes('OperationalAlertStates') ||
+    message.includes('operationalAlertStates')
+
+  const targetsGithubIssueNumber =
+    meta?.column === 'githubIssueNumber' ||
+    message.includes('githubIssueNumber') ||
+    message.includes('The column `(not available)` does not exist')
+
+  return targetsOperationalAlertStates && targetsGithubIssueNumber
+}
+
 function shouldNotifyAgain(lastNotifiedAt: Date | null, repeatMinutes: number): boolean {
   if (!lastNotifiedAt) return true
   return Date.now() - lastNotifiedAt.getTime() >= repeatMinutes * 60 * 1000
@@ -243,10 +269,12 @@ export async function runReliabilityAlertCycle(
     githubIssueNumber: number | null
   }> = []
   let alertStatePersistenceAvailable = true
+  let githubIssuePersistenceAvailable = true
+  const alertKeys = evaluation.rules.map((r) => r.alertKey)
 
   try {
     states = await prisma.operationalAlertStates.findMany({
-      where: { alertKey: { in: evaluation.rules.map((r) => r.alertKey) } },
+      where: { alertKey: { in: alertKeys } },
       select: {
         alertKey: true,
         isOpen: true,
@@ -255,8 +283,37 @@ export async function runReliabilityAlertCycle(
       },
     })
   } catch (error) {
-    if (!isMissingOperationalAlertStatesTableError(error)) throw error
-    alertStatePersistenceAvailable = false
+    if (isMissingOperationalAlertStatesGithubIssueColumnError(error)) {
+      githubIssuePersistenceAvailable = false
+
+      try {
+        const fallbackStates = await prisma.operationalAlertStates.findMany({
+          where: { alertKey: { in: alertKeys } },
+          select: {
+            alertKey: true,
+            isOpen: true,
+            lastNotifiedAt: true,
+          },
+        })
+
+        states = fallbackStates.map((state) => ({
+          ...state,
+          githubIssueNumber: null,
+        }))
+      } catch (fallbackError) {
+        if (!isMissingOperationalAlertStatesTableError(fallbackError)) throw fallbackError
+        alertStatePersistenceAvailable = false
+      }
+    } else {
+      if (!isMissingOperationalAlertStatesTableError(error)) throw error
+      alertStatePersistenceAvailable = false
+    }
+  }
+
+  if (githubToken && githubRepo && !githubIssuePersistenceAvailable) {
+    logger.warn(
+      'OperationalAlertStates.githubIssueNumber column is missing; GitHub issue automation is disabled until the migration is applied'
+    )
   }
 
   const stateMap = new Map(states.map((s) => [s.alertKey, s]))
@@ -283,7 +340,7 @@ export async function runReliabilityAlertCycle(
         let issueNumber = existing?.githubIssueNumber ?? null
 
         // Create a GitHub issue on first trigger
-        if (isFirstTrigger && githubToken && githubRepo) {
+        if (isFirstTrigger && githubToken && githubRepo && githubIssuePersistenceAvailable) {
           const created = await createGitHubIssue({
             token: githubToken,
             repo: githubRepo,
@@ -307,14 +364,16 @@ export async function runReliabilityAlertCycle(
             lastValue: numericValue,
             lastTriggeredAt: new Date(),
             lastNotifiedAt: shouldNotify ? new Date() : null,
-            githubIssueNumber: issueNumber,
+            ...(githubIssuePersistenceAvailable ? { githubIssueNumber: issueNumber } : {}),
           },
           update: {
             isOpen: true,
             lastValue: numericValue,
             lastTriggeredAt: new Date(),
             ...(shouldNotify ? { lastNotifiedAt: new Date() } : {}),
-            ...(issueNumber !== null ? { githubIssueNumber: issueNumber } : {}),
+            ...(githubIssuePersistenceAvailable && issueNumber !== null
+              ? { githubIssueNumber: issueNumber }
+              : {}),
           },
         })
 
@@ -326,7 +385,7 @@ export async function runReliabilityAlertCycle(
         issueNumbers.set(rule.alertKey, existing.githubIssueNumber ?? null)
 
         // Close the GitHub issue on resolution
-        if (existing.githubIssueNumber && githubToken && githubRepo) {
+        if (existing.githubIssueNumber && githubToken && githubRepo && githubIssuePersistenceAvailable) {
           await closeGitHubIssue({
             token: githubToken,
             repo: githubRepo,
@@ -348,7 +407,7 @@ export async function runReliabilityAlertCycle(
             isOpen: false,
             lastValue: numericValue,
             lastResolvedAt: new Date(),
-            githubIssueNumber: null,
+            ...(githubIssuePersistenceAvailable ? { githubIssueNumber: null } : {}),
           },
         })
       }


### PR DESCRIPTION
## Summary
- Detect Prisma `P2022` for missing `OperationalAlertStates.githubIssueNumber`.
- Retry alert state reads without the optional GitHub issue column when production DB lags behind the client schema.
- Keep alert dedupe/state persistence working while temporarily disabling GitHub issue creation/closure until the migration is applied.
- Add focused tests for both schema-lag fallback and normal GitHub issue persistence.

## Verification
- `npm test -- --runTestsByPath __tests__/lib/reliability-alerts.test.ts`
- `npm run ci:quick`
- pre-push hook: `npm run db:generate`, `npm run check:locales`, `npm run ci:quick`, smoke Jest paths

Fixes #372