### PR TITLE
feat: audio settings panel — volume slider and mute toggle (#312)

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,6 +8,7 @@ import { HeaderNavigation } from './Header/HeaderNavigation'
 import { HeaderActions } from './Header/HeaderActions'
 import { MobileMenu } from './Header/MobileMenu'
 import { NotificationsMenu } from './Header/NotificationsMenu'
+import { AudioSettingsButton } from './Header/AudioSettingsButton'
 import LanguageSwitcher from './LanguageSwitcher'
 import { useProfileNavigationTracking } from '@/lib/profile-navigation'
 
@@ -64,6 +65,10 @@ export default function Header() {
 
             <div className="hidden lg:block">
               <LanguageSwitcher />
+            </div>
+
+            <div className="hidden lg:block">
+              <AudioSettingsButton />
             </div>
 
             {isAuthenticated && !isLoading && <NotificationsMenu />}

--- a/components/Header/AudioSettingsButton.tsx
+++ b/components/Header/AudioSettingsButton.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from '@/lib/i18n-helpers'
+import { sounds } from '@/lib/sounds'
+
+function useAudioSettings() {
+  const [enabled, setEnabled] = useState(true)
+  const [volume, setVolumeState] = useState(0.7)
+
+  useEffect(() => {
+    setEnabled(sounds.isEnabled())
+    setVolumeState(sounds.getVolume())
+  }, [])
+
+  const toggleMute = () => {
+    const next = sounds.toggle()
+    setEnabled(next)
+  }
+
+  const changeVolume = (val: number) => {
+    sounds.setVolume(val)
+    setVolumeState(val)
+    if (!enabled && val > 0) {
+      sounds.toggle()
+      setEnabled(true)
+    }
+  }
+
+  return { enabled, volume, toggleMute, changeVolume }
+}
+
+export function AudioSettingsButton() {
+  const { t } = useTranslation()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [open, setOpen] = useState(false)
+  const { enabled, volume, toggleMute, changeVolume } = useAudioSettings()
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const icon = !enabled || volume === 0 ? '🔇' : volume < 0.5 ? '🔉' : '🔊'
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-label={t('header.openAudioSettings', 'Open audio settings')}
+        title={t('header.audioSettings', 'Audio Settings')}
+        className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-base hover:bg-white/20 transition-colors"
+      >
+        {icon}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-11 z-50 w-56 rounded-xl border border-white/10 bg-gray-900 p-4 shadow-xl">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-white/50">
+            {t('header.audioSettings', 'Audio Settings')}
+          </p>
+
+          {/* Mute toggle */}
+          <button
+            onClick={toggleMute}
+            className="mb-4 flex w-full items-center justify-between rounded-lg px-3 py-2 hover:bg-white/5 transition-colors"
+          >
+            <span className="text-sm text-white">
+              {enabled ? t('header.mute', 'Mute') : t('header.unmute', 'Unmute')}
+            </span>
+            <span className="text-base">{enabled ? '🔊' : '🔇'}</span>
+          </button>
+
+          {/* Volume slider */}
+          <div>
+            <div className="mb-1.5 flex items-center justify-between">
+              <label className="text-xs text-white/60">{t('header.volume', 'Volume')}</label>
+              <span className="text-xs text-white/60">{Math.round(volume * 100)}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={volume}
+              onChange={(e) => changeVolume(parseFloat(e.target.value))}
+              className="h-1.5 w-full cursor-pointer accent-purple-400"
+              aria-label={t('header.volume', 'Volume')}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function AudioSettingsMobilePanel() {
+  const { t } = useTranslation()
+  const { enabled, volume, toggleMute, changeVolume } = useAudioSettings()
+
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white/80 p-3 shadow-sm dark:border-gray-700 dark:bg-gray-800/60">
+      <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
+        {t('header.audioSettings', 'Audio Settings')}
+      </p>
+
+      <button
+        onClick={toggleMute}
+        className="mb-3 flex w-full items-center justify-between rounded-xl px-3 py-2.5 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+      >
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+          {enabled ? t('header.mute', 'Mute') : t('header.unmute', 'Unmute')}
+        </span>
+        <span className="text-base">{enabled ? '🔊' : '🔇'}</span>
+      </button>
+
+      <div className="px-1">
+        <div className="mb-1.5 flex items-center justify-between">
+          <label className="text-xs text-gray-500 dark:text-gray-400">{t('header.volume', 'Volume')}</label>
+          <span className="text-xs text-gray-500 dark:text-gray-400">{Math.round(volume * 100)}%</span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={volume}
+          onChange={(e) => changeVolume(parseFloat(e.target.value))}
+          className="h-1.5 w-full cursor-pointer accent-purple-500"
+          aria-label={t('header.volume', 'Volume')}
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/Header/MobileMenu.tsx
+++ b/components/Header/MobileMenu.tsx
@@ -8,6 +8,7 @@ import { navigateToProfile } from '@/lib/profile-navigation'
 import { buildCurrentAuthUrl } from '@/lib/auth-redirect'
 import { UserAvatar } from './UserAvatar'
 import LanguageSwitcher from '@/components/LanguageSwitcher'
+import { AudioSettingsMobilePanel } from './AudioSettingsButton'
 import { useTranslation } from '@/lib/i18n-helpers'
 
 interface MobileMenuProps {
@@ -365,6 +366,8 @@ export function MobileMenu({
                   </p>
                   <LanguageSwitcher variant="panel" />
                 </div>
+
+                <AudioSettingsMobilePanel />
               </div>
             </nav>
 

--- a/lib/sounds.ts
+++ b/lib/sounds.ts
@@ -1,6 +1,7 @@
 class SoundManager {
   private sounds: Map<string, HTMLAudioElement> = new Map()
   private enabled: boolean = true
+  private volume: number = 0.7
   private initialized: boolean = false
   private userInteracted: boolean = false
   private playingSounds: Set<string> = new Set()
@@ -9,9 +10,13 @@ class SoundManager {
   constructor() {
     if (typeof window !== 'undefined') {
       this.loadSounds()
-      const saved = localStorage.getItem('soundEnabled')
-      this.enabled = saved !== 'false'
-      
+      const savedEnabled = localStorage.getItem('soundEnabled')
+      this.enabled = savedEnabled !== 'false'
+      const savedVolume = parseFloat(localStorage.getItem('soundVolume') ?? '')
+      if (!isNaN(savedVolume)) {
+        this.volume = Math.max(0, Math.min(1, savedVolume))
+      }
+
       // Listen for first user interaction to enable audio playback
       this.setupUserInteraction()
     }
@@ -118,7 +123,7 @@ class SoundManager {
       if (options.volume !== undefined) {
         sound.volume = Math.max(0, Math.min(1, options.volume))
       } else {
-        sound.volume = 0.7 // Default volume
+        sound.volume = this.volume
       }
       
       sound.loop = options.loop || false
@@ -171,13 +176,22 @@ class SoundManager {
   toggle() {
     this.enabled = !this.enabled
     localStorage.setItem('soundEnabled', String(this.enabled))
-    
+
     // Stop all sounds when disabling
     if (!this.enabled) {
       this.stopAll()
     }
-    
+
     return this.enabled
+  }
+
+  setVolume(value: number) {
+    this.volume = Math.max(0, Math.min(1, value))
+    localStorage.setItem('soundVolume', String(this.volume))
+  }
+
+  getVolume() {
+    return this.volume
   }
 
   isEnabled() {
@@ -201,6 +215,8 @@ export const sounds = {
         stop: () => {},
         stopAll: () => {},
         toggle: () => false,
+        setVolume: () => {},
+        getVolume: () => 0.7,
         isEnabled: () => false,
         hasUserInteracted: () => false,
       } as unknown as SoundManager
@@ -217,23 +233,31 @@ export const sounds = {
   play(soundName: string, options?: Parameters<SoundManager['play']>[1]) {
     return this.instance.play(soundName, options)
   },
-  
+
   stop(soundName: string) {
     return this.instance.stop(soundName)
   },
-  
+
   stopAll() {
     return this.instance.stopAll()
   },
-  
+
   toggle() {
     return this.instance.toggle()
   },
-  
+
+  setVolume(value: number) {
+    return this.instance.setVolume(value)
+  },
+
+  getVolume() {
+    return this.instance.getVolume()
+  },
+
   isEnabled() {
     return this.instance.isEnabled()
   },
-  
+
   hasUserInteracted() {
     return this.instance.hasUserInteracted()
   },

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -314,6 +314,11 @@ const en = {
     exitGuest: 'Exit Guest',
     guestSession: 'Guest session',
     language: 'Language',
+    audioSettings: 'Audio Settings',
+    openAudioSettings: 'Open audio settings',
+    mute: 'Mute',
+    unmute: 'Unmute',
+    volume: 'Volume',
   },
   home: {
     title: 'Play Board Games Online with Friends',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -314,6 +314,11 @@ const no = {
     exitGuest: 'Avslutt gjest',
     guestSession: 'Gjesteøkt',
     language: 'Språk',
+    audioSettings: 'Lydinnstillinger',
+    openAudioSettings: 'Åpne lydinnstillinger',
+    mute: 'Demp',
+    unmute: 'Aktiver lyd',
+    volume: 'Volum',
   },
   home: {
     title: 'Spill brettspill på nett med venner',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -314,6 +314,11 @@ const ru = {
     exitGuest: 'Выйти из гостевого режима',
     guestSession: 'Гостевой режим',
     language: 'Язык',
+    audioSettings: 'Настройки звука',
+    openAudioSettings: 'Открыть настройки звука',
+    mute: 'Выключить звук',
+    unmute: 'Включить звук',
+    volume: 'Громкость',
   },
   home: {
     title: 'Играйте в настольные игры онлайн с друзьями',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -316,6 +316,11 @@ const uk: Translation = {
     exitGuest: 'Вийти з гостьового режиму',
     guestSession: 'Гостьовий режим',
     language: 'Мова',
+    audioSettings: 'Налаштування звуку',
+    openAudioSettings: 'Відкрити налаштування звуку',
+    mute: 'Вимкнути звук',
+    unmute: 'Увімкнути звук',
+    volume: 'Гучність',
   },
   home: {
     title: 'Грайте в настільні ігри онлайн з друзями',


### PR DESCRIPTION
## Summary

- `SoundManager` now persists `volume` (0–1) to `localStorage` (`soundVolume` key); loaded on init
- Added `setVolume(v)` and `getVolume()` methods; `play()` uses `this.volume` as default instead of hardcoded 0.7
- New `AudioSettingsButton` component — speaker icon in desktop header that opens a popover with mute toggle + volume slider
- New `AudioSettingsMobilePanel` — same controls as an inline panel in the mobile menu
- i18n keys: `header.audioSettings`, `header.openAudioSettings`, `header.mute`, `header.unmute`, `header.volume` (en, ru, uk, no)

## Test plan

- [ ] Desktop: speaker icon appears in header → click opens popover with toggle + slider
- [ ] Slider changes volume in real time, persists on page reload
- [ ] Mute toggle silences audio, icon changes to 🔇
- [ ] Mobile: audio panel visible in hamburger menu
- [ ] `npm run ci:quick` passes clean

Closes #312