### PR TITLE
feat(#398): add Memory bots, timer, chat, and leave controls

### DIFF
--- a/__tests__/lib/bots/memory-bot.test.ts
+++ b/__tests__/lib/bots/memory-bot.test.ts
@@ -1,0 +1,115 @@
+import { Move, Player } from '@/lib/game-engine'
+import { createBot, executeBotTurn } from '@/lib/bots'
+import { MemoryBot } from '@/lib/bots/memory/memory-bot'
+import { MemoryCard, MemoryGame, MemoryGameData } from '@/lib/games/memory-game'
+
+const HUMAN: Player = { id: 'human', name: 'Human' }
+const BOT: Player = { id: 'bot', name: 'Memory Bot' }
+
+function createGame(currentPlayerIndex = 1): MemoryGame {
+  const game = new MemoryGame('memory-bot-test')
+  game.addPlayer(HUMAN)
+  game.addPlayer(BOT)
+  game.startGame()
+
+  const state = game.getState()
+  state.currentPlayerIndex = currentPlayerIndex
+  const data = state.data as MemoryGameData
+  data.cards = [
+    { id: 'a1', value: 'A', isMatched: false, isFlipped: false },
+    { id: 'a2', value: 'A', isMatched: false, isFlipped: false },
+    { id: 'b1', value: 'B', isMatched: false, isFlipped: false },
+    { id: 'b2', value: 'B', isMatched: false, isFlipped: false },
+  ]
+  data.flippedCardIds = []
+  data.pendingMismatchCardIds = []
+  data.scores = {
+    [HUMAN.id]: 0,
+    [BOT.id]: 0,
+  }
+  game.restoreState(state)
+
+  return game
+}
+
+function valuesForDecision(game: MemoryGame, firstCardId: string, secondCardId: string): [string, string] {
+  const cards = ((game.getState().data as MemoryGameData).cards as MemoryCard[])
+  const firstCard = cards.find((card) => card.id === firstCardId)
+  const secondCard = cards.find((card) => card.id === secondCardId)
+
+  if (!firstCard || !secondCard) {
+    throw new Error('Expected cards to exist')
+  }
+
+  return [firstCard.value, secondCard.value]
+}
+
+describe('MemoryBot', () => {
+  const originalBotUxDelayMs = process.env.BOT_UX_DELAY_MS
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    if (originalBotUxDelayMs === undefined) {
+      delete process.env.BOT_UX_DELAY_MS
+    } else {
+      process.env.BOT_UX_DELAY_MS = originalBotUxDelayMs
+    }
+  })
+
+  it('hard difficulty recalls a known pair most of the time', async () => {
+    const game = createGame()
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.99)
+      .mockReturnValueOnce(0.01)
+      .mockReturnValueOnce(0)
+
+    const bot = new MemoryBot(game, 'hard', BOT.id)
+    const decision = await bot.makeDecision()
+    const [firstValue, secondValue] = valuesForDecision(game, decision.firstCardId, decision.secondCardId)
+
+    expect(decision.strategy).toBe('remembered-pair')
+    expect(firstValue).toBe(secondValue)
+  })
+
+  it('hard difficulty still has a chance to make a non-matching mistake', async () => {
+    const game = createGame()
+    jest.spyOn(Math, 'random').mockReturnValue(0.01)
+
+    const bot = new MemoryBot(game, 'hard', BOT.id)
+    const decision = await bot.makeDecision()
+    const [firstValue, secondValue] = valuesForDecision(game, decision.firstCardId, decision.secondCardId)
+
+    expect(decision.strategy).toBe('mistake')
+    expect(firstValue).not.toBe(secondValue)
+  })
+
+  it('is available through the shared bot factory', () => {
+    const game = createGame()
+
+    expect(createBot('memory', game, 'medium')).toBeInstanceOf(MemoryBot)
+  })
+
+  it('continues a bot turn through mismatch resolution', async () => {
+    process.env.BOT_UX_DELAY_MS = '0'
+    const game = createGame()
+    jest.spyOn(Math, 'random').mockReturnValue(0.01)
+    const moves: Move[] = []
+
+    await executeBotTurn(
+      'memory',
+      game,
+      BOT.id,
+      'hard',
+      async (move) => {
+        moves.push(move)
+        expect(game.makeMove(move)).toBe(true)
+      },
+    )
+
+    const data = game.getState().data as MemoryGameData
+    expect(moves.map((move) => move.type)).toEqual(['flip', 'flip', 'resolve-mismatch'])
+    expect(data.pendingMismatchCardIds).toEqual([])
+    expect(game.getState().currentPlayerIndex).toBe(0)
+  })
+})

--- a/__tests__/lib/game-catalog.test.ts
+++ b/__tests__/lib/game-catalog.test.ts
@@ -1,7 +1,9 @@
 import {
   getAvailableGameTypes,
+  getBotSupportedGameTypes,
   getCatalogAvailableGames,
   getCatalogGames,
+  hasBotSupport,
   isAvailableGameType,
 } from '@/lib/game-catalog'
 
@@ -43,6 +45,11 @@ describe('game catalog availability', () => {
     ])
     expect(isAvailableGameType('yahtzee')).toBe(true)
     expect(isAvailableGameType('rock_paper_scissors')).toBe(false)
