### PR TITLE
fix: host reassignment toast and test coverage (#229)

### DIFF
--- a/__tests__/api/lobby-leave.test.ts
+++ b/__tests__/api/lobby-leave.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+// @ts-nocheck - Jest mocks for Prisma are complex to type
+
+import { NextRequest } from 'next/server'
+import { POST as LEAVE } from '@/app/api/lobby/[code]/leave/route'
+import { prisma } from '@/lib/db'
+import { getRequestAuthUser } from '@/lib/request-auth'
+import { notifySocket } from '@/lib/socket-url'
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    lobbies: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    games: {
+      update: jest.fn(),
+    },
+    players: {
+      findFirst: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/request-auth', () => ({
+  getRequestAuthUser: jest.fn(),
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimit: jest.fn(() => jest.fn(() => Promise.resolve(null))),
+  rateLimitPresets: { api: {} },
+}))
+
+jest.mock('@/lib/socket-url', () => ({
+  notifySocket: jest.fn(() => Promise.resolve(true)),
+  getServerSocketUrl: jest.fn(() => 'http://localhost:3001'),
+  getSocketInternalAuthHeaders: jest.fn(() => ({})),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  })),
+}))
+
+jest.mock('@/lib/lobby-snapshot', () => ({
+  pickRelevantLobbyGame: jest.fn(),
+}))
+
+jest.mock('@/lib/lobby-player-requirements', () => ({
+  getLobbyPlayerRequirements: jest.fn(() => ({ minPlayersRequired: 2 })),
+}))
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockGetRequestAuthUser = getRequestAuthUser as jest.MockedFunction<typeof getRequestAuthUser>
+const mockNotifySocket = notifySocket as jest.MockedFunction<typeof notifySocket>
+
+function makeRequest(code = 'ABC123') {
+  return new NextRequest(`http://localhost/api/lobby/${code}/leave`, { method: 'POST' })
+}
+
+const HOST_ID = 'user-host'
+const OTHER_ID = 'user-other'
+
+const mockPlayer = (userId: string, extra = {}) => ({
+  id: `player-${userId}`,
+  userId,
+  position: 0,
+  createdAt: new Date('2026-01-01'),
+  user: { id: userId, username: userId === HOST_ID ? 'Host' : 'Other', email: null, bot: null },
+  ...extra,
+})
+
+const mockGame = (status = 'waiting', players = [mockPlayer(HOST_ID), mockPlayer(OTHER_ID)]) => ({
+  id: 'game-1',
+  status,
+  gameType: 'yahtzee',
+  updatedAt: new Date(),
+  players,
+})
+
+const mockLobby = (game = mockGame()) => ({
+  id: 'lobby-1',
+  code: 'ABC123',
+  creatorId: HOST_ID,
+  isActive: true,
+  games: [game],
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockNotifySocket.mockResolvedValue(true)
+  mockPrisma.lobbies.update.mockResolvedValue({} as any)
+  mockPrisma.games.update.mockResolvedValue({} as any)
+  mockPrisma.players.delete.mockResolvedValue({} as any)
+})
+
+describe('POST /api/lobby/[code]/leave — host reassignment', () => {
+  it('reassigns host to oldest remaining human player when creator leaves a waiting lobby', async () => {
+    mockGetRequestAuthUser.mockResolvedValue({ id: HOST_ID } as any)
+    const game = mockGame('waiting', [mockPlayer(HOST_ID), mockPlayer(OTHER_ID)])
+    mockPrisma.lobbies.findUnique.mockResolvedValue(mockLobby(game) as any)
+    mockPrisma.players.delete.mockResolvedValue({} as any)
+    mockPrisma.players.count
+      .mockResolvedValueOnce(1) // remainingPlayers after delete
+      .mockResolvedValueOnce(1) // remainingHumanPlayers
+    mockPrisma.players.findFirst.mockResolvedValue({
+      userId: OTHER_ID,
+      user: { username: 'Other' },
+    } as any)
+
+    const res = await LEAVE(makeRequest(), { params: Promise.resolve({ code: 'ABC123' }) })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.lobbyDeactivated).toBe(false)
+
+    // creatorId updated in DB
+    expect(mockPrisma.lobbies.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'lobby-1' },
+        data: { creatorId: OTHER_ID },
+      })
+    )
+
+    // lobby-update event carries new creatorId
+    expect(mockNotifySocket).toHaveBeenCalledWith(
+      'lobby:ABC123',
+      'lobby-update',
+      expect.objectContaining({ data: expect.objectContaining({ creatorId: OTHER_ID }) }),
+      expect.any(Number)
+    )
+
+    // player-left event carries nextCreatorId
+    expect(mockNotifySocket).toHaveBeenCalledWith(
+      'lobby:ABC123',
+      'player-left',
+      expect.objectContaining({ nextCreatorId: OTHER_ID, nextCreatorName: 'Other' }),
+      expect.any(Number)
+    )
+  })
+
+  it('does not reassign host when a non-creator leaves', async () => {
+    mockGetRequestAuthUser.mockResolvedValue({ id: OTHER_ID } as any)
+    const game = mockGame('waiting', [mockPlayer(HOST_ID), mockPlayer(OTHER_ID)])
+    mockPrisma.lobbies.findUnique.mockResolvedValue(mockLobby(game) as any)
+    mockPrisma.players.delete.mockResolvedValue({} as any)
+    mockPrisma.players.count
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+    mockPrisma.players.findFirst.mockResolvedValue(null)
+
+    const res = await LEAVE(makeRequest(), { params: Promise.resolve({ code: 'ABC123' }) })
+
+    expect(res.status).toBe(200)
+    // lobbies.update should NOT have been called with creatorId
+    const updateCalls = mockPrisma.lobbies.update.mock.calls
+    const creatorUpdate = updateCalls.find((call) => call[0]?.data?.creatorId !== undefined)
+    expect(creatorUpdate).toBeUndefined()
+  })
+
+  it('deactivates lobby when creator leaves and no human players remain', async () => {
+    mockGetRequestAuthUser.mockResolvedValue({ id: HOST_ID } as any)
+    const game = mockGame('waiting', [mockPlayer(HOST_ID)])
+    mockPrisma.lobbies.findUnique.mockResolvedValue(mockLobby(game) as any)
+    mockPrisma.players.delete.mockResolvedValue({} as any)
+    mockPrisma.players.count
+      .mockResolvedValueOnce(0) // remainingPlayers
+      .mockResolvedValueOnce(0) // remainingHumanPlayers
+
+    const res = await LEAVE(makeRequest(), { params: Promise.resolve({ code: 'ABC123' }) })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.lobbyDeactivated).toBe(true)
+    expect(mockPrisma.lobbies.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { isActive: false } })
+    )
+  })
+
+  it('picks reassignment candidate deterministically: lowest position, then earliest createdAt', async () => {
+    mockGetRequestAuthUser.mockResolvedValue({ id: HOST_ID } as any)
+    const early = mockPlayer('user-early', { position: 1, createdAt: new Date('2026-01-01') })
+    const late = mockPlayer('user-late', { position: 1, createdAt: new Date('2026-06-01') })
+    const game = mockGame('waiting', [mockPlayer(HOST_ID), early, late])
+    mockPrisma.lobbies.findUnique.mockResolvedValue(mockLobby(game) as any)
+    mockPrisma.players.delete.mockResolvedValue({} as any)
+    mockPrisma.players.count
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(2)
+    // Simulate DB returning the correct candidate
+    mockPrisma.players.findFirst.mockResolvedValue({
+      userId: 'user-early',
+      user: { username: 'Early' },
+    } as any)
+
+    await LEAVE(makeRequest(), { params: Promise.resolve({ code: 'ABC123' }) })
+
+    expect(mockPrisma.players.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: expect.arrayContaining([
+          { position: 'asc' },
+          { createdAt: 'asc' },
+        ]),
+        where: expect.objectContaining({
+          user: { bot: null },
+        }),
+      })
+    )
+    expect(mockPrisma.lobbies.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { creatorId: 'user-early' } })
+    )
+  })
+})

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -732,6 +732,8 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     username?: string
     playerName?: string
     remainingPlayers?: number
