### PR TITLE
fix: restore theme module, LobbyCard title, pre-commit hook hang

### DIFF
--- a/components/LobbyCard.tsx
+++ b/components/LobbyCard.tsx
@@ -72,7 +72,7 @@ export default function LobbyCard({ lobby, index, onOpenLobby, onWatchLobby }: L
       {/* Main info */}
       <div style={{ flex: 1, minWidth: 200 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 4 }}>
-          <span style={{ fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 17, color: 'var(--bd-ink)' }}>{lobby.name}</span>
+          <span title={lobby.name} className="truncate" style={{ fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 17, color: 'var(--bd-ink)', maxWidth: '100%' }}>{lobby.name}</span>
           <span style={{ fontFamily: "'JetBrains Mono', ui-monospace, monospace", fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', background: 'var(--bd-bg2)', color: 'var(--bd-ink-muted)', padding: '3px 8px', borderRadius: 8 }}>{lobby.code}</span>
         </div>
         <div style={{ fontSize: 13, color: 'var(--bd-ink-muted)', marginBottom: 10 }}>{creatorName} · {game.label}</div>

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -28,7 +28,8 @@ export function applyThemeMode(
     matchMedia?: (query: string) => MediaQueryList
   }
 ) {
-  if (typeof window === 'undefined' && !options?.documentElement) {
+  const isServer = typeof window === 'undefined'
+  if (isServer && (!options?.documentElement || !options?.matchMedia)) {
     return
   }
 

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,22 +1,24 @@
-export type ThemeMode = 'light'
+export type ThemeMode = 'light' | 'dark' | 'system'
 
 export const THEME_STORAGE_KEY = 'theme'
 export const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)'
 
+const VALID_THEME_MODES: ThemeMode[] = ['light', 'dark', 'system']
+
 export function normalizeThemeMode(value: string | null | undefined): ThemeMode {
-  void value
-  return 'light'
+  if (value && (VALID_THEME_MODES as string[]).includes(value)) {
+    return value as ThemeMode
+  }
+  return 'system'
 }
 
 export function getStoredThemeMode(storage?: Pick<Storage, 'getItem'>): ThemeMode {
-  void storage
-  return 'light'
+  return normalizeThemeMode(storage?.getItem(THEME_STORAGE_KEY))
 }
 
 export function resolveThemeMode(mode: ThemeMode, prefersDark: boolean): 'light' | 'dark' {
-  void mode
-  void prefersDark
-  return 'light'
+  if (mode === 'system') return prefersDark ? 'dark' : 'light'
+  return mode
 }
 
 export function applyThemeMode(
@@ -26,21 +28,26 @@ export function applyThemeMode(
     matchMedia?: (query: string) => MediaQueryList
   }
 ) {
-  void mode
   if (typeof window === 'undefined' && !options?.documentElement) {
     return
   }
 
   const documentElement = options?.documentElement ?? document.documentElement
-  documentElement.classList.remove('dark')
-  documentElement.style.colorScheme = 'light'
+  const matchMedia = options?.matchMedia ?? window.matchMedia
+  const resolved = resolveThemeMode(mode, matchMedia(DARK_MEDIA_QUERY).matches)
+
+  documentElement.classList.toggle('dark', resolved === 'dark')
+  documentElement.style.colorScheme = resolved
 }
 
 export function getThemeInitScript() {
   return `(() => {
   try {
-    document.documentElement.classList.remove('dark');
-    document.documentElement.style.colorScheme = 'light';
+    const stored = localStorage.getItem('${THEME_STORAGE_KEY}');
+    const prefersDark = window.matchMedia('${DARK_MEDIA_QUERY}').matches;
+    const resolved = stored === 'dark' || (stored !== 'light' && prefersDark) ? 'dark' : 'light';
+    document.documentElement.classList.toggle('dark', resolved === 'dark');
+    document.documentElement.style.colorScheme = resolved;
   } catch {}
 })();`
 }

--- a/scripts/git-hook-pre-commit.ts
+++ b/scripts/git-hook-pre-commit.ts
@@ -19,8 +19,8 @@ function main() {
 
   printHeader('Boardly pre-commit hook')
 
-  printStep('Git staged diff sanity', 'git diff --cached --check')
-  runChecked('git', ['diff', '--cached', '--check'])
+  printStep('Git staged diff sanity', 'git --no-pager diff --cached --check')
+  runChecked('git', ['--no-pager', 'diff', '--cached', '--check'])
 
   const stagedFiles = getStagedFiles()
   if (stagedFiles.length === 0) {


### PR DESCRIPTION
## Summary
- Restore `ThemeMode` union type (`'light' | 'dark' | 'system'`) and proper `normalizeThemeMode`/`getStoredThemeMode` logic in `lib/theme.ts` that was stubbed to always return `'light'`
- Add `title` attribute and `truncate` class to lobby name span in `LobbyCard` so the `getByTitle` query and overflow truncation work correctly
- Fix pre-commit hook hanging in no-TTY contexts by using `git --no-pager diff` — without `--no-pager`, git tries to open `less` as pager which blocks on stdin when there's no terminal

## Test plan
- [x] `pnpm test appearance-preferences` — all 5 tests pass
- [x] `pnpm test lobby-card` — test passes
- [x] Pre-commit hook completes in ~0.35s without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)