+  })
+
+  it('exposes memory as a bot-supported game type', () => {
+    expect(hasBotSupport('memory')).toBe(true)
+    expect(getBotSupportedGameTypes()).toContain('memory')
   })
 
   it('can promote experimental catalog entries through the shared availability path', () => {

--- a/__tests__/lib/game-registry.test.ts
+++ b/__tests__/lib/game-registry.test.ts
@@ -186,7 +186,7 @@ describe('Game Registry', () => {
       expect(meta.name).toBe('Memory')
       expect(meta.minPlayers).toBe(2)
       expect(meta.maxPlayers).toBe(4)
-      expect(meta.supportsBots).toBe(false)
+      expect(meta.supportsBots).toBe(true)
     })
 
     it('should throw error for unknown type', () => {
@@ -217,11 +217,11 @@ describe('Game Registry', () => {
       expect(hasBotSupport('yahtzee')).toBe(true)
       expect(hasBotSupport('tic_tac_toe')).toBe(true)
       expect(hasBotSupport('rock_paper_scissors')).toBe(true)
+      expect(hasBotSupport('memory')).toBe(true)
     })
 
     it('should return false for games without bot support', () => {
       expect(hasBotSupport('guess_the_spy')).toBe(false)
-      expect(hasBotSupport('memory')).toBe(false)
     })
 
     it('should return false for unknown game types', () => {

--- a/__tests__/lib/games/memory-game.test.ts
+++ b/__tests__/lib/games/memory-game.test.ts
@@ -117,6 +117,29 @@ describe('MemoryGame', () => {
     expect(game.getState().currentPlayerIndex).toBe(1)
   })
 
+  it('passes the turn and hides an unmatched flipped card when the active player times out', () => {
+    const game = new MemoryGame('memory-timeout')
+    game.addPlayer(PLAYER_ONE)
+    game.addPlayer(PLAYER_TWO)
+    expect(game.startGame()).toBe(true)
+
+    restoreWithCards(game, [
+      { id: 'a1', value: 'A', isMatched: false, isFlipped: false },
+      { id: 'a2', value: 'A', isMatched: false, isFlipped: false },
+      { id: 'b1', value: 'B', isMatched: false, isFlipped: false },
+      { id: 'b2', value: 'B', isMatched: false, isFlipped: false },
+    ])
+
+    expect(game.makeMove(buildMove(PLAYER_ONE.id, 'flip', { cardId: 'a1' }))).toBe(true)
+    expect(game.makeMove(buildMove(PLAYER_ONE.id, 'timeout-pass'))).toBe(true)
+
+    const data = getData(game)
+    expect(data.cards.find((card) => card.id === 'a1')?.isFlipped).toBe(false)
+    expect(data.flippedCardIds).toEqual([])
+    expect(data.pendingMismatchCardIds).toEqual([])
+    expect(game.getState().currentPlayerIndex).toBe(1)
+  })
+
   it('finishes game and leaves winner empty for a tie', () => {
     const game = new MemoryGame('memory-tie')
     game.addPlayer(PLAYER_ONE)

--- a/__tests__/lib/lobby-player-requirements.test.ts
+++ b/__tests__/lib/lobby-player-requirements.test.ts
@@ -34,12 +34,12 @@ describe('getLobbyPlayerRequirements', () => {
     })
   })
 
-  it('returns strict two-player minimum for memory game', () => {
+  it('keeps two-player requirement for bot-enabled memory game', () => {
     const requirements = getLobbyPlayerRequirements('memory')
 
     expect(requirements).toEqual({
       gameType: 'memory',
-      supportsBots: false,
+      supportsBots: true,
       minPlayersRequired: 2,
       desiredPlayerCount: 2,
     })

--- a/app/api/game/[gameId]/state/route.ts
+++ b/app/api/game/[gameId]/state/route.ts
@@ -696,7 +696,8 @@ export async function POST(
         }
       } else if (
         game.lobby.gameType === 'tic_tac_toe' ||
-        game.lobby.gameType === 'yahtzee'
+        game.lobby.gameType === 'yahtzee' ||
+        game.lobby.gameType === 'memory'
       ) {
         const currentPlayerId = enginePlayers[authoritativeState.currentPlayerIndex]?.id
         const currentBotPlayer = botPlayers.find((player) => player.userId === currentPlayerId)

--- a/app/globals.css
+++ b/app/globals.css
@@ -1602,8 +1602,17 @@ input[type="range"].slider-thumb::-moz-range-track {
   padding: 14px 16px;
 }
 
+.memory-header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .spy-header-timer,
 .memory-status,
+.memory-turn-timer,
 .spy-timer-pill {
   display: inline-flex;
   align-items: center;
@@ -1615,6 +1624,65 @@ input[type="range"].slider-thumb::-moz-range-track {
   font-size: 13px;
   font-weight: 700;
   padding: 8px 10px;
+}
+
+.memory-turn-timer {
+  min-width: 132px;
+  align-items: stretch;
+  flex-direction: column;
+  gap: 5px;
+  color: var(--bd-ink);
+}
+
+.memory-turn-timer-warning {
+  border-color: rgba(224,75,59,0.45);
+  background: rgba(255,107,91,0.12);
+  color: var(--bd-coral-deep);
+}
+
+.memory-turn-timer-track {
+  height: 5px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--bd-bg2);
+}
+
+.memory-turn-timer-track > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--bd-mint);
+  transition: width 1s linear;
+}
+
+.memory-turn-timer-warning .memory-turn-timer-track > span {
+  background: var(--bd-coral);
+}
+
+.memory-leave-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 40px;
+  border-radius: 14px;
+  border: 1.5px solid rgba(224,75,59,0.35);
+  background: rgba(255,107,91,0.12);
+  color: var(--bd-coral-deep);
+  font-size: 13px;
+  font-weight: 800;
+  padding: 8px 11px;
+  transition: background 0.12s, color 0.12s, border-color 0.12s, transform 0.12s;
+}
+
+.memory-leave-button:hover {
+  border-color: var(--bd-coral);
+  background: var(--bd-coral);
+  color: #fff;
+}
+
+.memory-leave-button:active {
+  transform: translateY(1px);
 }
 
 .spy-header-timer {
@@ -1789,6 +1857,13 @@ input[type="range"].slider-thumb::-moz-range-track {
   align-items: start;
 }
 
+.memory-side-stack {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .memory-board-panel {
   padding: clamp(10px, 2vw, 16px);
   background: var(--bd-card-warm);
@@ -1796,6 +1871,16 @@ input[type="range"].slider-thumb::-moz-range-track {
 
 .memory-score-panel {
   padding: 14px;
+}
+
+.memory-chat-panel {
+  min-height: 380px;
+  height: min(520px, calc(100vh - 320px));
+  overflow: hidden;
+  background: #fff;
+  border: 1.5px solid var(--bd-line);
+  border-radius: 18px;
+  box-shadow: 0 4px 14px rgba(31,27,22,0.07);
 }
 
 .memory-grid {
@@ -1897,11 +1982,26 @@ input[type="range"].slider-thumb::-moz-range-track {
     flex-direction: column;
   }
 
+  .memory-header-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .memory-status,
+  .memory-turn-timer,
+  .memory-leave-button {
+    flex: 1 1 150px;
+  }
+
   .memory-layout {
     grid-template-columns: 1fr;
   }
 
-  .memory-score-panel {
+  .memory-side-stack {
     order: -1;
+  }
+
+  .memory-chat-panel {
+    height: 420px;
   }
 }

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -1249,6 +1249,12 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
       })
   }, [isConnected, isReconnecting, status, isGuest, guestToken, guestId, username, code])
 
+  useEffect(() => {
+    if (lobby?.gameType === 'memory' && game?.status === 'playing') {
+      setUnreadMessageCount(0)
+    }
+  }, [chatMessages.length, game?.status, lobby?.gameType])
+
   // Handle bot overlay progression
   useEffect(() => {
     if (!showingBotOverlay || botMoveSteps.length === 0) return
@@ -2334,8 +2340,21 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
               players={Array.isArray(game.players) ? game.players : []}
               state={gameEngine.getState()}
               currentUserId={getCurrentUserId()}
+              turnTimerLimit={turnTimerLimit}
               canStartGame={!!canStartGame}
               onPlayAgain={handleStartGame}
+              onLeave={() => setShowLeaveConfirmModal(true)}
+              chatMessages={chatMessages}
+              onSendChatMessage={(message) => {
+                emitWhenConnected('send-chat-message', {
+                  lobbyCode: code,
+                  message,
+                  userId: getCurrentUserId(),
+                  username: getCurrentUserName(),
+                })
+              }}
+              chatUnreadCount={unreadMessageCount}
+              someoneTyping={someoneTyping}
             />
           ) : gameEngine ? (
             <div className="flex h-full items-center justify-center p-4">

--- a/app/lobby/[code]/components/MemoryGameBoard.tsx
+++ b/app/lobby/[code]/components/MemoryGameBoard.tsx
@@ -3,10 +3,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Move, Player } from '@/lib/game-engine'
 import type { MemoryCard, MemoryGameData } from '@/lib/games/memory-game'
+import type { ChatMessagePayload } from '@/types/game'
 import { useTranslation, type TranslationKeys } from '@/lib/i18n-helpers'
 import { showToast } from '@/lib/i18n-toast'
 import { fetchWithGuest } from '@/lib/fetch-with-guest'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import Chat from '@/components/Chat'
+import { useGameTimer } from '../hooks/useGameTimer'
 
 interface LobbyPlayer {
   id: string
@@ -25,7 +28,21 @@ interface MemoryState {
   status: 'waiting' | 'playing' | 'finished' | string
   currentPlayerIndex: number
   players: Player[]
+  lastMoveAt?: number
+  updatedAt?: Date | string | number
   data?: MemoryGameData
+}
+
+interface AutoActionContext {
+  source: 'turn-timeout'
+  debounceKey: string
+  turnSnapshot: {
+    currentPlayerId: string
+    currentPlayerIndex: number
+    lastMoveAt: number | null
+    rollsLeft: number
+    updatedAt: string | number | null
+  }
 }
 
 interface MemoryGameBoardProps {
@@ -34,8 +51,14 @@ interface MemoryGameBoardProps {
   state: unknown
   players: LobbyPlayer[]
   currentUserId: string | null | undefined
+  turnTimerLimit?: number
   canStartGame?: boolean
   onPlayAgain?: () => void
+  onLeave?: () => void
+  chatMessages?: ChatMessagePayload[]
+  onSendChatMessage?: (message: string) => void
+  chatUnreadCount?: number
+  someoneTyping?: boolean
 }
 
 const MISMATCH_RESOLVE_DELAY_MS = 1200
@@ -59,8 +82,14 @@ export default function MemoryGameBoard({
   state,
   players,
   currentUserId,
+  turnTimerLimit: rawTurnTimerLimit,
   canStartGame,
   onPlayAgain,
+  onLeave,
+  chatMessages = [],
+  onSendChatMessage,
+  chatUnreadCount = 0,
+  someoneTyping = false,
 }: MemoryGameBoardProps) {
   const { t } = useTranslation()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -86,6 +115,10 @@ export default function MemoryGameBoard({
   const scoreByPlayerId = gameData?.scores || {}
   const currentPlayerId = parsedState.players?.[parsedState.currentPlayerIndex]?.id || null
   const isMyTurn = !!currentUserId && currentUserId === currentPlayerId && parsedState.status === 'playing'
+  const turnTimerLimit =
+    typeof rawTurnTimerLimit === 'number' && Number.isFinite(rawTurnTimerLimit) && rawTurnTimerLimit > 0
+      ? Math.floor(rawTurnTimerLimit)
+      : 60
 
   const displayNameByUserId = useMemo(() => {
     const result = new Map<string, string>()
@@ -102,8 +135,36 @@ export default function MemoryGameBoard({
 
   const submitMoveRef = useRef<typeof submitMove | null>(null)
 
+  const buildAutoActionContext = useCallback((playerId: string): AutoActionContext => {
+    const lastMoveAt =
+      typeof parsedState.lastMoveAt === 'number' && Number.isFinite(parsedState.lastMoveAt)
+        ? parsedState.lastMoveAt
+        : null
+    const updatedAt =
+      typeof parsedState.updatedAt === 'number' || typeof parsedState.updatedAt === 'string'
+        ? parsedState.updatedAt
+        : parsedState.updatedAt instanceof Date
+          ? parsedState.updatedAt.toISOString()
+          : null
+
+    return {
+      source: 'turn-timeout',
+      debounceKey: `${gameId}:${playerId}:${parsedState.currentPlayerIndex}:${lastMoveAt ?? 'none'}`,
+      turnSnapshot: {
+        currentPlayerId: playerId,
+        currentPlayerIndex: parsedState.currentPlayerIndex,
+        lastMoveAt,
+        rollsLeft: 0,
+        updatedAt,
+      },
+    }
+  }, [gameId, parsedState.currentPlayerIndex, parsedState.lastMoveAt, parsedState.updatedAt])
+
   const submitMove = useCallback(
-    async (move: Pick<Move, 'type' | 'data'>) => {
+    async (
+      move: Pick<Move, 'type' | 'data'>,
+      options?: { autoActionContext?: AutoActionContext }
+    ) => {
       if (isSubmitting) return false
 
       setIsSubmitting(true)
@@ -115,6 +176,7 @@ export default function MemoryGameBoard({
           },
           body: JSON.stringify({
             move,
+            autoActionContext: options?.autoActionContext,
           }),
         })
 
@@ -124,7 +186,8 @@ export default function MemoryGameBoard({
           const isExpectedRaceError =
             payload?.code === 'TURN_ALREADY_ENDED' ||
             payload?.code === 'TURN_TIMER_ACTIVE' ||
-            payload?.code === 'AUTO_ACTION_DEBOUNCED'
+            payload?.code === 'AUTO_ACTION_DEBOUNCED' ||
+            payload?.code === 'STATE_CONFLICT'
 
           if (!isExpectedRaceError) {
             showToast.error('games.memory.game.moveFailed', undefined, {
@@ -154,6 +217,29 @@ export default function MemoryGameBoard({
   useEffect(() => {
     submitMoveRef.current = submitMove
   }, [submitMove])
+
+  const timerState =
+    parsedState.status === 'playing' && pendingMismatchCardIds.length !== 2
+      ? parsedState
+      : null
+  const { timeLeft, timerActive } = useGameTimer({
+    isMyTurn,
+    gameState: timerState,
+    turnTimerLimit,
+    onTimeout: async (): Promise<boolean> => {
+      if (!isMyTurn || !currentPlayerId || pendingMismatchCardIds.length === 2) {
+        return true
+      }
+
+      const autoActionContext = buildAutoActionContext(currentPlayerId)
+      const submitted = await submitMoveRef.current?.(
+        { type: 'timeout-pass', data: {} },
+        { autoActionContext }
+      )
+
+      return submitted ?? false
+    },
+  })
 
   useEffect(() => {
     if (!isMyTurn || pendingMismatchCardIds.length !== 2) {
@@ -228,6 +314,8 @@ export default function MemoryGameBoard({
   const matchedPairs = cards.filter((card) => card.isMatched).length / 2
   const totalPairs = Math.max(1, cards.length / 2)
   const progressPercent = Math.min(100, Math.max(0, (matchedPairs / totalPairs) * 100))
+  const timerPercent = Math.min(100, Math.max(0, (timeLeft / Math.max(1, turnTimerLimit)) * 100))
+  const isTimerWarning = timerActive && parsedState.status === 'playing' && timeLeft <= 10
   const currentPlayerName =
     (currentPlayerId && displayNameByUserId.get(currentPlayerId)) ||
     t('games.memory.game.unknownPlayer')
@@ -241,9 +329,28 @@ export default function MemoryGameBoard({
             <h2 className="mt-1 truncate text-2xl font-black text-[var(--bd-ink)]">{t('games.memory.name')}</h2>
             <p className="mt-1 text-sm font-semibold text-[var(--bd-ink-muted)]">{difficultyLabel}</p>
           </div>
-          <div className="memory-status">
-            <span className={`bd-live-dot ${parsedState.status === 'finished' ? 'opacity-0' : ''}`} />
-            <span>{statusMessage}</span>
+          <div className="memory-header-actions">
+            <div className="memory-status">
+              <span className={`bd-live-dot ${parsedState.status === 'finished' ? 'opacity-0' : ''}`} />
+              <span>{statusMessage}</span>
+            </div>
+            <div className={`memory-turn-timer ${isTimerWarning ? 'memory-turn-timer-warning' : ''}`}>
+              <span className="font-black tabular-nums">{timeLeft}s</span>
+              <span className="memory-turn-timer-track" aria-hidden>
+                <span style={{ width: `${timerPercent}%` }} />
+              </span>
+            </div>
+            {onLeave && (
+              <button
+                type="button"
+                onClick={onLeave}
+                aria-label={t('game.ui.leave')}
+                className="memory-leave-button"
+              >
+                <span aria-hidden>🚪</span>
+                <span>{t('game.ui.leave')}</span>
+              </button>
+            )}
           </div>
         </header>
 
@@ -320,26 +427,43 @@ export default function MemoryGameBoard({
             </div>
           </section>
 
-          <aside className="memory-score-panel">
-            <h3 className="spy-section-title">{t('games.memory.game.scoreboardTitle')}</h3>
-            <div className="mt-3 space-y-2">
-              {(parsedState.players || []).map((player) => {
-                const score = scoreByPlayerId[player.id] ?? player.score ?? 0
-                const isCurrent = player.id === currentPlayerId
-                return (
-                  <div key={player.id} className={`memory-score-row ${isCurrent ? 'memory-score-row-active' : ''}`}>
-                    <span className="bd-avatar bd-avatar-sun h-9 w-9">
-                      {(displayNameByUserId.get(player.id) || player.name || '?').charAt(0).toUpperCase()}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate font-bold">{displayNameByUserId.get(player.id) || player.name || t('games.memory.game.unknownPlayer')}</p>
-                      <p className="text-xs font-semibold opacity-70">{t('games.memory.game.pairsLabel', { count: score })}</p>
+          <aside className="memory-side-stack">
+            <section className="memory-score-panel">
+              <h3 className="spy-section-title">{t('games.memory.game.scoreboardTitle')}</h3>
+              <div className="mt-3 space-y-2">
+                {(parsedState.players || []).map((player) => {
+                  const score = scoreByPlayerId[player.id] ?? player.score ?? 0
+                  const isCurrent = player.id === currentPlayerId
+                  return (
+                    <div key={player.id} className={`memory-score-row ${isCurrent ? 'memory-score-row-active' : ''}`}>
+                      <span className="bd-avatar bd-avatar-sun h-9 w-9">
+                        {(displayNameByUserId.get(player.id) || player.name || '?').charAt(0).toUpperCase()}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-bold">{displayNameByUserId.get(player.id) || player.name || t('games.memory.game.unknownPlayer')}</p>
+                        <p className="text-xs font-semibold opacity-70">{t('games.memory.game.pairsLabel', { count: score })}</p>
+                      </div>
+                      <span className="text-lg font-black">{score}</span>
                     </div>
-                    <span className="text-lg font-black">{score}</span>
-                  </div>
-                )
-              })}
-            </div>
+                  )
+                })}
+              </div>
+            </section>
+
+            {onSendChatMessage && (
+              <section className="memory-chat-panel">
+                <Chat
+                  messages={chatMessages}
+                  onSendMessage={onSendChatMessage}
+                  currentUserId={currentUserId || null}
+                  isMinimized={false}
+                  onToggleMinimize={() => {}}
+                  unreadCount={chatUnreadCount}
+                  someoneTyping={someoneTyping}
+                  fullScreen
+                />
+              </section>
+            )}
           </aside>
         </main>
       </div>

--- a/app/lobby/create/page.tsx
+++ b/app/lobby/create/page.tsx
@@ -112,7 +112,9 @@ const GAME_INFO: Record<string, GameInfo> = {
     allowedPlayers: [2, 3, 4],
     defaultMaxPlayers: 4,
     settings: {
-      hasTurnTimer: false,
+      hasTurnTimer: true,
+      turnTimerOptions: [30, 60, 90, 120],
+      defaultTurnTimer: 60,
       hasGameModes: false,
       hasDifficultySelection: true,
       difficultyOptions: ['easy', 'medium', 'hard'],

--- a/lib/bots/core/bot-factory.ts
+++ b/lib/bots/core/bot-factory.ts
@@ -11,10 +11,13 @@ import { YahtzeeBotExecutor } from '../yahtzee/yahtzee-bot-executor'
 import { YahtzeeGame } from '@/lib/games/yahtzee-game'
 import { TicTacToeGame } from '@/lib/games/tic-tac-toe-game'
 import { RockPaperScissorsGame } from '@/lib/games/rock-paper-scissors-game'
+import { MemoryGame } from '@/lib/games/memory-game'
 import { TicTacToeBot } from '../tic-tac-toe/tic-tac-toe-bot'
 import { TicTacToeBotExecutor } from '../tic-tac-toe/tic-tac-toe-bot-executor'
 import { RockPaperScissorsBot } from '../rock-paper-scissors/rock-paper-scissors-bot'
 import { RockPaperScissorsBotExecutor } from '../rock-paper-scissors/rock-paper-scissors-bot-executor'
+import { MemoryBot } from '../memory/memory-bot'
+import { MemoryBotExecutor } from '../memory/memory-bot-executor'
 import type { RegisteredGameType } from '@/lib/game-registry'
 // Future imports:
 // import { SpyBot } from '../spy/spy-bot'
@@ -36,6 +39,9 @@ export function createBot<T extends GameEngine>(
 
         case 'rock_paper_scissors':
             return new RockPaperScissorsBot(gameEngine as unknown as RockPaperScissorsGame, difficulty) as unknown as BaseBot<T, unknown>
+
+        case 'memory':
+            return new MemoryBot(gameEngine as unknown as MemoryGame, difficulty) as unknown as BaseBot<T, unknown>
 
         // Future game bots:
         // case 'guess_the_spy':
@@ -92,6 +98,20 @@ export async function executeBotTurn(
                 throw new Error('Expected RockPaperScissorsGame engine for rock_paper_scissors bot turn')
             }
             await RockPaperScissorsBotExecutor.executeBotTurn(
+                gameEngine,
+                botUserId,
+                difficulty,
+                onMove,
+                onBotAction,
+            )
+            return
+        }
+
+        case 'memory': {
+            if (!(gameEngine instanceof MemoryGame)) {
+                throw new Error('Expected MemoryGame engine for memory bot turn')
+            }
+            await MemoryBotExecutor.executeBotTurn(
                 gameEngine,
                 botUserId,
                 difficulty,

--- a/lib/bots/core/bot-helpers.ts
+++ b/lib/bots/core/bot-helpers.ts
@@ -51,8 +51,9 @@ export function botSupportsGame(botType: string | null, gameType: string): boole
         'yahtzee': ['yahtzee'],
         'tic_tac_toe': ['tic_tac_toe'],
         'rock_paper_scissors': ['rock_paper_scissors'],
+        'memory': ['memory'],
         'spy': ['guess_the_spy'],
-        'generic': ['yahtzee', 'tic_tac_toe', 'rock_paper_scissors', 'guess_the_spy'] // Generic bots support all games
+        'generic': ['yahtzee', 'tic_tac_toe', 'rock_paper_scissors', 'guess_the_spy', 'memory'] // Generic bots support all games
     }
 
     return supportMap[botType]?.includes(gameType) ?? false

--- a/lib/bots/index.ts
+++ b/lib/bots/index.ts
@@ -34,3 +34,7 @@ export {
     RockPaperScissorsBotExecutor,
     type RockPaperScissorsBotActionEvent,
 } from './rock-paper-scissors/rock-paper-scissors-bot-executor'
+
+// Memory exports
+export { MemoryBot, type MemoryBotDecision } from './memory/memory-bot'
+export { MemoryBotExecutor, type MemoryBotActionEvent } from './memory/memory-bot-executor'

--- a/lib/bots/memory/memory-bot-executor.ts
+++ b/lib/bots/memory/memory-bot-executor.ts
@@ -1,0 +1,191 @@
+import { MemoryGame, MemoryGameData } from '@/lib/games/memory-game'
+import { clientLogger } from '@/lib/client-logger'
+import { BotDifficulty, MoveCallback } from '../core/bot-types'
+import { resolveBotUxDelayMs } from '../core/bot-ux-timing'
+import { MemoryBot, MemoryBotDecision } from './memory-bot'
+
+export interface MemoryBotActionEvent {
+  type: 'thinking' | 'flip' | 'match' | 'mismatch' | 'resolve-mismatch'
+  botName?: string
+  message: string
+  data?: {
+    cardId?: string
+    firstCardId?: string
+    secondCardId?: string
+    strategy?: MemoryBotDecision['strategy']
+  }
+}
+
+const MAX_PAIR_ATTEMPTS_PER_TURN = 40
+
+export class MemoryBotExecutor {
+  static async executeBotTurn(
+    gameEngine: MemoryGame,
+    botUserId: string,
+    difficulty: BotDifficulty,
+    onMove: MoveCallback,
+    onBotAction?: (event: MemoryBotActionEvent) => void,
+  ): Promise<void> {
+    const bot = new MemoryBot(gameEngine, difficulty, botUserId)
+    const botPlayer = gameEngine.getPlayers().find((player) => player.id === botUserId)
+
+    if (!botPlayer) {
+      throw new Error(`Memory bot player ${botUserId} not found`)
+    }
+
+    let attempts = 0
+    while (attempts < MAX_PAIR_ATTEMPTS_PER_TURN && this.isBotActiveTurn(gameEngine, botUserId)) {
+      const dataBeforeMove = this.getData(gameEngine)
+
+      if (dataBeforeMove.pendingMismatchCardIds.length === 2) {
+        await this.resolveMismatch(bot, botPlayer.name, difficulty, onMove, onBotAction)
+        return
+      }
+
+      if (!this.hasAvailableFlip(dataBeforeMove)) {
+        return
+      }
+
+      onBotAction?.({
+        type: 'thinking',
+        botName: botPlayer.name,
+        message: `${botPlayer.name} is thinking...`,
+      })
+
+      await this.delay(difficulty, 260)
+
+      const decision = await bot.makeDecision()
+      await this.executeDecision(decision, bot, botPlayer.name, difficulty, onMove, onBotAction)
+      attempts += 1
+
+      const stateAfterPair = gameEngine.getState()
+      if (stateAfterPair.status !== 'playing') {
+        return
+      }
+
+      const dataAfterPair = stateAfterPair.data as MemoryGameData
+      if (dataAfterPair.pendingMismatchCardIds.length === 2) {
+        onBotAction?.({
+          type: 'mismatch',
+          botName: botPlayer.name,
+          data: {
+            firstCardId: dataAfterPair.pendingMismatchCardIds[0],
+            secondCardId: dataAfterPair.pendingMismatchCardIds[1],
+            strategy: decision.strategy,
+          },
+          message: `${botPlayer.name} missed a pair`,
+        })
+        await this.delay(difficulty, 1200)
+        await this.resolveMismatch(bot, botPlayer.name, difficulty, onMove, onBotAction)
+        return
+      }
+
+      onBotAction?.({
+        type: 'match',
+        botName: botPlayer.name,
+        data: {
+          firstCardId: decision.firstCardId,
+          secondCardId: decision.secondCardId,
+          strategy: decision.strategy,
+        },
+        message: `${botPlayer.name} found a pair`,
+      })
+
+      await this.delay(difficulty, 420)
+    }
+
+    if (attempts >= MAX_PAIR_ATTEMPTS_PER_TURN) {
+      clientLogger.warn('🤖 [MEMORY-BOT] Stopped after safety cap', {
+        botUserId,
+        attempts,
+      })
+    }
+  }
+
+  private static async executeDecision(
+    decision: MemoryBotDecision,
+    bot: MemoryBot,
+    botName: string,
+    difficulty: BotDifficulty,
+    onMove: MoveCallback,
+    onBotAction?: (event: MemoryBotActionEvent) => void,
+  ): Promise<void> {
+    if (!decision.firstCardAlreadyFlipped) {
+      const firstMove = bot.decisionToMove(decision)
+      await onMove(firstMove)
+
+      onBotAction?.({
+        type: 'flip',
+        botName,
+        data: {
+          cardId: decision.firstCardId,
+          strategy: decision.strategy,
+        },
+        message: `${botName} flipped a card`,
+      })
+
+      await this.delay(difficulty, 360)
+    }
+
+    const secondMove = bot.decisionToSecondMove(decision)
+    await onMove(secondMove)
+
+    onBotAction?.({
+      type: 'flip',
+      botName,
+      data: {
+        cardId: decision.secondCardId,
+        firstCardId: decision.firstCardId,
+        secondCardId: decision.secondCardId,
+        strategy: decision.strategy,
+      },
+      message: `${botName} flipped a second card`,
+    })
+  }
+
+  private static async resolveMismatch(
+    bot: MemoryBot,
+    botName: string,
+    difficulty: BotDifficulty,
+    onMove: MoveCallback,
+    onBotAction?: (event: MemoryBotActionEvent) => void,
+  ): Promise<void> {
+    await this.delay(difficulty, 180)
+    await onMove(bot.createResolveMismatchMove())
+
+    onBotAction?.({
+      type: 'resolve-mismatch',
+      botName,
+      message: `${botName} ends the turn`,
+    })
+  }
+
+  private static hasAvailableFlip(data: MemoryGameData): boolean {
+    const visibleUnmatchedCount = data.cards.filter((card) => card.isFlipped && !card.isMatched).length
+    const hiddenUnmatchedCount = data.cards.filter((card) => !card.isFlipped && !card.isMatched).length
+
+    if (visibleUnmatchedCount === 1) {
+      return hiddenUnmatchedCount >= 1
+    }
+
+    if (visibleUnmatchedCount > 1) {
+      return false
+    }
+
+    return hiddenUnmatchedCount >= 2
+  }
+
+  private static isBotActiveTurn(gameEngine: MemoryGame, botUserId: string): boolean {
+    const state = gameEngine.getState()
+    return state.status === 'playing' && gameEngine.getCurrentPlayer()?.id === botUserId
+  }
+
+  private static getData(gameEngine: MemoryGame): MemoryGameData {
+    return gameEngine.getState().data as MemoryGameData
+  }
+
+  private static delay(difficulty: BotDifficulty, baseMs: number): Promise<void> {
+    const delayMs = resolveBotUxDelayMs(difficulty, baseMs)
+    return new Promise((resolve) => setTimeout(resolve, delayMs))
+  }
+}

--- a/lib/bots/memory/memory-bot.ts
+++ b/lib/bots/memory/memory-bot.ts
@@ -1,0 +1,250 @@
+import { Move } from '@/lib/game-engine'
+import { MemoryCard, MemoryGame, MemoryGameData } from '@/lib/games/memory-game'
+import { BaseBot } from '../core/base-bot'
+import { BotDifficulty } from '../core/bot-types'
+
+export interface MemoryBotDecision {
+  type: 'flip-pair'
+  firstCardId: string
+  secondCardId: string
+  firstCardAlreadyFlipped: boolean
+  strategy: 'remembered-pair' | 'remembered-mate' | 'guess' | 'mistake'
+}
+
+interface MemoryBotProfile {
+  pairRecallChance: number
+  mateRecallChance: number
+  mistakeChance: number
+}
+
+const MEMORY_BOT_PROFILES: Record<BotDifficulty, MemoryBotProfile> = {
+  easy: {
+    pairRecallChance: 0.18,
+    mateRecallChance: 0.22,
+    mistakeChance: 0.48,
+  },
+  medium: {
+    pairRecallChance: 0.58,
+    mateRecallChance: 0.62,
+    mistakeChance: 0.24,
+  },
+  hard: {
+    pairRecallChance: 0.88,
+    mateRecallChance: 0.86,
+    mistakeChance: 0.12,
+  },
+}
+
+export class MemoryBot extends BaseBot<MemoryGame, MemoryBotDecision> {
+  private botUserId: string | null
+
+  constructor(
+    gameEngine: MemoryGame,
+    difficulty: BotDifficulty = 'medium',
+    botUserId?: string,
+  ) {
+    super(gameEngine, difficulty)
+    this.botUserId = botUserId ?? null
+  }
+
+  setBotUserId(botUserId: string) {
+    this.botUserId = botUserId
+  }
+
+  async makeDecision(): Promise<MemoryBotDecision> {
+    const gameData = this.gameEngine.getState().data as MemoryGameData
+    const profile = MEMORY_BOT_PROFILES[this.config.difficulty]
+    const visibleCards = gameData.cards.filter((card) => card.isFlipped && !card.isMatched)
+    const hiddenCards = gameData.cards.filter((card) => !card.isFlipped && !card.isMatched)
+
+    if (visibleCards.length === 1) {
+      const firstCard = visibleCards[0]
+      const secondCard = this.pickSecondCard(firstCard, hiddenCards, profile)
+
+      return {
+        type: 'flip-pair',
+        firstCardId: firstCard.id,
+        secondCardId: secondCard.card.id,
+        firstCardAlreadyFlipped: true,
+        strategy: secondCard.strategy,
+      }
+    }
+
+    if (hiddenCards.length < 2) {
+      throw new Error('No available Memory cards for bot move')
+    }
+
+    const pairDecision = this.pickPair(hiddenCards, profile)
+    return {
+      type: 'flip-pair',
+      firstCardId: pairDecision.first.id,
+      secondCardId: pairDecision.second.id,
+      firstCardAlreadyFlipped: false,
+      strategy: pairDecision.strategy,
+    }
+  }
+
+  decisionToMove(decision: MemoryBotDecision): Move {
+    const cardId = decision.firstCardAlreadyFlipped ? decision.secondCardId : decision.firstCardId
+    return this.createFlipMove(cardId)
+  }
+
+  decisionToSecondMove(decision: MemoryBotDecision): Move {
+    return this.createFlipMove(decision.secondCardId)
+  }
+
+  createResolveMismatchMove(): Move {
+    const playerId = this.resolveBotPlayerId()
+    return {
+      playerId,
+      type: 'resolve-mismatch',
+      data: {},
+      timestamp: new Date(),
+    }
+  }
+
+  evaluateState(): string {
+    const state = this.gameEngine.getState()
+    const gameData = state.data as MemoryGameData
+    const matchedPairs = gameData.cards.filter((card) => card.isMatched).length / 2
+    return `Memory turn=${state.currentPlayerIndex} matchedPairs=${matchedPairs} pendingMismatch=${gameData.pendingMismatchCardIds.length}`
+  }
+
+  private pickPair(
+    hiddenCards: MemoryCard[],
+    profile: MemoryBotProfile,
+  ): { first: MemoryCard; second: MemoryCard; strategy: MemoryBotDecision['strategy'] } {
+    const pairs = this.findHiddenPairs(hiddenCards)
+    const shouldMakeMistake = Math.random() < profile.mistakeChance
+    const shouldRecallPair = !shouldMakeMistake && pairs.length > 0 && Math.random() < profile.pairRecallChance
+
+    if (shouldRecallPair) {
+      const pair = this.pickRandom(pairs)
+      return {
+        first: pair[0],
+        second: pair[1],
+        strategy: 'remembered-pair',
+      }
+    }
+
+    if (shouldMakeMistake) {
+      const nonMatchingPair = this.pickNonMatchingPair(hiddenCards)
+      if (nonMatchingPair) {
+        return {
+          first: nonMatchingPair[0],
+          second: nonMatchingPair[1],
+          strategy: 'mistake',
+        }
+      }
+    }
+
+    const [first, second] = this.pickRandomPair(hiddenCards)
+    return {
+      first,
+      second,
+      strategy: 'guess',
+    }
+  }
+
+  private pickSecondCard(
+    firstCard: MemoryCard,
+    hiddenCards: MemoryCard[],
+    profile: MemoryBotProfile,
+  ): { card: MemoryCard; strategy: MemoryBotDecision['strategy'] } {
+    if (hiddenCards.length === 0) {
+      throw new Error('No hidden Memory cards available for bot move')
+    }
+
+    const matchingMates = hiddenCards.filter((card) => card.value === firstCard.value)
+    const shouldMakeMistake = Math.random() < profile.mistakeChance
+    const shouldRecallMate = !shouldMakeMistake && matchingMates.length > 0 && Math.random() < profile.mateRecallChance
+
+    if (shouldRecallMate) {
+      return {
+        card: this.pickRandom(matchingMates),
+        strategy: 'remembered-mate',
+      }
+    }
+
+    if (shouldMakeMistake) {
+      const nonMatchingCards = hiddenCards.filter((card) => card.value !== firstCard.value)
+      if (nonMatchingCards.length > 0) {
+        return {
+          card: this.pickRandom(nonMatchingCards),
+          strategy: 'mistake',
+        }
+      }
+    }
+
+    return {
+      card: this.pickRandom(hiddenCards),
+      strategy: 'guess',
+    }
+  }
+
+  private findHiddenPairs(hiddenCards: MemoryCard[]): Array<[MemoryCard, MemoryCard]> {
+    const cardsByValue = new Map<string, MemoryCard[]>()
+    for (const card of hiddenCards) {
+      const group = cardsByValue.get(card.value) ?? []
+      group.push(card)
+      cardsByValue.set(card.value, group)
+    }
+
+    return Array.from(cardsByValue.values())
+      .filter((cards) => cards.length >= 2)
+      .map((cards) => [cards[0], cards[1]])
+  }
+
+  private pickNonMatchingPair(cards: MemoryCard[]): [MemoryCard, MemoryCard] | null {
+    const shuffled = this.shuffle(cards)
+    for (let index = 0; index < shuffled.length; index += 1) {
+      for (let nextIndex = index + 1; nextIndex < shuffled.length; nextIndex += 1) {
+        if (shuffled[index].value !== shuffled[nextIndex].value) {
+          return [shuffled[index], shuffled[nextIndex]]
+        }
+      }
+    }
+    return null
+  }
+
+  private pickRandomPair(cards: MemoryCard[]): [MemoryCard, MemoryCard] {
+    const firstIndex = Math.floor(Math.random() * cards.length)
+    let secondIndex = Math.floor(Math.random() * (cards.length - 1))
+    if (secondIndex >= firstIndex) {
+      secondIndex += 1
+    }
+
+    return [cards[firstIndex], cards[secondIndex]]
+  }
+
+  private pickRandom<T>(items: T[]): T {
+    return items[Math.floor(Math.random() * items.length)]
+  }
+
+  private shuffle<T>(items: T[]): T[] {
+    const shuffled = [...items]
+    for (let index = shuffled.length - 1; index > 0; index -= 1) {
+      const swapIndex = Math.floor(Math.random() * (index + 1))
+      ;[shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]]
+    }
+    return shuffled
+  }
+
+  private createFlipMove(cardId: string): Move {
+    const playerId = this.resolveBotPlayerId()
+    return {
+      playerId,
+      type: 'flip',
+      data: { cardId },
+      timestamp: new Date(),
+    }
+  }
+
+  private resolveBotPlayerId(): string {
+    const playerId = this.botUserId || this.gameEngine.getCurrentPlayer()?.id
+    if (!playerId) {
+      throw new Error('Unable to resolve bot player id for Memory move')
+    }
+    return playerId
+  }
+}

--- a/lib/game-catalog.ts
+++ b/lib/game-catalog.ts
@@ -89,7 +89,7 @@ const GAME_METADATA: Record<RegisteredGameType, GameMetadata> = {
     icon: '🧠',
     minPlayers: 2,
     maxPlayers: 4,
-    supportsBots: false,
+    supportsBots: true,
     translationKey: 'memory',
   },
 }

--- a/lib/game-registry.ts
+++ b/lib/game-registry.ts
@@ -130,7 +130,7 @@ const REGISTRY: Record<RegisteredGameType, GameRegistryEntry> = {
       icon: '🧠',
       minPlayers: 2,
       maxPlayers: 4,
-      supportsBots: false,
+      supportsBots: true,
       translationKey: 'memory',
     },
     create: (id, cfg) =>

--- a/lib/games/memory-game.ts
+++ b/lib/games/memory-game.ts
@@ -96,6 +96,11 @@ export class MemoryGame extends GameEngine {
       return data.pendingMismatchCardIds.length === 2
     }
 
+    if (move.type === 'timeout-pass') {
+      const currentPlayer = this.state.players[this.state.currentPlayerIndex]
+      return !!currentPlayer && currentPlayer.id === move.playerId
+    }
+
     if (move.type !== 'flip') {
       return false
     }
@@ -132,6 +137,25 @@ export class MemoryGame extends GameEngine {
           card.isFlipped = false
         }
       }
+      data.pendingMismatchCardIds = []
+      data.flippedCardIds = []
+      data.advanceTurnAfterMove = true
+      return
+    }
+
+    if (move.type === 'timeout-pass') {
+      const cardIdsToHide =
+        data.pendingMismatchCardIds.length > 0
+          ? data.pendingMismatchCardIds
+          : data.flippedCardIds
+
+      for (const cardId of cardIdsToHide) {
+        const card = data.cards.find((entry) => entry.id === cardId)
+        if (card && !card.isMatched) {
+          card.isFlipped = false
+        }
+      }
+
       data.pendingMismatchCardIds = []
       data.flippedCardIds = []
       data.advanceTurnAfterMove = true
@@ -205,7 +229,7 @@ export class MemoryGame extends GameEngine {
       return false
     }
 
-    if (move.type === 'resolve-mismatch' && data.advanceTurnAfterMove) {
+    if ((move.type === 'resolve-mismatch' || move.type === 'timeout-pass') && data.advanceTurnAfterMove) {
       data.advanceTurnAfterMove = false
       return true
     }


### PR DESCRIPTION
## Summary

- Add Memory bot support with easy, medium, and hard difficulty profiles, including explicit mistake chance for hard bots.
- Add server-authoritative Memory turn timeout handling and expose Memory turn timer settings in lobby creation.
- Add Memory in-game timer UI, leave control, scoreboard/chat side panel, and bot-support metadata.
- Add focused tests for Memory bot decisions/executor, Memory timeout behavior, and bot-support metadata.

## Validation

- `npm run typecheck`
- `npx jest __tests__/lib/games/memory-game.test.ts __tests__/lib/bots/memory-bot.test.ts --runInBand`
- `npm run lint`
- Pre-push hook: `npm run db:generate`, `npm run check:locales`, `npm run ci:quick`, Jest smoke tests

Closes #398