+    nextCreatorId?: string
+    nextCreatorName?: string
   }) => {
     clientLogger.log('📡 Player left:', data)
 
@@ -742,6 +744,15 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     const departedPlayerName = data.username || data.playerName
     if (departedPlayerName) {
       showToast.info('toast.playerLeft', undefined, { player: departedPlayerName })
+    }
+
+    if (data.nextCreatorId) {
+      const currentUserId = isGuest ? guestId : session?.user?.id
+      if (data.nextCreatorId === currentUserId) {
+        showToast.success('toast.youAreNowHost')
+      } else if (data.nextCreatorName) {
+        showToast.info('toast.hostReassigned', undefined, { player: data.nextCreatorName })
+      }
     }
 
     if (typeof data.remainingPlayers === 'number' && data.remainingPlayers < minPlayersRequired) {
@@ -755,7 +766,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
     if (loadLobbyRef.current) {
       void loadLobbyRef.current()
     }
-  }, [minPlayersRequired, triggerLifecycleRedirect])
+  }, [isGuest, guestId, session?.user?.id, minPlayersRequired, triggerLifecycleRedirect])
 
   const currentUserIdForMembership = isGuest ? guestId : session?.user?.id
   const canJoinSocketLobbyRoom = React.useMemo(() => {

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1705,6 +1705,8 @@ const en = {
     socialRematchMessage: '{{player}} asked for a rematch in {{lobby}}',
     socialJoinAction: 'Join',
     socialOpenAction: 'Open',
+    hostReassigned: '👑 {{player}} is now the host',
+    youAreNowHost: '👑 You are now the host',
   },
   deleteAccount: {
     title: 'Delete Account',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -1692,7 +1692,9 @@ const no = {
     socialInviteMessage: '{{player}} inviterte deg til {{lobby}}',
     socialRematchMessage: '{{player}} ba om revansj i {{lobby}}',
     socialJoinAction: 'Bli med',
-    socialOpenAction: 'Åpne'
+    socialOpenAction: 'Åpne',
+    hostReassigned: '👑 {{player}} er nå vert',
+    youAreNowHost: '👑 Du er nå vert',
   },
   deleteAccount: {
     title: 'Slett konto',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -1692,7 +1692,9 @@ const ru = {
     socialInviteMessage: '{{player}} пригласил вас в {{lobby}}',
     socialRematchMessage: '{{player}} запросил реванш в {{lobby}}',
     socialJoinAction: 'Войти',
-    socialOpenAction: 'Открыть'
+    socialOpenAction: 'Открыть',
+    hostReassigned: '👑 {{player}} теперь хост',
+    youAreNowHost: '👑 Вы теперь хост',
   },
   deleteAccount: {
     title: 'Удалить аккаунт',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -1707,6 +1707,8 @@ const uk: Translation = {
     socialRematchMessage: '{{player}} запросив реванш у {{lobby}}',
     socialJoinAction: 'Увійти',
     socialOpenAction: 'Відкрити',
+    hostReassigned: '👑 {{player}} тепер хост',
+    youAreNowHost: '👑 Ви тепер хост',
   },
   deleteAccount: {
     title: 'Видалення Акаунту',


### PR DESCRIPTION
## Summary

- `onPlayerLeft` now shows a toast when the host is reassigned: **"You are now the host"** for the new host, **"X is now the host"** for others
- Locale keys added: `toast.hostReassigned` / `toast.youAreNowHost` (en, ru, uk, no)
- Backend `player-left` event already carries `nextCreatorId`/`nextCreatorName` — handler type updated to include these fields
- 4 unit tests added covering: reassignment on creator leave, no reassignment on non-creator leave, lobby deactivation when no humans remain, deterministic candidate ordering

## Test plan

- [ ] Host leaves waiting lobby → remaining players see "X is now the host" toast, new host sees "You are now the host"
- [ ] Non-creator leaves → no host toast shown
- [ ] Last human leaves → lobby deactivated
- [ ] All 4 unit tests pass: `npm test -- __tests__/api/lobby-leave.test.ts`

Closes #229