### PR TITLE
seo+fix: source map 404s, 301 www redirect, sitemap, viewport

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css'
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import Providers from './providers'
 import dynamic from 'next/dynamic'
 import { getThemeInitScript } from '@/lib/theme'
@@ -100,6 +100,16 @@ export const metadata: Metadata = {
   },
 }
 
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 5,
+  minimumScale: 1,
+  viewportFit: 'cover',
+  userScalable: true,
+  themeColor: '#1F1B16',
+}
+
 export default function RootLayout({
   children,
 }: {
@@ -175,16 +185,10 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className={`${bricolageFont.variable} ${interFont.className}`}>
       <head>
-        {/* Mobile viewport configuration with safe area support */}
-        <meta 
-          name="viewport" 
-          content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0, viewport-fit=cover, user-scalable=yes" 
-        />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="apple-mobile-web-app-title" content="Boardly" />
-        <meta name="theme-color" content="#1F1B16" />
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" href="/icons/icon-192.svg" sizes="192x192" type="image/svg+xml" />
         <link rel="icon" href="/icons/icon-512.svg" sizes="512x512" type="image/svg+xml" />

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,83 +1,44 @@
 import { MetadataRoute } from 'next'
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://boardly.online'
-  const lastModified = new Date('2026-04-22T00:00:00.000Z')
+const baseUrl = 'https://boardly.online'
+const now = new Date()
 
+function page(
+  path: string,
+  opts: { changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency']; priority: number; lastModified?: Date }
+): MetadataRoute.Sitemap[number] {
+  return {
+    url: `${baseUrl}${path}`,
+    lastModified: opts.lastModified ?? now,
+    changeFrequency: opts.changeFrequency,
+    priority: opts.priority,
+  }
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
   return [
-    {
-      url: baseUrl,
-      lastModified,
-      changeFrequency: 'daily',
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/games`,
-      lastModified,
-      changeFrequency: 'weekly',
-      priority: 0.9,
-    },
-    // Game landing pages - primary SEO targets
-    {
-      url: `${baseUrl}/games/yahtzee`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/games/tic-tac-toe`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/games/memory`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.85,
-    },
-    {
-      url: `${baseUrl}/games/spy`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.85,
-    },
-    // Guides - long-tail content
-    {
-      url: `${baseUrl}/guides`,
-      lastModified,
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/guides/how-to-play-yahtzee-online`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/guides/how-to-play-spy-game-online`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.75,
-    },
-    {
-      url: `${baseUrl}/guides/best-free-multiplayer-browser-games`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.75,
-    },
-    {
-      url: `${baseUrl}/privacy`,
-      lastModified,
-      changeFrequency: 'yearly',
-      priority: 0.3,
-    },
-    {
-      url: `${baseUrl}/terms`,
-      lastModified,
-      changeFrequency: 'yearly',
-      priority: 0.3,
-    },
+    page('/', { changeFrequency: 'daily', priority: 1.0 }),
+    page('/games', { changeFrequency: 'weekly', priority: 0.9 }),
+
+    // Active game pages
+    page('/games/yahtzee', { changeFrequency: 'monthly', priority: 0.9 }),
+    page('/games/tic-tac-toe', { changeFrequency: 'monthly', priority: 0.9 }),
+    page('/games/memory', { changeFrequency: 'monthly', priority: 0.85 }),
+    page('/games/spy', { changeFrequency: 'monthly', priority: 0.85 }),
+    page('/games/alias', { changeFrequency: 'monthly', priority: 0.8 }),
+    page('/games/liars-party', { changeFrequency: 'monthly', priority: 0.8 }),
+
+    // Discovery pages
+    page('/leaderboard', { changeFrequency: 'daily', priority: 0.7 }),
+
+    // Guides
+    page('/guides', { changeFrequency: 'weekly', priority: 0.8 }),
+    page('/guides/how-to-play-yahtzee-online', { changeFrequency: 'monthly', priority: 0.8 }),
+    page('/guides/how-to-play-spy-game-online', { changeFrequency: 'monthly', priority: 0.75 }),
+    page('/guides/best-free-multiplayer-browser-games', { changeFrequency: 'monthly', priority: 0.75 }),
+
+    // Legal
+    page('/privacy', { changeFrequency: 'yearly', priority: 0.3 }),
+    page('/terms', { changeFrequency: 'yearly', priority: 0.3 }),
   ]
 }

--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,7 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: '/(.*)',
+        source: '/:path*',
         has: [{ type: 'host', value: 'www.boardly.online' }],
         destination: 'https://boardly.online/:path*',
         permanent: true,

--- a/next.config.js
+++ b/next.config.js
@@ -26,6 +26,17 @@ const allowedDevOrigins = Array.from(new Set([
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+
+  async redirects() {
+    return [
+      {
+        source: '/(.*)',
+        has: [{ type: 'host', value: 'www.boardly.online' }],
+        destination: 'https://boardly.online/:path*',
+        permanent: true,
+      },
+    ]
+  },
   // Allow local host variants in development to prevent HMR/CORS failures
   // when opening the app via localhost, 127.0.0.1, or LAN IP.
   allowedDevOrigins,

--- a/next.config.js
+++ b/next.config.js
@@ -83,43 +83,21 @@ const nextConfig = {
 }
 
 const sentryWebpackOptions = {
-  // For all available options, see:
-  // https://github.com/getsentry/sentry-webpack-plugin#options
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
-
-  // Organization and project (from Sentry dashboard)
   org: process.env.SENTRY_ORG || "boardly-v6",
   project: process.env.SENTRY_PROJECT || "javascript-nextjs",
-
-  // Auth token for uploading source maps (optional - set SENTRY_AUTH_TOKEN in .env.local)
   authToken: process.env.SENTRY_AUTH_TOKEN,
-
-  // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
-
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: true,
-
-  // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
-  // This can increase your server load as well as your hosting bill.
-  // Note: Check that the configured route will not match with your Next.js proxy, otherwise reporting of client-
-  // side errors will fail.
   tunnelRoute: "/monitoring",
-
-  // Hides source maps from generated client bundles
-  hideSourceMaps: true,
-
-  webpack: {
-    // Automatically tree-shake Sentry logger statements to reduce bundle size.
-    treeshake: {
-      removeDebugLogging: true,
-    },
-
-    automaticVercelMonitors: true,
-  },
-  
-  // Disable telemetry to reduce noise in logs
   telemetry: false,
+
+  // Strip sourceMappingURL comments from client bundles and delete .map files
+  // after uploading to Sentry (v10 API — replaces hideSourceMaps + widenClientFileUpload)
+  hideSourceMaps: true,
+  sourcemaps: {
+    deleteFilesAfterUpload: ['**/*.js.map', '**/*.css.map'],
+  },
+
+  automaticVercelMonitors: true,
 }
 
 // Sentry webpack plugin is only needed for production builds.


### PR DESCRIPTION
## Summary
- Fix 38 source map 404 console errors — Sentry v10 `sourcemaps.deleteFilesAfterUpload` API
- SEO: add 301 permanent redirect www→non-www (was 307 Temporary, blocking Google indexing)
- SEO: sitemap — add missing pages (alias, liars-party, leaderboard), dynamic lastModified
- Fix duplicate `<meta name="viewport">` — moved to `export const viewport`

## Test plan
- [ ] CI green ✅
- [ ] Vercel preview deploys
- [ ] `www.boardly.online` → verify 301 redirect (also needs Vercel Dashboard domain setting change)
- [ ] `/sitemap.xml` — confirm new pages present with today's date