### PR TITLE
fix(#351): restore Alias client engine

### DIFF
--- a/__tests__/lib/restore-game-engine-client.test.ts
+++ b/__tests__/lib/restore-game-engine-client.test.ts
@@ -1,0 +1,23 @@
+import { restoreGameEngineClient } from '@/lib/restore-game-engine-client'
+import { AliasGame } from '@/lib/games/alias'
+import { YahtzeeGame } from '@/lib/games/yahtzee-game'
+
+describe('restoreGameEngineClient', () => {
+  it('restores Alias client engines even when Alias is not publicly enabled', async () => {
+    const engine = await restoreGameEngineClient('alias', 'game-alias', {
+      players: [],
+      status: 'waiting',
+    })
+
+    expect(engine).toBeInstanceOf(AliasGame)
+  })
+
+  it('falls back to Yahtzee for unknown game types', async () => {
+    const engine = await restoreGameEngineClient('unknown_game', 'game-unknown', {
+      players: [],
+      status: 'waiting',
+    })
+
+    expect(engine).toBeInstanceOf(YahtzeeGame)
+  })
+})

--- a/lib/restore-game-engine-client.ts
+++ b/lib/restore-game-engine-client.ts
@@ -1,12 +1,28 @@
 import type { GameEngine, RestorableGameState } from './game-engine'
 import {
   DEFAULT_GAME_TYPE,
-  isSupportedGameType,
   type SupportedCatalogGameType,
 } from './game-catalog'
 
+const CLIENT_RESTORABLE_GAME_TYPES = new Set<SupportedCatalogGameType>([
+  'yahtzee',
+  'guess_the_spy',
+  'tic_tac_toe',
+  'rock_paper_scissors',
+  'memory',
+  'telephone_doodle',
+  'sketch_and_guess',
+  'liars_party',
+  'fake_artist',
+  'alias',
+])
+
+function isClientRestorableGameType(gameType: string): gameType is SupportedCatalogGameType {
+  return CLIENT_RESTORABLE_GAME_TYPES.has(gameType as SupportedCatalogGameType)
+}
+
 function normalizeGameType(gameType: string): SupportedCatalogGameType {
-  return isSupportedGameType(gameType) ? gameType : DEFAULT_GAME_TYPE
+  return isClientRestorableGameType(gameType) ? gameType : DEFAULT_GAME_TYPE
 }
 
 async function createGameEngineClient(


### PR DESCRIPTION
## Summary
- restore Alias client engines without depending on public catalog availability
- keep unknown restored game types falling back to Yahtzee
- add regression coverage for Alias restore behavior

Related to #351.

## Verification
- npm test -- --runTestsByPath __tests__/lib/restore-game-engine-client.test.ts
- npm run ci:quick
- pre-push hook (db:generate, locale parity, ci:quick, Jest smoke tests)