### PR TITLE
fix: catch missing githubIssueNumber column error in upsert/update

### DIFF
--- a/lib/reliability-alerts.ts
+++ b/lib/reliability-alerts.ts
@@ -356,26 +356,50 @@ export async function runReliabilityAlertCycle(
 
         issueNumbers.set(rule.alertKey, issueNumber)
 
-        await prisma.operationalAlertStates.upsert({
-          where: { alertKey: rule.alertKey },
-          create: {
-            alertKey: rule.alertKey,
-            isOpen: true,
-            lastValue: numericValue,
-            lastTriggeredAt: new Date(),
-            lastNotifiedAt: shouldNotify ? new Date() : null,
-            ...(githubIssuePersistenceAvailable ? { githubIssueNumber: issueNumber } : {}),
-          },
-          update: {
-            isOpen: true,
-            lastValue: numericValue,
-            lastTriggeredAt: new Date(),
-            ...(shouldNotify ? { lastNotifiedAt: new Date() } : {}),
-            ...(githubIssuePersistenceAvailable && issueNumber !== null
-              ? { githubIssueNumber: issueNumber }
-              : {}),
-          },
-        })
+        try {
+          await prisma.operationalAlertStates.upsert({
+            where: { alertKey: rule.alertKey },
+            create: {
+              alertKey: rule.alertKey,
+              isOpen: true,
+              lastValue: numericValue,
+              lastTriggeredAt: new Date(),
+              lastNotifiedAt: shouldNotify ? new Date() : null,
+              ...(githubIssuePersistenceAvailable ? { githubIssueNumber: issueNumber } : {}),
+            },
+            update: {
+              isOpen: true,
+              lastValue: numericValue,
+              lastTriggeredAt: new Date(),
+              ...(shouldNotify ? { lastNotifiedAt: new Date() } : {}),
+              ...(githubIssuePersistenceAvailable && issueNumber !== null
+                ? { githubIssueNumber: issueNumber }
+                : {}),
+            },
+          })
+        } catch (upsertError) {
+          if (isMissingOperationalAlertStatesGithubIssueColumnError(upsertError)) {
+            githubIssuePersistenceAvailable = false
+            await prisma.operationalAlertStates.upsert({
+              where: { alertKey: rule.alertKey },
+              create: {
+                alertKey: rule.alertKey,
+                isOpen: true,
+                lastValue: numericValue,
+                lastTriggeredAt: new Date(),
+                lastNotifiedAt: shouldNotify ? new Date() : null,
+              },
+              update: {
+                isOpen: true,
+                lastValue: numericValue,
+                lastTriggeredAt: new Date(),
+                ...(shouldNotify ? { lastNotifiedAt: new Date() } : {}),
+              },
+            })
+          } else {
+            throw upsertError
+          }
+        }
 
         continue
       }
@@ -401,15 +425,31 @@ export async function runReliabilityAlertCycle(
           })
         }
 
-        await prisma.operationalAlertStates.update({
-          where: { alertKey: rule.alertKey },
-          data: {
-            isOpen: false,
-            lastValue: numericValue,
-            lastResolvedAt: new Date(),
-            ...(githubIssuePersistenceAvailable ? { githubIssueNumber: null } : {}),
-          },
-        })
+        try {
+          await prisma.operationalAlertStates.update({
+            where: { alertKey: rule.alertKey },
+            data: {
+              isOpen: false,
+              lastValue: numericValue,
+              lastResolvedAt: new Date(),
+              ...(githubIssuePersistenceAvailable ? { githubIssueNumber: null } : {}),
+            },
+          })
+        } catch (updateError) {
+          if (isMissingOperationalAlertStatesGithubIssueColumnError(updateError)) {
+            githubIssuePersistenceAvailable = false
+            await prisma.operationalAlertStates.update({
+              where: { alertKey: rule.alertKey },
+              data: {
+                isOpen: false,
+                lastValue: numericValue,
+                lastResolvedAt: new Date(),
+              },
+            })
+          } else {
+            throw updateError
+          }
+        }
       }
     }
   } else {


### PR DESCRIPTION
## Summary

- `findMany` with `select: { githubIssueNumber: true }` can silently return `[]` without executing SQL (Prisma short-circuits empty `IN` clauses or empty result sets), so a missing column in the DB goes undetected
- `githubIssuePersistenceAvailable` stays `true`, and the first `upsert`/`update` that actually hits the DB throws P2022 — crashing the cron with HTTP 500
- Fix: wrap both `upsert` and `update` calls in try-catch; on P2022 for the missing column, set `githubIssuePersistenceAvailable = false` and retry without `githubIssueNumber`

## Test plan

- [ ] Verify cron succeeds on next scheduled run after merge + deploy
- [ ] Confirm existing error handling for missing table (P2021) still works as before