### PR TITLE
fix(#387): defer nonessential global ui for bundle budget

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,16 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import Providers from './providers'
-import { Suspense } from 'react'
-import { SpeedInsights } from '@vercel/speed-insights/next'
-import { Analytics } from '@vercel/analytics/react'
+import dynamic from 'next/dynamic'
 import { getThemeInitScript } from '@/lib/theme'
-import FeedbackWidget from '@/components/FeedbackWidget'
-import Header from '@/components/Header'
+
+const FeedbackWidget = dynamic(() => import('@/components/FeedbackWidget'), {
+  loading: () => null,
+})
+
+const DeferredTelemetry = dynamic(() => import('@/components/DeferredTelemetry'), {
+  loading: () => null,
+})
 
 // Header Skeleton with fixed dimensions to prevent CLS
 function HeaderSkeleton() {
@@ -27,6 +31,10 @@ function HeaderSkeleton() {
     </header>
   )
 }
+
+const Header = dynamic(() => import('@/components/Header'), {
+  loading: () => <HeaderSkeleton />,
+})
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://boardly.online'),
@@ -221,18 +229,11 @@ export default function RootLayout({
       </head>
       <body className="antialiased">
         <Providers>
-          <Suspense fallback={<HeaderSkeleton />}>
-            <Header />
-          </Suspense>
+          <Header />
           <main>{children}</main>
           <FeedbackWidget />
         </Providers>
-        {isProduction && (
-          <>
-            <SpeedInsights />
-            <Analytics />
-          </>
-        )}
+        {isProduction && <DeferredTelemetry />}
       </body>
     </html>
   )

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,16 +1,24 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { useEffect } from 'react'
 import { SessionProvider } from 'next-auth/react'
 import { ToastProvider } from '@/contexts/ToastContext'
 import { GuestProvider } from '@/contexts/GuestContext'
 import { OnboardingProvider } from '@/contexts/OnboardingContext'
-import { OnboardingModal } from '@/components/Onboarding/OnboardingModal'
 import DeferredGlobalEffects from '@/components/DeferredGlobalEffects'
-import { Toaster } from 'react-hot-toast'
 import i18n from '@/i18n'
 import { applyThemeMode } from '@/lib/theme'
 import { getStoredAppearanceLocale } from '@/lib/appearance-preferences'
+
+const OnboardingModal = dynamic(
+  () => import('@/components/Onboarding/OnboardingModal').then((mod) => mod.OnboardingModal),
+  { ssr: false }
+)
+const GlobalToaster = dynamic(
+  () => import('react-hot-toast').then((mod) => mod.Toaster),
+  { ssr: false }
+)
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   useEffect(() => {
@@ -30,7 +38,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       <GuestProvider>
         <OnboardingProvider>
           <ToastProvider>
-            <Toaster position="top-right" />
+            <GlobalToaster position="top-right" />
             <DeferredGlobalEffects />
             <OnboardingModal />
             {children}

--- a/components/DeferredTelemetry.tsx
+++ b/components/DeferredTelemetry.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/next'
+
+const TELEMETRY_IDLE_TIMEOUT_MS = 2000
+
+export default function DeferredTelemetry() {
+  const [enabled, setEnabled] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number
+      cancelIdleCallback?: (handle: number) => void
+    }
+
+    if (typeof idleWindow.requestIdleCallback === 'function') {
+      const idleId = idleWindow.requestIdleCallback(
+        () => setEnabled(true),
+        { timeout: TELEMETRY_IDLE_TIMEOUT_MS }
+      )
+
+      return () => idleWindow.cancelIdleCallback?.(idleId)
+    }
+
+    const timeoutId = window.setTimeout(() => setEnabled(true), TELEMETRY_IDLE_TIMEOUT_MS)
+    return () => window.clearTimeout(timeoutId)
+  }, [])
+
+  if (!enabled) {
+    return null
+  }
+
+  return (
+    <>
+      <SpeedInsights />
+      <Analytics />
+    </>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,16 +1,29 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { useSession } from 'next-auth/react'
 import { useRouter, usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useGuest } from '@/contexts/GuestContext'
 import { HeaderNavigation } from './Header/HeaderNavigation'
 import { HeaderActions } from './Header/HeaderActions'
-import { MobileMenu } from './Header/MobileMenu'
-import { NotificationsMenu } from './Header/NotificationsMenu'
-import { AudioSettingsButton } from './Header/AudioSettingsButton'
-import LanguageSwitcher from './LanguageSwitcher'
 import { useProfileNavigationTracking } from '@/lib/profile-navigation'
+
+const MobileMenu = dynamic(
+  () => import('./Header/MobileMenu').then((mod) => mod.MobileMenu),
+  { loading: () => null }
+)
+const NotificationsMenu = dynamic(
+  () => import('./Header/NotificationsMenu').then((mod) => mod.NotificationsMenu),
+  { loading: () => null }
+)
+const AudioSettingsButton = dynamic(
+  () => import('./Header/AudioSettingsButton').then((mod) => mod.AudioSettingsButton),
+  { loading: () => null }
+)
+const LanguageSwitcher = dynamic(() => import('./LanguageSwitcher'), {
+  loading: () => null,
+})
 
 export default function Header() {
   const { data: session, status } = useSession()


### PR DESCRIPTION
## Summary
- lazy-load nonessential global UI from the app shell
- defer telemetry and toaster startup until after the initial route payload
- split heavy header utilities behind dynamic boundaries to keep /lobby/[code]/page within budget

## Verification
- npm run typecheck
- npm run build
- npm run check:bundle-budget
- npm run ci:quick

Fixes #387