### PR TITLE
Stats fixes, leaderboard losses column, shared stats-core module

### DIFF
--- a/__tests__/api/leaderboard.test.ts
+++ b/__tests__/api/leaderboard.test.ts
@@ -42,6 +42,7 @@ describe('GET /api/leaderboard', () => {
         publicProfileId: 'public-1',
         gamesPlayed: BigInt(12),
         wins: BigInt(5),
+        losses: BigInt(7),
         winRate: 41.7,
       },
     ] as any)
@@ -62,6 +63,7 @@ describe('GET /api/leaderboard', () => {
           publicProfileId: 'public-1',
           gamesPlayed: 12,
           wins: 5,
+          losses: 7,
           winRate: 41.7,
         },
       ],

--- a/__tests__/api/user-profile.test.ts
+++ b/__tests__/api/user-profile.test.ts
@@ -133,7 +133,7 @@ describe('GET /api/user/profile', () => {
     expect(payload.user).toMatchObject({
       publicProfileId: 'generated-public-id',
       friendsCount: 3,
-      gamesPlayed: 8,
+      gamesPlayed: 5,
       linkedAccountsCount: 1,
       achievementStats: {
         completedGamesCount: 5,

--- a/__tests__/api/user-stats.test.ts
+++ b/__tests__/api/user-stats.test.ts
@@ -173,7 +173,7 @@ describe('GET /api/user/[id]/stats', () => {
         wins: 1,
         losses: 1,
         draws: 1,
-        winRate: 33.3,
+        winRate: 50,
         avgGameDurationMinutes: 15,
         favoriteGame: 'yahtzee',
         currentWinStreak: 0,

--- a/__tests__/components/player-stats-dashboard.test.tsx
+++ b/__tests__/components/player-stats-dashboard.test.tsx
@@ -98,7 +98,7 @@ describe('PlayerStatsDashboard', () => {
     expect(await screen.findByText('profile.stats.dashboard.title')).toBeTruthy()
     expect(screen.getByText('24')).toBeTruthy()
     expect(screen.getByText('75%')).toBeTruthy()
-    expect(screen.getByText('18profile.stats.dashboard.summary.minutesSuffix')).toBeTruthy()
+    expect(screen.getByText('1080profile.stats.dashboard.summary.secondsSuffix')).toBeTruthy()
 
     expect(mockFetch).toHaveBeenCalledWith('/api/user/user-1/stats', { cache: 'no-store' })
 

--- a/__tests__/lib/games/spy-game.test.ts
+++ b/__tests__/lib/games/spy-game.test.ts
@@ -470,7 +470,7 @@ describe('SpyGame', () => {
       data.phase = SpyGamePhase.VOTING
       data.currentRound = data.totalRounds
       data.spyPlayerId = 'p1'
-      data.scores = { p1: 0, p2: 0, p3: 0 }
+      data.scores = { p1: 0, p2: 10, p3: 0 }
       data.votes = {}
 
       expect(

--- a/__tests__/lib/stats-calculator.test.ts
+++ b/__tests__/lib/stats-calculator.test.ts
@@ -87,7 +87,7 @@ describe('calculateUserStats', () => {
       wins: 1,
       losses: 1,
       draws: 1,
-      winRate: 33.3,
+      winRate: 50,
       avgGameDurationMinutes: 15,
       favoriteGame: 'yahtzee',
       currentWinStreak: 0,

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -58,13 +58,21 @@ export async function GET(req: NextRequest) {
       publicProfileId: string | null
       gamesPlayed: bigint
       wins: bigint
+      losses: bigint
       winRate: number
     }
 
     // Raw SQL needed for FILTER aggregates and conditional clauses —
     // Prisma groupBy cannot express this query.
     const rows = await prisma.$queryRaw<LeaderboardRow[]>(Prisma.sql`
-      WITH leaderboard_rows AS (
+      WITH game_winner_counts AS (
+        SELECT
+          p."gameId",
+          COUNT(*) FILTER (WHERE p."isWinner" = true) AS winner_count
+        FROM "Players" p
+        GROUP BY p."gameId"
+      ),
+      leaderboard_rows AS (
         SELECT
           u.id AS "userId",
           u.username,
@@ -78,10 +86,12 @@ export async function GET(req: NextRequest) {
               WHERE result->>'userId' = p."userId"
                 AND result->>'isWinner' = 'true'
             )
-          ) AS "isWinner"
+          ) AS "isWinner",
+          (gwc.winner_count = 0) AS "isDraw"
         FROM "Players" p
         JOIN "Games" g   ON g.id = p."gameId"
         JOIN "Users" u   ON u.id = p."userId"
+        JOIN game_winner_counts gwc ON gwc."gameId" = g.id
         LEFT JOIN "Bots" b ON b."userId" = u.id
         LEFT JOIN "AccountPreferences" ap ON ap."userId" = u.id
         WHERE g.status = 'finished'
@@ -94,19 +104,28 @@ export async function GET(req: NextRequest) {
         "userId",
         username,
         "publicProfileId",
-        COUNT("playerId")                       AS "gamesPlayed",
-        COUNT("playerId") FILTER (WHERE "isWinner" = true) AS wins,
+        COUNT("playerId")                                                        AS "gamesPlayed",
+        COUNT("playerId") FILTER (WHERE "isWinner" = true)                      AS wins,
+        COUNT("playerId") FILTER (WHERE NOT "isWinner" AND NOT "isDraw")        AS losses,
         ROUND(
           COUNT("playerId") FILTER (WHERE "isWinner" = true)::numeric
-          / NULLIF(COUNT("playerId"), 0) * 100,
+          / NULLIF(
+              COUNT("playerId") FILTER (WHERE "isWinner" = true)
+              + COUNT("playerId") FILTER (WHERE NOT "isWinner" AND NOT "isDraw"),
+              0
+            ) * 100,
           1
-        )::float                         AS "winRate"
+        )::float                                                                 AS "winRate"
       FROM leaderboard_rows
       GROUP BY "userId", username, "publicProfileId"
       HAVING COUNT("playerId") >= ${MIN_GAMES}
       ORDER BY
         COUNT("playerId") FILTER (WHERE "isWinner" = true)::numeric
-        / NULLIF(COUNT("playerId"), 0) DESC NULLS LAST,
+        / NULLIF(
+            COUNT("playerId") FILTER (WHERE "isWinner" = true)
+            + COUNT("playerId") FILTER (WHERE NOT "isWinner" AND NOT "isDraw"),
+            0
+          ) DESC NULLS LAST,
         COUNT("playerId") FILTER (WHERE "isWinner" = true) DESC
       LIMIT ${PAGE_SIZE}
       OFFSET ${offset}

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -140,6 +140,7 @@ export async function GET(req: NextRequest) {
       publicProfileId: r.publicProfileId ?? null,
       gamesPlayed: Number(r.gamesPlayed),
       wins: Number(r.wins),
+      losses: Number(r.losses),
       winRate: r.winRate ?? 0,
     }))
 

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -89,7 +89,7 @@ export async function GET(req: NextRequest) {
                 AND result->>'isWinner' = 'true'
             )
           ) AS "isWinner",
-          (gwc.winner_count = 0) AS "isDraw"
+          (gwc.winner_count = 0 OR (p."isWinner" = true AND gwc.winner_count > 1)) AS "isDraw"
         FROM "Players" p
         JOIN "Games" g   ON g.id = p."gameId"
         JOIN "Users" u   ON u.id = p."userId"
@@ -107,12 +107,12 @@ export async function GET(req: NextRequest) {
         username,
         "publicProfileId",
         COUNT("playerId")                                                        AS "gamesPlayed",
-        COUNT("playerId") FILTER (WHERE "isWinner" = true)                      AS wins,
+        COUNT("playerId") FILTER (WHERE "isWinner" = true AND NOT "isDraw")      AS wins,
         COUNT("playerId") FILTER (WHERE NOT "isWinner" AND NOT "isDraw")        AS losses,
         ROUND(
-          COUNT("playerId") FILTER (WHERE "isWinner" = true)::numeric
+          COUNT("playerId") FILTER (WHERE "isWinner" = true AND NOT "isDraw")::numeric
           / NULLIF(
-              COUNT("playerId") FILTER (WHERE "isWinner" = true)
+              COUNT("playerId") FILTER (WHERE "isWinner" = true AND NOT "isDraw")
               + COUNT("playerId") FILTER (WHERE NOT "isWinner" AND NOT "isDraw"),
               0
             ) * 100,
@@ -122,13 +122,13 @@ export async function GET(req: NextRequest) {
       GROUP BY "userId", username, "publicProfileId"
       HAVING COUNT("playerId") >= ${MIN_GAMES}
       ORDER BY
-        COUNT("playerId") FILTER (WHERE "isWinner" = true)::numeric
+        COUNT("playerId") FILTER (WHERE "isWinner" = true AND NOT "isDraw")::numeric
         / NULLIF(
-            COUNT("playerId") FILTER (WHERE "isWinner" = true)
+            COUNT("playerId") FILTER (WHERE "isWinner" = true AND NOT "isDraw")
             + COUNT("playerId") FILTER (WHERE NOT "isWinner" AND NOT "isDraw"),
             0
           ) DESC NULLS LAST,
-        COUNT("playerId") FILTER (WHERE "isWinner" = true) DESC
+        COUNT("playerId") FILTER (WHERE "isWinner" = true AND NOT "isDraw") DESC
       LIMIT ${PAGE_SIZE}
       OFFSET ${offset}
     `)

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -52,6 +52,8 @@ export async function GET(req: NextRequest) {
   const offset = page * PAGE_SIZE
 
   try {
+    // Win rate formula: wins / (wins + losses) — mirrors computeWinRate() in lib/stats-core.ts.
+    // Outcome logic mirrors resolveOutcome() in lib/stats-core.ts.
     type LeaderboardRow = {
       userId: string
       username: string | null

--- a/app/api/lobby/[code]/invite/route.ts
+++ b/app/api/lobby/[code]/invite/route.ts
@@ -7,6 +7,7 @@ import { apiLogger } from '@/lib/logger'
 import { getNotificationPreferences } from '@/lib/notification-preferences'
 import { recordNotificationDelivery } from '@/lib/notifications-log'
 import { createInAppNotification } from '@/lib/in-app-notifications'
+import { sendGameInviteEmail } from '@/lib/email'
 import { SocketEvents, SocketRooms } from '@/types/socket-events'
 import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
 
@@ -229,11 +230,31 @@ export async function POST(
           return { success: false, error: 'Recipient disabled game invite emails' }
         }
 
+        const emailResult = await sendGameInviteEmail(
+          recipientEmail,
+          friend.username || 'Player',
+          requestUser.username || 'A friend',
+          lobby.name || '',
+          lobby.gameType,
+          inviteUrl
+        )
+
+        if (!emailResult.success) {
+          await recordNotificationDelivery({
+            userId: friend.id,
+            type: 'game_invite',
+            status: 'failed',
+            reason: emailResult.error || 'send_failed',
+            dedupeKey,
+            payload: { ...payload, recipientEmail },
+          })
+          return { success: false, error: emailResult.error }
+        }
+
         await recordNotificationDelivery({
           userId: friend.id,
           type: 'game_invite',
-          status: 'skipped',
-          reason: 'email_notifications_disabled',
+          status: 'sent',
           dedupeKey,
           payload: { ...payload, recipientEmail },
         })

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -45,7 +45,7 @@ type ProfileAchievementStats = {
 function buildProfilePayload(
   user: SelectedProfileUser,
   achievementStats: ProfileAchievementStats = {
-    completedGamesCount: user._count.players,
+    completedGamesCount: 0,
     winsCount: 0,
   }
 ) {
@@ -59,7 +59,7 @@ function buildProfilePayload(
     createdAt: user.createdAt.toISOString(),
     publicProfileId: user.publicProfileId,
     friendsCount: user._count.friendshipsInitiated + user._count.friendshipsReceived,
-    gamesPlayed: user._count.players,
+    gamesPlayed: achievementStats.completedGamesCount,
     linkedAccountsCount: user._count.accounts,
     achievementStats,
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -264,6 +264,11 @@
   width: min(100%, clamp(360px, 38vw, 480px));
 }
 
+.home-hero-board-inner {
+  inset: 8%;
+  position: absolute;
+}
+
 .home-hero-board-surface {
   background: var(--bd-mint);
   background-image: radial-gradient(rgba(31,27,22,0.12) 1px, transparent 1px);
@@ -275,6 +280,11 @@
   overflow: hidden;
   position: absolute;
   transform: rotate(-3deg);
+}
+
+.home-hero-board-inner > .home-hero-board-surface {
+  inset: 0;
+  transform: none;
 }
 
 .home-section {
@@ -428,12 +438,20 @@
     width: min(82vw, 280px);
   }
 
+  .home-hero-board-inner {
+    inset: 10%;
+  }
+
   .home-hero-board-surface {
     background-size: 14px 14px;
     border-width: 3px;
     border-radius: 24px;
     box-shadow: 6px 6px 0 var(--bd-ink);
     inset: 10%;
+  }
+
+  .home-hero-board-inner > .home-hero-board-surface {
+    inset: 0;
   }
 
   .home-section-games {

--- a/app/globals.css
+++ b/app/globals.css
@@ -32,12 +32,24 @@
   100% { transform: translateY(7px)  rotate(0deg);  }
 }
 
+@keyframes bd-float-board {
+  0%   { transform: translateY(0px)   rotate(-1.1deg); }
+  30%  { transform: translateY(-5px)  rotate(-0.4deg); }
+  60%  { transform: translateY(3px)   rotate(-1.8deg); }
+  100% { transform: translateY(0px)   rotate(-1.1deg); }
+}
+
 .bd-float {
   animation: bd-float 5s ease-in-out infinite;
 }
 
+.bd-float-board {
+  animation: bd-float-board 7s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .bd-float { animation: none; }
+  .bd-float      { animation: none; }
+  .bd-float-board { animation: none; transform: rotate(-1.1deg); }
 }
 
 /* ============ END BOARDLY DESIGN SYSTEM ============ */

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -50,20 +50,20 @@ const winRateColor = (winRate: number) => {
 function LeaderboardRow({ entry, isLast, t }: { entry: LeaderboardEntry; isLast: boolean; t: (key: TranslationKeys) => string }) {
   const medal = MEDAL[entry.rank]
   const isTop3 = entry.rank <= 3
-  const rowClass = `grid gap-3 px-4 py-4 transition-colors sm:grid-cols-[4rem_minmax(0,1fr)_6rem_6rem_6rem_6rem] sm:items-center sm:px-5 ${
+  const rowClass = `grid gap-3 px-4 py-4 transition-colors md:grid-cols-[4rem_minmax(0,1fr)_6rem_6rem_6rem_6rem] md:items-center md:px-5 ${
     entry.publicProfileId ? 'hover:bg-bd-card-warm' : ''
   } ${!isLast ? 'border-b border-bd-line' : ''} ${isTop3 ? 'bg-white' : 'bg-white/75'}`
 
   const content = (
     <>
-      <div className="flex items-center gap-3 sm:block">
+      <div className="flex items-center gap-3 md:block">
         <span
           className="inline-grid h-11 w-11 place-items-center rounded-2xl border-2 border-bd-ink text-sm font-extrabold text-bd-ink shadow-[2px_2px_0_#1F1B16]"
           style={{ background: rankAccent(entry.rank), fontFamily: 'var(--bd-font-display)' }}
         >
           {medal ?? entry.rank}
         </span>
-        <span className="text-xs font-bold uppercase tracking-[0.1em] text-bd-ink-muted sm:hidden">{t('leaderboard.rank')}</span>
+        <span className="text-xs font-bold uppercase tracking-[0.1em] text-bd-ink-muted md:hidden">{t('leaderboard.rank')}</span>
       </div>
       <div className="min-w-0">
         <span className="block truncate text-base font-bold text-bd-ink">{entry.username}</span>
@@ -71,24 +71,24 @@ function LeaderboardRow({ entry, isLast, t }: { entry: LeaderboardEntry; isLast:
           <span className="text-xs font-semibold text-bd-ink-muted">{t('leaderboard.viewProfile')}</span>
         )}
       </div>
-      <div className="grid grid-cols-4 gap-2 sm:contents">
-        <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft sm:bg-transparent sm:p-0 sm:text-right">
-          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted sm:hidden">{t('leaderboard.gamesPlayed')}</span>
+      <div className="grid grid-cols-2 gap-2 md:contents">
+        <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft md:bg-transparent md:p-0 md:text-right">
+          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted md:hidden">{t('leaderboard.gamesPlayed')}</span>
           {entry.gamesPlayed}
         </span>
-        <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft sm:bg-transparent sm:p-0 sm:text-right">
-          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted sm:hidden">{t('leaderboard.wins')}</span>
+        <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft md:bg-transparent md:p-0 md:text-right">
+          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted md:hidden">{t('leaderboard.wins')}</span>
           {entry.wins}
         </span>
-        <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft sm:bg-transparent sm:p-0 sm:text-right">
-          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted sm:hidden">{t('leaderboard.losses')}</span>
+        <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft md:bg-transparent md:p-0 md:text-right">
+          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted md:hidden">{t('leaderboard.losses')}</span>
           {entry.losses}
         </span>
         <span
-          className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-extrabold sm:bg-transparent sm:p-0 sm:text-right"
+          className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-extrabold md:bg-transparent md:p-0 md:text-right"
           style={{ color: winRateColor(entry.winRate) }}
         >
-          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted sm:hidden">{t('leaderboard.winRate')}</span>
+          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted md:hidden">{t('leaderboard.winRate')}</span>
           {entry.winRate}%
         </span>
       </div>
@@ -285,7 +285,7 @@ function LeaderboardPageContent() {
 
             {/* Table */}
             <div className="bd-card overflow-hidden">
-              <div className="hidden grid-cols-[4rem_minmax(0,1fr)_6rem_6rem_6rem] gap-3 border-b border-bd-line bg-bd-card-warm px-5 py-3 text-xs font-bold uppercase tracking-[0.1em] text-bd-ink-muted sm:grid">
+              <div className="hidden grid-cols-[4rem_minmax(0,1fr)_6rem_6rem_6rem_6rem] gap-3 border-b border-bd-line bg-bd-card-warm px-5 py-3 text-xs font-bold uppercase tracking-[0.1em] text-bd-ink-muted md:grid">
                 <span>{t('leaderboard.rank')}</span>
                 <span>{t('leaderboard.player', 'Player')}</span>
                 <span className="text-right">{t('leaderboard.gamesPlayed', 'Played')}</span>

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -50,7 +50,7 @@ const winRateColor = (winRate: number) => {
 function LeaderboardRow({ entry, isLast, t }: { entry: LeaderboardEntry; isLast: boolean; t: (key: TranslationKeys) => string }) {
   const medal = MEDAL[entry.rank]
   const isTop3 = entry.rank <= 3
-  const rowClass = `grid gap-3 px-4 py-4 transition-colors sm:grid-cols-[4rem_minmax(0,1fr)_6rem_6rem_6rem] sm:items-center sm:px-5 ${
+  const rowClass = `grid gap-3 px-4 py-4 transition-colors sm:grid-cols-[4rem_minmax(0,1fr)_6rem_6rem_6rem_6rem] sm:items-center sm:px-5 ${
     entry.publicProfileId ? 'hover:bg-bd-card-warm' : ''
   } ${!isLast ? 'border-b border-bd-line' : ''} ${isTop3 ? 'bg-white' : 'bg-white/75'}`
 
@@ -71,7 +71,7 @@ function LeaderboardRow({ entry, isLast, t }: { entry: LeaderboardEntry; isLast:
           <span className="text-xs font-semibold text-bd-ink-muted">{t('leaderboard.viewProfile')}</span>
         )}
       </div>
-      <div className="grid grid-cols-3 gap-2 sm:contents">
+      <div className="grid grid-cols-4 gap-2 sm:contents">
         <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft sm:bg-transparent sm:p-0 sm:text-right">
           <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted sm:hidden">{t('leaderboard.gamesPlayed')}</span>
           {entry.gamesPlayed}
@@ -79,6 +79,10 @@ function LeaderboardRow({ entry, isLast, t }: { entry: LeaderboardEntry; isLast:
         <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft sm:bg-transparent sm:p-0 sm:text-right">
           <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted sm:hidden">{t('leaderboard.wins')}</span>
           {entry.wins}
+        </span>
+        <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft sm:bg-transparent sm:p-0 sm:text-right">
+          <span className="block text-[10px] uppercase tracking-[0.1em] text-bd-ink-muted sm:hidden">{t('leaderboard.losses')}</span>
+          {entry.losses}
         </span>
         <span
           className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-extrabold sm:bg-transparent sm:p-0 sm:text-right"
@@ -286,6 +290,7 @@ function LeaderboardPageContent() {
                 <span>{t('leaderboard.player', 'Player')}</span>
                 <span className="text-right">{t('leaderboard.gamesPlayed', 'Played')}</span>
                 <span className="text-right">{t('leaderboard.wins', 'Wins')}</span>
+                <span className="text-right">{t('leaderboard.losses', 'Losses')}</span>
                 <span className="text-right">{t('leaderboard.winRate', 'Win %')}</span>
               </div>
 

--- a/app/leaderboard/use-leaderboard.ts
+++ b/app/leaderboard/use-leaderboard.ts
@@ -10,6 +10,7 @@ export interface LeaderboardEntry {
   publicProfileId: string | null
   gamesPlayed: number
   wins: number
+  losses: number
   winRate: number
 }
 

--- a/components/Header/MobileMenu.tsx
+++ b/components/Header/MobileMenu.tsx
@@ -152,7 +152,7 @@ export function MobileMenu({
               borderRadius: 99,
               background: 'var(--bd-ink)',
               transition: 'all 0.3s',
-              top: mobileMenuOpen ? '50%' : '25%',
+              top: mobileMenuOpen ? '50%' : 4,
               transform: mobileMenuOpen ? 'translateY(-50%) rotate(45deg)' : 'none',
             }}
           />
@@ -179,7 +179,7 @@ export function MobileMenu({
               borderRadius: 99,
               background: 'var(--bd-ink)',
               transition: 'all 0.3s',
-              top: mobileMenuOpen ? '50%' : '75%',
+              top: mobileMenuOpen ? '50%' : 17,
               transform: mobileMenuOpen ? 'translateY(-50%) rotate(-45deg)' : 'none',
             }}
           />

--- a/components/HomePage/HeroBoard.tsx
+++ b/components/HomePage/HeroBoard.tsx
@@ -1,82 +1,99 @@
-import Die from '@/components/ui/Die'
+'use client'
+
+import { useState, useEffect } from 'react'
+import HeroDemoTicTacToe from './HeroDemoTicTacToe'
+import HeroDemoMemory from './HeroDemoMemory'
+import HeroDemoConnectFour from './HeroDemoConnectFour'
+
+const DEMOS = [
+  {
+    component: HeroDemoTicTacToe,
+    badge: 'TIC-TAC-TOE',
+    rotate: '10deg',
+    color: 'var(--bd-coral)',
+    textColor: 'white',
+  },
+  {
+    component: HeroDemoMemory,
+    badge: 'MEMORY',
+    rotate: '-8deg',
+    color: 'var(--bd-sun)',
+    textColor: 'var(--bd-ink)',
+  },
+  {
+    component: HeroDemoConnectFour,
+    badge: 'CONNECT FOUR',
+    rotate: '12deg',
+    color: 'var(--bd-lav)',
+    textColor: 'var(--bd-ink)',
+  },
+]
 
 export default function HeroBoard() {
+  const [demoIndex, setDemoIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    setDemoIndex(Math.floor(Math.random() * DEMOS.length))
+  }, [])
+
+  if (demoIndex === null) {
+    return <StaticFallback />
+  }
+
+  const demo = DEMOS[demoIndex]
+  const Demo = demo.component
+
   return (
     <div className="home-hero-board">
-      {/* main playing surface */}
       <div className="home-hero-board-surface">
-        <div
-          style={{
-            position: 'absolute',
-            inset: 24,
-            background: 'rgba(255,255,255,0.18)',
-            borderRadius: 18,
-            border: '2px dashed rgba(31,27,22,0.3)',
-          }}
-        />
+        <Demo />
       </div>
 
-      {/* dice cluster */}
-      <div
-        className="bd-float"
-        style={{ position: 'absolute', top: '12%', left: '28%', animationDelay: '0s' }}
-      >
-        <Die value={6} size={70} rotate="-12deg" />
-      </div>
-      <div
-        className="bd-float"
-        style={{ position: 'absolute', top: '24%', left: '52%', animationDelay: '0.6s' }}
-      >
-        <Die value={4} size={56} rotate="8deg" />
-      </div>
-      <div
-        className="bd-float"
-        style={{ position: 'absolute', top: '44%', left: '18%', animationDelay: '1.2s' }}
-      >
-        <Die value={2} size={62} rotate="4deg" />
-      </div>
-
-      {/* card */}
+      {/* game badge sticker */}
       <div
         className="bd-float"
         style={{
           position: 'absolute',
-          bottom: '14%',
-          right: '14%',
-          width: 90,
-          height: 130,
-          background: 'var(--bd-coral)',
-          border: '3px solid var(--bd-ink)',
-          borderRadius: 14,
-          boxShadow: '4px 4px 0 var(--bd-ink)',
-          transform: 'rotate(8deg)',
-          display: 'grid',
-          placeItems: 'center',
-          color: 'white',
+          top: '3%',
+          right: '3%',
+          transform: `rotate(${demo.rotate})`,
+          background: demo.color,
+          color: demo.textColor,
+          border: '2px solid var(--bd-ink)',
+          boxShadow: '2px 2px 0 var(--bd-ink)',
+          borderRadius: 999,
+          padding: '6px 14px',
           fontFamily: 'var(--bd-font-display)',
-          fontSize: 40,
-          animationDelay: '0.8s',
+          fontWeight: 700,
+          fontSize: 13,
+          animationDelay: '0.3s',
+          whiteSpace: 'nowrap',
         }}
       >
-        ♠
+        {demo.badge}
       </div>
 
-      {/* chess piece */}
-      <div
-        className="bd-float"
-        style={{
-          position: 'absolute',
-          bottom: '18%',
-          left: '18%',
-          width: 50,
-          height: 90,
-          background: 'var(--bd-ink)',
-          borderRadius: '24px 24px 4px 4px',
-          animationDelay: '1.4s',
-        }}
-      />
+      {/* squiggle decoration */}
+      <svg
+        style={{ position: 'absolute', bottom: '1%', left: '38%', width: 80, height: 40 }}
+        viewBox="0 0 80 40"
+      >
+        <path
+          d="M2 20 Q 12 5, 22 20 T 42 20 T 62 20 T 78 20"
+          style={{ stroke: 'var(--bd-lav-deep)' }}
+          strokeWidth="4"
+          fill="none"
+          strokeLinecap="round"
+        />
+      </svg>
+    </div>
+  )
+}
 
-      {/* YAHTZEE! sticker */}
+function StaticFallback() {
+  return (
+    <div className="home-hero-board">
+      <div className="home-hero-board-surface" />
       <div
         className="bd-float"
         style={{
@@ -92,26 +109,11 @@ export default function HeroBoard() {
           padding: '6px 14px',
           fontFamily: 'var(--bd-font-display)',
           fontWeight: 700,
-          fontSize: 14,
-          animationDelay: '0.3s',
+          fontSize: 13,
         }}
       >
-        YAHTZEE!
+        BOARDLY
       </div>
-
-      {/* squiggle */}
-      <svg
-        style={{ position: 'absolute', bottom: '2%', left: '40%', width: 80, height: 40 }}
-        viewBox="0 0 80 40"
-      >
-        <path
-          d="M2 20 Q 12 5, 22 20 T 42 20 T 62 20 T 78 20"
-          style={{ stroke: 'var(--bd-lav-deep)' }}
-          strokeWidth="4"
-          fill="none"
-          strokeLinecap="round"
-        />
-      </svg>
     </div>
   )
 }

--- a/components/HomePage/HeroBoard.tsx
+++ b/components/HomePage/HeroBoard.tsx
@@ -5,27 +5,110 @@ import HeroDemoTicTacToe from './HeroDemoTicTacToe'
 import HeroDemoMemory from './HeroDemoMemory'
 import HeroDemoConnectFour from './HeroDemoConnectFour'
 
-const DEMOS = [
+type Demo = {
+  component: React.ComponentType
+  badge: string
+  badgeRotate: string
+  badgeColor: string
+  badgeTextColor: string
+  boardColor: string
+  extra: React.ReactNode
+}
+
+const DEMOS: Demo[] = [
   {
     component: HeroDemoTicTacToe,
     badge: 'TIC-TAC-TOE',
-    rotate: '10deg',
-    color: 'var(--bd-coral)',
-    textColor: 'white',
+    badgeRotate: '10deg',
+    badgeColor: 'var(--bd-coral)',
+    badgeTextColor: 'white',
+    boardColor: 'var(--bd-card-warm)',
+    extra: (
+      <>
+        <div
+          className="bd-float"
+          style={{
+            position: 'absolute', top: '5%', left: '2%',
+            fontSize: 48, fontFamily: 'var(--bd-font-display)', fontWeight: 900,
+            color: 'var(--bd-coral)', transform: 'rotate(-14deg)',
+            animationDelay: '0.4s', lineHeight: 1, userSelect: 'none',
+          }}
+        >✕</div>
+        <div
+          className="bd-float"
+          style={{
+            position: 'absolute', bottom: '8%', left: '3%',
+            fontSize: 38, fontFamily: 'var(--bd-font-display)', fontWeight: 900,
+            color: 'var(--bd-ink)', transform: 'rotate(9deg)',
+            animationDelay: '1.2s', lineHeight: 1, userSelect: 'none',
+          }}
+        >○</div>
+      </>
+    ),
   },
   {
     component: HeroDemoMemory,
     badge: 'MEMORY',
-    rotate: '-8deg',
-    color: 'var(--bd-sun)',
-    textColor: 'var(--bd-ink)',
+    badgeRotate: '-8deg',
+    badgeColor: 'var(--bd-sun)',
+    badgeTextColor: 'var(--bd-ink)',
+    boardColor: 'var(--bd-sky)',
+    extra: (
+      <>
+        <div
+          className="bd-float"
+          style={{
+            position: 'absolute', top: '7%', left: '2%',
+            width: 30, height: 40,
+            background: 'var(--bd-lav)', border: '2px solid var(--bd-ink)',
+            borderRadius: 6, boxShadow: '2px 2px 0 var(--bd-ink)',
+            transform: 'rotate(-13deg)', animationDelay: '0.6s',
+          }}
+        />
+        <div
+          className="bd-float"
+          style={{
+            position: 'absolute', bottom: '10%', left: '3%',
+            width: 26, height: 36,
+            background: 'var(--bd-coral)', border: '2px solid var(--bd-ink)',
+            borderRadius: 6, boxShadow: '2px 2px 0 var(--bd-ink)',
+            transform: 'rotate(7deg)', animationDelay: '1.4s',
+          }}
+        />
+      </>
+    ),
   },
   {
     component: HeroDemoConnectFour,
     badge: 'CONNECT FOUR',
-    rotate: '12deg',
-    color: 'var(--bd-lav)',
-    textColor: 'var(--bd-ink)',
+    badgeRotate: '12deg',
+    badgeColor: 'var(--bd-lav)',
+    badgeTextColor: 'white',
+    boardColor: 'var(--bd-mint)',
+    extra: (
+      <>
+        <div
+          className="bd-float"
+          style={{
+            position: 'absolute', top: '7%', left: '2%',
+            width: 38, height: 38,
+            background: 'var(--bd-coral)', border: '3px solid var(--bd-ink)',
+            borderRadius: '50%', boxShadow: '2px 2px 0 var(--bd-ink)',
+            animationDelay: '0.5s',
+          }}
+        />
+        <div
+          className="bd-float"
+          style={{
+            position: 'absolute', bottom: '12%', left: '3%',
+            width: 32, height: 32,
+            background: 'var(--bd-sun)', border: '3px solid var(--bd-ink)',
+            borderRadius: '50%', boxShadow: '2px 2px 0 var(--bd-ink)',
+            animationDelay: '1.3s',
+          }}
+        />
+      </>
+    ),
   },
 ]
 
@@ -45,7 +128,10 @@ export default function HeroBoard() {
 
   return (
     <div className="home-hero-board">
-      <div className="home-hero-board-surface" style={{ transform: 'none' }}>
+      <div
+        className="home-hero-board-surface"
+        style={{ transform: 'rotate(-1.1deg)', background: demo.boardColor }}
+      >
         <Demo />
       </div>
 
@@ -56,9 +142,9 @@ export default function HeroBoard() {
           position: 'absolute',
           top: '3%',
           right: '3%',
-          transform: `rotate(${demo.rotate})`,
-          background: demo.color,
-          color: demo.textColor,
+          transform: `rotate(${demo.badgeRotate})`,
+          background: demo.badgeColor,
+          color: demo.badgeTextColor,
           border: '2px solid var(--bd-ink)',
           boxShadow: '2px 2px 0 var(--bd-ink)',
           borderRadius: 999,
@@ -73,7 +159,10 @@ export default function HeroBoard() {
         {demo.badge}
       </div>
 
-      {/* squiggle decoration */}
+      {/* per-game floating decorations */}
+      {demo.extra}
+
+      {/* squiggle */}
       <svg
         style={{ position: 'absolute', bottom: '1%', left: '38%', width: 80, height: 40 }}
         viewBox="0 0 80 40"
@@ -93,23 +182,16 @@ export default function HeroBoard() {
 function StaticFallback() {
   return (
     <div className="home-hero-board">
-      <div className="home-hero-board-surface" />
+      <div className="home-hero-board-surface" style={{ transform: 'rotate(-1.1deg)' }} />
       <div
         className="bd-float"
         style={{
-          position: 'absolute',
-          top: '4%',
-          right: '4%',
+          position: 'absolute', top: '4%', right: '4%',
           transform: 'rotate(12deg)',
-          background: 'var(--bd-sun)',
-          color: 'var(--bd-ink)',
-          border: '2px solid var(--bd-ink)',
-          boxShadow: '2px 2px 0 var(--bd-ink)',
-          borderRadius: 999,
-          padding: '6px 14px',
-          fontFamily: 'var(--bd-font-display)',
-          fontWeight: 700,
-          fontSize: 13,
+          background: 'var(--bd-sun)', color: 'var(--bd-ink)',
+          border: '2px solid var(--bd-ink)', boxShadow: '2px 2px 0 var(--bd-ink)',
+          borderRadius: 999, padding: '6px 14px',
+          fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 13,
         }}
       >
         BOARDLY

--- a/components/HomePage/HeroBoard.tsx
+++ b/components/HomePage/HeroBoard.tsx
@@ -45,7 +45,7 @@ export default function HeroBoard() {
 
   return (
     <div className="home-hero-board">
-      <div className="home-hero-board-surface">
+      <div className="home-hero-board-surface" style={{ transform: 'none' }}>
         <Demo />
       </div>
 

--- a/components/HomePage/HeroBoard.tsx
+++ b/components/HomePage/HeroBoard.tsx
@@ -137,7 +137,7 @@ export default function HeroBoard() {
         <div
           style={{
             position: 'absolute',
-            top: '-9%',
+            top: '-5%',
             right: '-9%',
             background: demo.badgeColor,
             color: demo.badgeTextColor,

--- a/components/HomePage/HeroBoard.tsx
+++ b/components/HomePage/HeroBoard.tsx
@@ -8,7 +8,6 @@ import HeroDemoConnectFour from './HeroDemoConnectFour'
 type Demo = {
   component: React.ComponentType
   badge: string
-  badgeRotate: string
   badgeColor: string
   badgeTextColor: string
   boardColor: string
@@ -19,7 +18,6 @@ const DEMOS: Demo[] = [
   {
     component: HeroDemoTicTacToe,
     badge: 'TIC-TAC-TOE',
-    badgeRotate: '10deg',
     badgeColor: 'var(--bd-coral)',
     badgeTextColor: 'white',
     boardColor: 'var(--bd-card-warm)',
@@ -49,7 +47,6 @@ const DEMOS: Demo[] = [
   {
     component: HeroDemoMemory,
     badge: 'MEMORY',
-    badgeRotate: '-8deg',
     badgeColor: 'var(--bd-sun)',
     badgeTextColor: 'var(--bd-ink)',
     boardColor: 'var(--bd-sky)',
@@ -81,7 +78,6 @@ const DEMOS: Demo[] = [
   {
     component: HeroDemoConnectFour,
     badge: 'CONNECT FOUR',
-    badgeRotate: '12deg',
     badgeColor: 'var(--bd-lav)',
     badgeTextColor: 'white',
     boardColor: 'var(--bd-mint)',
@@ -143,7 +139,6 @@ export default function HeroBoard() {
             position: 'absolute',
             top: '-9%',
             right: '-9%',
-            transform: `rotate(${demo.badgeRotate})`,
             background: demo.badgeColor,
             color: demo.badgeTextColor,
             border: '2px solid var(--bd-ink)',

--- a/components/HomePage/HeroBoard.tsx
+++ b/components/HomePage/HeroBoard.tsx
@@ -128,35 +128,36 @@ export default function HeroBoard() {
 
   return (
     <div className="home-hero-board">
-      <div
-        className="home-hero-board-surface bd-float-board"
-        style={{ background: demo.boardColor }}
-      >
-        <Demo />
-      </div>
+      {/* inner wrapper animates — surface + badge move together */}
+      <div className="home-hero-board-inner bd-float-board">
+        <div
+          className="home-hero-board-surface"
+          style={{ background: demo.boardColor }}
+        >
+          <Demo />
+        </div>
 
-      {/* game badge sticker */}
-      <div
-        className="bd-float"
-        style={{
-          position: 'absolute',
-          top: '3%',
-          right: '3%',
-          transform: `rotate(${demo.badgeRotate})`,
-          background: demo.badgeColor,
-          color: demo.badgeTextColor,
-          border: '2px solid var(--bd-ink)',
-          boxShadow: '2px 2px 0 var(--bd-ink)',
-          borderRadius: 999,
-          padding: '6px 14px',
-          fontFamily: 'var(--bd-font-display)',
-          fontWeight: 700,
-          fontSize: 13,
-          animationDelay: '0.3s',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {demo.badge}
+        {/* badge attached to the board */}
+        <div
+          style={{
+            position: 'absolute',
+            top: '-9%',
+            right: '-9%',
+            transform: `rotate(${demo.badgeRotate})`,
+            background: demo.badgeColor,
+            color: demo.badgeTextColor,
+            border: '2px solid var(--bd-ink)',
+            boxShadow: '2px 2px 0 var(--bd-ink)',
+            borderRadius: 999,
+            padding: '6px 14px',
+            fontFamily: 'var(--bd-font-display)',
+            fontWeight: 700,
+            fontSize: 13,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {demo.badge}
+        </div>
       </div>
 
       {/* per-game floating decorations */}
@@ -182,19 +183,8 @@ export default function HeroBoard() {
 function StaticFallback() {
   return (
     <div className="home-hero-board">
-      <div className="home-hero-board-surface bd-float-board" />
-      <div
-        className="bd-float"
-        style={{
-          position: 'absolute', top: '4%', right: '4%',
-          transform: 'rotate(12deg)',
-          background: 'var(--bd-sun)', color: 'var(--bd-ink)',
-          border: '2px solid var(--bd-ink)', boxShadow: '2px 2px 0 var(--bd-ink)',
-          borderRadius: 999, padding: '6px 14px',
-          fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 13,
-        }}
-      >
-        BOARDLY
+      <div className="home-hero-board-inner bd-float-board">
+        <div className="home-hero-board-surface" />
       </div>
     </div>
   )

--- a/components/HomePage/HeroBoard.tsx
+++ b/components/HomePage/HeroBoard.tsx
@@ -28,7 +28,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', top: '5%', left: '2%',
+            position: 'absolute', top: '35%', left: '2%',
             fontSize: 48, fontFamily: 'var(--bd-font-display)', fontWeight: 900,
             color: 'var(--bd-coral)', transform: 'rotate(-14deg)',
             animationDelay: '0.4s', lineHeight: 1, userSelect: 'none',
@@ -37,7 +37,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', bottom: '8%', left: '3%',
+            position: 'absolute', bottom: '5%', right: '8%',
             fontSize: 38, fontFamily: 'var(--bd-font-display)', fontWeight: 900,
             color: 'var(--bd-ink)', transform: 'rotate(9deg)',
             animationDelay: '1.2s', lineHeight: 1, userSelect: 'none',
@@ -58,7 +58,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', top: '7%', left: '2%',
+            position: 'absolute', top: '38%', left: '2%',
             width: 30, height: 40,
             background: 'var(--bd-lav)', border: '2px solid var(--bd-ink)',
             borderRadius: 6, boxShadow: '2px 2px 0 var(--bd-ink)',
@@ -68,7 +68,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', bottom: '10%', left: '3%',
+            position: 'absolute', bottom: '6%', right: '10%',
             width: 26, height: 36,
             background: 'var(--bd-coral)', border: '2px solid var(--bd-ink)',
             borderRadius: 6, boxShadow: '2px 2px 0 var(--bd-ink)',
@@ -90,7 +90,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', top: '7%', left: '2%',
+            position: 'absolute', top: '36%', left: '2%',
             width: 38, height: 38,
             background: 'var(--bd-coral)', border: '3px solid var(--bd-ink)',
             borderRadius: '50%', boxShadow: '2px 2px 0 var(--bd-ink)',
@@ -100,7 +100,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', bottom: '12%', left: '3%',
+            position: 'absolute', bottom: '7%', right: '9%',
             width: 32, height: 32,
             background: 'var(--bd-sun)', border: '3px solid var(--bd-ink)',
             borderRadius: '50%', boxShadow: '2px 2px 0 var(--bd-ink)',
@@ -129,8 +129,8 @@ export default function HeroBoard() {
   return (
     <div className="home-hero-board">
       <div
-        className="home-hero-board-surface"
-        style={{ transform: 'rotate(-1.1deg)', background: demo.boardColor }}
+        className="home-hero-board-surface bd-float-board"
+        style={{ background: demo.boardColor }}
       >
         <Demo />
       </div>
@@ -182,7 +182,7 @@ export default function HeroBoard() {
 function StaticFallback() {
   return (
     <div className="home-hero-board">
-      <div className="home-hero-board-surface" style={{ transform: 'rotate(-1.1deg)' }} />
+      <div className="home-hero-board-surface bd-float-board" />
       <div
         className="bd-float"
         style={{

--- a/components/HomePage/HeroBoard.tsx
+++ b/components/HomePage/HeroBoard.tsx
@@ -37,7 +37,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', bottom: '5%', right: '8%',
+            position: 'absolute', bottom: '18%', right: '1%',
             fontSize: 38, fontFamily: 'var(--bd-font-display)', fontWeight: 900,
             color: 'var(--bd-ink)', transform: 'rotate(9deg)',
             animationDelay: '1.2s', lineHeight: 1, userSelect: 'none',
@@ -68,7 +68,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', bottom: '6%', right: '10%',
+            position: 'absolute', bottom: '18%', right: '1%',
             width: 26, height: 36,
             background: 'var(--bd-coral)', border: '2px solid var(--bd-ink)',
             borderRadius: 6, boxShadow: '2px 2px 0 var(--bd-ink)',
@@ -100,7 +100,7 @@ const DEMOS: Demo[] = [
         <div
           className="bd-float"
           style={{
-            position: 'absolute', bottom: '7%', right: '9%',
+            position: 'absolute', bottom: '18%', right: '1%',
             width: 32, height: 32,
             background: 'var(--bd-sun)', border: '3px solid var(--bd-ink)',
             borderRadius: '50%', boxShadow: '2px 2px 0 var(--bd-ink)',

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -110,8 +110,8 @@ export default function HeroDemoConnectFour() {
       </div>
 
       <div style={{
-        fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 14,
-        color: 'rgba(31,27,22,0.7)', minHeight: 20,
+        fontFamily: 'var(--bd-font-display)', fontWeight: 600, fontSize: 11,
+        color: 'rgba(31,27,22,0.55)', minHeight: 16, textAlign: 'center', width: '100%',
       }}>
         {statusText}
       </div>

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -110,7 +110,7 @@ export default function HeroDemoConnectFour() {
 
       {/* Column click targets */}
       <div style={{ position: 'relative' }}>
-        <div style={{ display: 'flex', gap: GAP, marginBottom: 4 }}>
+        <div style={{ display: 'flex', gap: GAP, marginBottom: 4, paddingLeft: 7, paddingRight: 7 }}>
           {Array.from({ length: COLS }, (_, c) => (
             <div
               key={c}

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+const COLS = 6
+const ROWS = 5
+
+type Cell = 'red' | 'yellow' | null
+type Board = Cell[][]
+
+function makeBoard(): Board {
+  return Array.from({ length: ROWS }, () => Array(COLS).fill(null))
+}
+
+function dropPiece(board: Board, col: number, player: Cell): Board | null {
+  for (let row = ROWS - 1; row >= 0; row--) {
+    if (!board[row][col]) {
+      const next = board.map((r) => [...r])
+      next[row][col] = player
+      return next
+    }
+  }
+  return null
+}
+
+function checkWin(board: Board, player: Cell): boolean {
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      if (
+        (c + 3 < COLS && [0,1,2,3].every((i) => board[r][c + i] === player)) ||
+        (r + 3 < ROWS && [0,1,2,3].every((i) => board[r + i][c] === player)) ||
+        (r + 3 < ROWS && c + 3 < COLS && [0,1,2,3].every((i) => board[r + i][c + i] === player)) ||
+        (r + 3 < ROWS && c - 3 >= 0 && [0,1,2,3].every((i) => board[r + i][c - i] === player))
+      ) return true
+    }
+  }
+  return false
+}
+
+function botMove(board: Board): number {
+  for (let c = 0; c < COLS; c++) {
+    const b = dropPiece(board, c, 'yellow')
+    if (b && checkWin(b, 'yellow')) return c
+  }
+  for (let c = 0; c < COLS; c++) {
+    const b = dropPiece(board, c, 'red')
+    if (b && checkWin(b, 'red')) return c
+  }
+  const available = Array.from({ length: COLS }, (_, i) => i).filter((c) => !board[0][c])
+  return available[Math.floor(Math.random() * available.length)]
+}
+
+export default function HeroDemoConnectFour() {
+  const [board, setBoard] = useState<Board>(makeBoard)
+  const [winner, setWinner] = useState<'red' | 'yellow' | 'draw' | null>(null)
+  const [hoverCol, setHoverCol] = useState<number | null>(null)
+
+  const reset = useCallback(() => {
+    setBoard(makeBoard())
+    setWinner(null)
+  }, [])
+
+  useEffect(() => {
+    if (!winner) return
+    const t = setTimeout(reset, 2400)
+    return () => clearTimeout(t)
+  }, [winner, reset])
+
+  function handleColClick(col: number) {
+    if (winner || board[0][col]) return
+    let next = dropPiece(board, col, 'red')
+    if (!next) return
+    if (checkWin(next, 'red')) { setBoard(next); setWinner('red'); return }
+    const full = next.every((row) => row.every(Boolean))
+    if (full) { setBoard(next); setWinner('draw'); return }
+
+    const bot = botMove(next)
+    if (bot >= 0) {
+      next = dropPiece(next, bot, 'yellow') ?? next
+      if (checkWin(next, 'yellow')) { setBoard(next); setWinner('yellow'); return }
+    }
+    setBoard(next)
+  }
+
+  const statusText =
+    winner === 'red' ? '🎉 You win!'
+    : winner === 'yellow' ? 'Bot wins!'
+    : winner === 'draw' ? "It's a draw!"
+    : 'Drop a piece ↓'
+
+  const CELL = 33
+  const GAP = 5
+
+  return (
+    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8, padding: '10px 8px' }}>
+      {/* Coming soon badge */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6,
+        background: 'var(--bd-sun)', border: '2px solid var(--bd-ink)',
+        borderRadius: 999, padding: '3px 10px',
+        fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 11, color: 'var(--bd-ink)',
+        boxShadow: '2px 2px 0 var(--bd-ink)',
+      }}>
+        🚧 Connect Four — coming soon
+      </div>
+
+      <div style={{ fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 13, color: 'rgba(31,27,22,0.65)', minHeight: 18 }}>
+        {statusText}
+      </div>
+
+      {/* Column click targets */}
+      <div style={{ position: 'relative' }}>
+        <div style={{ display: 'flex', gap: GAP, marginBottom: 4 }}>
+          {Array.from({ length: COLS }, (_, c) => (
+            <div
+              key={c}
+              onClick={() => handleColClick(c)}
+              onMouseEnter={() => setHoverCol(c)}
+              onMouseLeave={() => setHoverCol(null)}
+              style={{
+                width: CELL, height: 16,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                cursor: winner || board[0][c] ? 'default' : 'pointer',
+                fontSize: 12,
+                color: hoverCol === c && !board[0][c] && !winner ? 'var(--bd-coral)' : 'transparent',
+                transition: 'color 0.1s',
+                fontWeight: 900,
+              }}
+            >
+              ▼
+            </div>
+          ))}
+        </div>
+
+        {/* Grid */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${COLS}, ${CELL}px)`,
+          gridTemplateRows: `repeat(${ROWS}, ${CELL}px)`,
+          gap: GAP,
+          background: 'rgba(255,255,255,0.3)',
+          border: '2.5px solid var(--bd-ink)',
+          borderRadius: 14,
+          padding: 7,
+          boxShadow: '0 3px 0 rgba(31,27,22,0.15)',
+        }}>
+          {board.map((row, r) =>
+            row.map((cell, c) => (
+              <div
+                key={`${r}-${c}`}
+                onClick={() => handleColClick(c)}
+                style={{
+                  width: CELL, height: CELL,
+                  borderRadius: '50%',
+                  background: cell === 'red'
+                    ? 'var(--bd-coral)'
+                    : cell === 'yellow'
+                      ? 'var(--bd-sun)'
+                      : hoverCol === c && !board[0][c] && !winner
+                        ? 'rgba(255,107,91,0.2)'
+                        : 'rgba(255,255,255,0.5)',
+                  border: `2px solid ${cell ? 'var(--bd-ink)' : 'rgba(31,27,22,0.2)'}`,
+                  cursor: winner || board[0][c] ? 'default' : 'pointer',
+                  transition: 'background 0.1s',
+                  boxShadow: cell ? '0 2px 0 rgba(31,27,22,0.2)' : 'none',
+                }}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -71,8 +71,7 @@ export default function HeroDemoConnectFour() {
     let next = dropPiece(board, col, 'red')
     if (!next) return
     if (checkWin(next, 'red')) { setBoard(next); setWinner('red'); return }
-    const full = next.every((row) => row.every(Boolean))
-    if (full) { setBoard(next); setWinner('draw'); return }
+    if (next.every((row) => row.every(Boolean))) { setBoard(next); setWinner('draw'); return }
 
     const bot = botMove(next)
     if (bot >= 0) {
@@ -85,32 +84,41 @@ export default function HeroDemoConnectFour() {
   const statusText =
     winner === 'red' ? '🎉 You win!'
     : winner === 'yellow' ? 'Bot wins!'
-    : winner === 'draw' ? "It's a draw!"
-    : 'Drop a piece ↓'
+    : winner === 'draw' ? "Draw!"
+    : 'Drop a piece'
 
-  const CELL = 33
+  const CELL = 34
   const GAP = 5
+  const PADDING = 8
 
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8, padding: '10px 8px' }}>
-      {/* Coming soon badge */}
+    <div style={{
+      width: '100%', height: '100%',
+      display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center',
+      gap: 8, padding: '10px 8px',
+    }}>
+      {/* coming soon badge */}
       <div style={{
-        display: 'flex', alignItems: 'center', gap: 6,
-        background: 'var(--bd-sun)', border: '2px solid var(--bd-ink)',
-        borderRadius: 999, padding: '3px 10px',
+        display: 'inline-flex', alignItems: 'center', gap: 5,
+        background: 'rgba(255,255,255,0.9)', border: '2px solid var(--bd-ink)',
+        borderRadius: 999, padding: '4px 12px',
         fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 11, color: 'var(--bd-ink)',
         boxShadow: '2px 2px 0 var(--bd-ink)',
       }}>
-        🚧 Connect Four — coming soon
+        🚧 Coming soon
       </div>
 
-      <div style={{ fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 13, color: 'rgba(31,27,22,0.65)', minHeight: 18 }}>
+      <div style={{
+        fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 14,
+        color: 'rgba(31,27,22,0.7)', minHeight: 20,
+      }}>
         {statusText}
       </div>
 
-      {/* Column click targets */}
       <div style={{ position: 'relative' }}>
-        <div style={{ display: 'flex', gap: GAP, marginBottom: 4, paddingLeft: 7, paddingRight: 7 }}>
+        {/* drop indicators */}
+        <div style={{ display: 'flex', gap: GAP, marginBottom: 4, paddingLeft: PADDING, paddingRight: PADDING }}>
           {Array.from({ length: COLS }, (_, c) => (
             <div
               key={c}
@@ -121,10 +129,9 @@ export default function HeroDemoConnectFour() {
                 width: CELL, height: 16,
                 display: 'flex', alignItems: 'center', justifyContent: 'center',
                 cursor: winner || board[0][c] ? 'default' : 'pointer',
-                fontSize: 12,
+                fontSize: 13, fontWeight: 900,
                 color: hoverCol === c && !board[0][c] && !winner ? 'var(--bd-coral)' : 'transparent',
                 transition: 'color 0.1s',
-                fontWeight: 900,
               }}
             >
               ▼
@@ -132,17 +139,17 @@ export default function HeroDemoConnectFour() {
           ))}
         </div>
 
-        {/* Grid */}
+        {/* grid */}
         <div style={{
           display: 'grid',
           gridTemplateColumns: `repeat(${COLS}, ${CELL}px)`,
           gridTemplateRows: `repeat(${ROWS}, ${CELL}px)`,
           gap: GAP,
-          background: 'rgba(255,255,255,0.3)',
+          background: 'rgba(31,27,22,0.15)',
           border: '2.5px solid var(--bd-ink)',
           borderRadius: 14,
-          padding: 7,
-          boxShadow: '0 3px 0 rgba(31,27,22,0.15)',
+          padding: PADDING,
+          boxShadow: '0 4px 0 rgba(31,27,22,0.2)',
         }}>
           {board.map((row, r) =>
             row.map((cell, c) => (
@@ -157,12 +164,14 @@ export default function HeroDemoConnectFour() {
                     : cell === 'yellow'
                       ? 'var(--bd-sun)'
                       : hoverCol === c && !board[0][c] && !winner
-                        ? 'rgba(255,107,91,0.2)'
-                        : 'rgba(255,255,255,0.5)',
-                  border: `2px solid ${cell ? 'var(--bd-ink)' : 'rgba(31,27,22,0.2)'}`,
+                        ? 'rgba(255,255,255,0.55)'
+                        : 'rgba(255,255,255,0.35)',
+                  border: cell
+                    ? '2.5px solid var(--bd-ink)'
+                    : '2px solid rgba(31,27,22,0.2)',
                   cursor: winner || board[0][c] ? 'default' : 'pointer',
-                  transition: 'background 0.1s',
-                  boxShadow: cell ? '0 2px 0 rgba(31,27,22,0.2)' : 'none',
+                  transition: 'background 0.12s',
+                  boxShadow: cell ? '0 2px 0 rgba(31,27,22,0.25)' : 'inset 0 2px 4px rgba(31,27,22,0.1)',
                 }}
               />
             ))

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -87,9 +87,9 @@ export default function HeroDemoConnectFour() {
     : winner === 'draw' ? "Draw!"
     : 'Drop a piece'
 
-  const CELL = 34
-  const GAP = 5
-  const PADDING = 8
+  const CELL = 28
+  const GAP = 4
+  const PADDING = 7
 
   return (
     <div style={{

--- a/components/HomePage/HeroDemoMemory.tsx
+++ b/components/HomePage/HeroDemoMemory.tsx
@@ -4,28 +4,30 @@ import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 
 const PAIRS = ['🎲', '🃏', '🏆', '⭐', '🎮', '🎯']
-const INITIAL_CARDS = [...PAIRS, ...PAIRS]
-  .map((emoji, i) => ({ id: i, emoji, matched: false }))
-  .sort(() => Math.random() - 0.5)
+
+function shuffle<T>(arr: T[]): T[] {
+  return [...arr].sort(() => Math.random() - 0.5)
+}
 
 type Card = { id: number; emoji: string; matched: boolean }
 
+function makeCards(): Card[] {
+  return shuffle([...PAIRS, ...PAIRS]).map((emoji, i) => ({ id: i, emoji, matched: false }))
+}
+
 export default function HeroDemoMemory() {
-  const [cards, setCards] = useState<Card[]>(INITIAL_CARDS)
+  const [cards, setCards] = useState<Card[]>(makeCards)
   const [flipped, setFlipped] = useState<number[]>([])
   const [locked, setLocked] = useState(false)
 
   const reset = useCallback(() => {
-    setCards(
-      [...PAIRS, ...PAIRS]
-        .map((emoji, i) => ({ id: i, emoji, matched: false }))
-        .sort(() => Math.random() - 0.5)
-    )
+    setCards(makeCards())
     setFlipped([])
     setLocked(false)
   }, [])
 
   const allMatched = cards.every((c) => c.matched)
+  const matchedCount = cards.filter((c) => c.matched).length / 2
 
   useEffect(() => {
     if (!allMatched) return
@@ -46,23 +48,26 @@ export default function HeroDemoMemory() {
         setFlipped([])
         setLocked(false)
       } else {
-        setTimeout(() => {
-          setFlipped([])
-          setLocked(false)
-        }, 900)
+        setTimeout(() => { setFlipped([]); setLocked(false) }, 900)
       }
     }
   }
 
-  const matchedCount = cards.filter((c) => c.matched).length / 2
-
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, padding: '12px 8px' }}>
-      <div style={{ fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 13, color: 'rgba(31,27,22,0.65)', minHeight: 20 }}>
-        {allMatched ? '🎉 All matched!' : `${matchedCount} / ${PAIRS.length} pairs found`}
+    <div style={{
+      width: '100%', height: '100%',
+      display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center',
+      gap: 12, padding: '16px 8px',
+    }}>
+      <div style={{
+        fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 14,
+        color: 'rgba(31,27,22,0.8)', minHeight: 22,
+      }}>
+        {allMatched ? '🎉 All matched!' : `${matchedCount} / ${PAIRS.length} pairs`}
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 46px)', gridTemplateRows: 'repeat(3, 52px)', gap: 7 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 48px)', gridTemplateRows: 'repeat(3, 54px)', gap: 7 }}>
         {cards.map((card, i) => {
           const isFlipped = flipped.includes(i) || card.matched
           return (
@@ -70,24 +75,24 @@ export default function HeroDemoMemory() {
               key={card.id + '-' + i}
               onClick={() => handleFlip(i)}
               style={{
-                width: 46, height: 52,
+                width: 48, height: 54,
                 background: card.matched
-                  ? 'rgba(255,255,255,0.8)'
+                  ? 'rgba(255,255,255,0.85)'
                   : isFlipped
-                    ? 'rgba(255,255,255,0.7)'
+                    ? '#fff'
                     : 'var(--bd-ink)',
-                border: '2.5px solid var(--bd-ink)',
+                border: `2.5px solid ${card.matched ? 'rgba(31,27,22,0.2)' : 'var(--bd-ink)'}`,
                 borderRadius: 10,
-                fontSize: isFlipped ? 22 : 0,
+                fontSize: isFlipped ? 24 : 16,
+                color: isFlipped ? 'var(--bd-ink)' : 'rgba(255,255,255,0.35)',
                 cursor: card.matched || locked ? 'default' : 'pointer',
-                boxShadow: isFlipped ? 'none' : '0 3px 0 rgba(31,27,22,0.3)',
-                transition: 'background 0.2s, font-size 0.15s',
+                boxShadow: isFlipped ? 'none' : '0 4px 0 rgba(31,27,22,0.35)',
+                transition: 'background 0.18s, box-shadow 0.18s, font-size 0.12s',
                 lineHeight: 1,
                 padding: 0,
-                opacity: card.matched ? 0.55 : 1,
               }}
             >
-              {isFlipped ? card.emoji : ''}
+              {isFlipped ? card.emoji : '?'}
             </button>
           )
         })}
@@ -95,7 +100,10 @@ export default function HeroDemoMemory() {
 
       <Link
         href="/games/memory"
-        style={{ fontSize: 11, fontWeight: 600, color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 4 }}
+        style={{
+          fontSize: 12, fontWeight: 600,
+          color: 'rgba(31,27,22,0.6)', textDecoration: 'underline', marginTop: 2,
+        }}
       >
         Play full game →
       </Link>

--- a/components/HomePage/HeroDemoMemory.tsx
+++ b/components/HomePage/HeroDemoMemory.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+
+const PAIRS = ['🎲', '🃏', '🏆', '⭐', '🎮', '🎯']
+const INITIAL_CARDS = [...PAIRS, ...PAIRS]
+  .map((emoji, i) => ({ id: i, emoji, matched: false }))
+  .sort(() => Math.random() - 0.5)
+
+type Card = { id: number; emoji: string; matched: boolean }
+
+export default function HeroDemoMemory() {
+  const [cards, setCards] = useState<Card[]>(INITIAL_CARDS)
+  const [flipped, setFlipped] = useState<number[]>([])
+  const [locked, setLocked] = useState(false)
+
+  const reset = useCallback(() => {
+    setCards(
+      [...PAIRS, ...PAIRS]
+        .map((emoji, i) => ({ id: i, emoji, matched: false }))
+        .sort(() => Math.random() - 0.5)
+    )
+    setFlipped([])
+    setLocked(false)
+  }, [])
+
+  const allMatched = cards.every((c) => c.matched)
+
+  useEffect(() => {
+    if (!allMatched) return
+    const t = setTimeout(reset, 2000)
+    return () => clearTimeout(t)
+  }, [allMatched, reset])
+
+  function handleFlip(idx: number) {
+    if (locked || cards[idx].matched || flipped.includes(idx)) return
+    const next = [...flipped, idx]
+    setFlipped(next)
+
+    if (next.length === 2) {
+      setLocked(true)
+      const [a, b] = next
+      if (cards[a].emoji === cards[b].emoji) {
+        setCards((prev) => prev.map((c, i) => (i === a || i === b ? { ...c, matched: true } : c)))
+        setFlipped([])
+        setLocked(false)
+      } else {
+        setTimeout(() => {
+          setFlipped([])
+          setLocked(false)
+        }, 900)
+      }
+    }
+  }
+
+  const matchedCount = cards.filter((c) => c.matched).length / 2
+
+  return (
+    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, padding: '12px 8px' }}>
+      <div style={{ fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 13, color: 'rgba(31,27,22,0.65)', minHeight: 20 }}>
+        {allMatched ? '🎉 All matched!' : `${matchedCount} / ${PAIRS.length} pairs found`}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 46px)', gridTemplateRows: 'repeat(3, 52px)', gap: 7 }}>
+        {cards.map((card, i) => {
+          const isFlipped = flipped.includes(i) || card.matched
+          return (
+            <button
+              key={card.id + '-' + i}
+              onClick={() => handleFlip(i)}
+              style={{
+                width: 46, height: 52,
+                background: card.matched
+                  ? 'rgba(255,255,255,0.8)'
+                  : isFlipped
+                    ? 'rgba(255,255,255,0.7)'
+                    : 'var(--bd-ink)',
+                border: '2.5px solid var(--bd-ink)',
+                borderRadius: 10,
+                fontSize: isFlipped ? 22 : 0,
+                cursor: card.matched || locked ? 'default' : 'pointer',
+                boxShadow: isFlipped ? 'none' : '0 3px 0 rgba(31,27,22,0.3)',
+                transition: 'background 0.2s, font-size 0.15s',
+                lineHeight: 1,
+                padding: 0,
+                opacity: card.matched ? 0.55 : 1,
+              }}
+            >
+              {isFlipped ? card.emoji : ''}
+            </button>
+          )
+        })}
+      </div>
+
+      <Link
+        href="/games/memory"
+        style={{ fontSize: 11, fontWeight: 600, color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 4 }}
+      >
+        Play full game →
+      </Link>
+    </div>
+  )
+}

--- a/components/HomePage/HeroDemoTicTacToe.tsx
+++ b/components/HomePage/HeroDemoTicTacToe.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+
+type Cell = 'X' | 'O' | null
+
+const WINS = [
+  [0, 1, 2], [3, 4, 5], [6, 7, 8],
+  [0, 3, 6], [1, 4, 7], [2, 5, 8],
+  [0, 4, 8], [2, 4, 6],
+]
+
+function checkWinner(board: Cell[]): Cell | 'draw' | null {
+  for (const [a, b, c] of WINS) {
+    if (board[a] && board[a] === board[b] && board[a] === board[c]) return board[a]
+  }
+  if (board.every(Boolean)) return 'draw'
+  return null
+}
+
+function botMove(board: Cell[]): number {
+  for (const [a, b, c] of WINS) {
+    if (board[a] === 'O' && board[b] === 'O' && !board[c]) return c
+    if (board[a] === 'O' && !board[b] && board[c] === 'O') return b
+    if (!board[a] && board[b] === 'O' && board[c] === 'O') return a
+  }
+  for (const [a, b, c] of WINS) {
+    if (board[a] === 'X' && board[b] === 'X' && !board[c]) return c
+    if (board[a] === 'X' && !board[b] && board[c] === 'X') return b
+    if (!board[a] && board[b] === 'X' && board[c] === 'X') return a
+  }
+  if (!board[4]) return 4
+  const empty = board.map((c, i) => (c ? -1 : i)).filter((i) => i >= 0)
+  return empty[Math.floor(Math.random() * empty.length)]
+}
+
+const EMPTY: Cell[] = Array(9).fill(null)
+
+export default function HeroDemoTicTacToe() {
+  const [board, setBoard] = useState<Cell[]>(EMPTY)
+  const [winner, setWinner] = useState<Cell | 'draw' | null>(null)
+
+  const reset = useCallback(() => {
+    setBoard(EMPTY)
+    setWinner(null)
+  }, [])
+
+  function handleClick(i: number) {
+    if (board[i] || winner) return
+    const next = [...board]
+    next[i] = 'X'
+    const w = checkWinner(next)
+    if (!w) {
+      const bot = botMove(next)
+      if (bot >= 0) next[bot] = 'O'
+    }
+    setBoard(next)
+    setWinner(checkWinner(next))
+  }
+
+  useEffect(() => {
+    if (!winner) return
+    const t = setTimeout(reset, 2200)
+    return () => clearTimeout(t)
+  }, [winner, reset])
+
+  const statusText =
+    winner === 'X' ? '🎉 You win!'
+    : winner === 'O' ? 'Bot wins!'
+    : winner === 'draw' ? "It's a draw!"
+    : 'Your turn (X)'
+
+  return (
+    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, padding: '12px 8px' }}>
+      <div style={{ fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 13, color: 'rgba(31,27,22,0.65)', minHeight: 20 }}>
+        {statusText}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 60px)', gridTemplateRows: 'repeat(3, 60px)', gap: 7 }}>
+        {board.map((cell, i) => (
+          <button
+            key={i}
+            onClick={() => handleClick(i)}
+            style={{
+              width: 60, height: 60,
+              background: cell ? 'rgba(255,255,255,0.75)' : 'rgba(255,255,255,0.45)',
+              border: '2.5px solid var(--bd-ink)',
+              borderRadius: 12,
+              fontSize: 24,
+              fontWeight: 900,
+              fontFamily: 'var(--bd-font-display)',
+              color: cell === 'X' ? 'var(--bd-coral)' : 'var(--bd-ink)',
+              cursor: cell || winner ? 'default' : 'pointer',
+              boxShadow: cell ? 'none' : '0 3px 0 rgba(31,27,22,0.18)',
+              transition: 'transform 0.08s, box-shadow 0.08s',
+              lineHeight: 1,
+              padding: 0,
+            }}
+          >
+            {cell}
+          </button>
+        ))}
+      </div>
+
+      <Link
+        href="/games/tic-tac-toe"
+        style={{ fontSize: 11, fontWeight: 600, color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 4 }}
+      >
+        Play full game →
+      </Link>
+    </div>
+  )
+}

--- a/components/HomePage/HeroDemoTicTacToe.tsx
+++ b/components/HomePage/HeroDemoTicTacToe.tsx
@@ -68,32 +68,40 @@ export default function HeroDemoTicTacToe() {
   const statusText =
     winner === 'X' ? '🎉 You win!'
     : winner === 'O' ? 'Bot wins!'
-    : winner === 'draw' ? "It's a draw!"
+    : winner === 'draw' ? "Draw!"
     : 'Your turn (X)'
 
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 10, padding: '12px 8px' }}>
-      <div style={{ fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 13, color: 'rgba(31,27,22,0.65)', minHeight: 20 }}>
+    <div style={{
+      width: '100%', height: '100%',
+      display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center',
+      gap: 12, padding: '16px 8px',
+    }}>
+      <div style={{
+        fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 14,
+        color: 'rgba(31,27,22,0.7)', minHeight: 22,
+      }}>
         {statusText}
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 60px)', gridTemplateRows: 'repeat(3, 60px)', gap: 7 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 64px)', gridTemplateRows: 'repeat(3, 64px)', gap: 8 }}>
         {board.map((cell, i) => (
           <button
             key={i}
             onClick={() => handleClick(i)}
             style={{
-              width: 60, height: 60,
-              background: cell ? 'rgba(255,255,255,0.75)' : 'rgba(255,255,255,0.45)',
+              width: 64, height: 64,
+              background: '#fff',
               border: '2.5px solid var(--bd-ink)',
-              borderRadius: 12,
-              fontSize: 24,
+              borderRadius: 14,
+              fontSize: 28,
               fontWeight: 900,
               fontFamily: 'var(--bd-font-display)',
               color: cell === 'X' ? 'var(--bd-coral)' : 'var(--bd-ink)',
               cursor: cell || winner ? 'default' : 'pointer',
-              boxShadow: cell ? 'none' : '0 3px 0 rgba(31,27,22,0.18)',
-              transition: 'transform 0.08s, box-shadow 0.08s',
+              boxShadow: cell ? 'none' : '0 4px 0 rgba(31,27,22,0.2)',
+              transition: 'box-shadow 0.08s, transform 0.08s',
               lineHeight: 1,
               padding: 0,
             }}
@@ -105,7 +113,10 @@ export default function HeroDemoTicTacToe() {
 
       <Link
         href="/games/tic-tac-toe"
-        style={{ fontSize: 11, fontWeight: 600, color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 4 }}
+        style={{
+          fontSize: 12, fontWeight: 600,
+          color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 2,
+        }}
       >
         Play full game →
       </Link>

--- a/components/PlayerStatsDashboard.tsx
+++ b/components/PlayerStatsDashboard.tsx
@@ -390,8 +390,8 @@ export default function PlayerStatsDashboard({ userId }: PlayerStatsDashboardPro
       {
         id: 'avgDuration',
         label: t('profile.stats.dashboard.summary.avgDuration'),
-        value: `${Math.round(stats.overall.avgGameDurationMinutes)}${t(
-          'profile.stats.dashboard.summary.minutesSuffix'
+        value: `${Math.round(stats.overall.avgGameDurationMinutes * 60)}${t(
+          'profile.stats.dashboard.summary.secondsSuffix'
         )}`,
         accentClassName: 'bg-bd-sun text-[#9b6b00]',
       },
@@ -451,24 +451,24 @@ export default function PlayerStatsDashboard({ userId }: PlayerStatsDashboardPro
       )
     : null
 
-  const overallInsightItems = useMemo(() => {
-    if (!stats) return []
+  const gameInsightItems = useMemo(() => {
+    if (!selectedGameStats || !stats) return []
 
     return [
       {
         id: 'wins',
         label: t('profile.stats.dashboard.summary.wins'),
-        value: stats.overall.wins,
+        value: selectedGameStats.wins,
       },
       {
         id: 'losses',
         label: t('profile.stats.dashboard.summary.losses'),
-        value: stats.overall.losses,
+        value: selectedGameStats.losses,
       },
       {
         id: 'draws',
         label: t('profile.stats.dashboard.summary.draws'),
-        value: stats.overall.draws,
+        value: selectedGameStats.draws,
       },
       {
         id: 'currentStreak',
@@ -481,7 +481,7 @@ export default function PlayerStatsDashboard({ userId }: PlayerStatsDashboardPro
         value: stats.overall.longestWinStreak,
       },
     ]
-  }, [stats, t])
+  }, [selectedGameStats, stats, t])
 
   if (loading && !stats) {
     return (
@@ -624,7 +624,7 @@ export default function PlayerStatsDashboard({ userId }: PlayerStatsDashboardPro
                         {t(selectedAnalyticsProfile.titleKey)}
                       </h4>
                       <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-3 2xl:grid-cols-5">
-                        {overallInsightItems.map((item) => (
+                        {gameInsightItems.map((item) => (
                           <div
                             key={item.id}
                             className={`${tileClassName} flex min-h-[112px] flex-col justify-center px-3 py-4 text-center sm:px-4`}

--- a/components/PlayerStatsDashboard.tsx
+++ b/components/PlayerStatsDashboard.tsx
@@ -395,6 +395,12 @@ export default function PlayerStatsDashboard({ userId }: PlayerStatsDashboardPro
         )}`,
         accentClassName: 'bg-bd-sun text-[#9b6b00]',
       },
+      {
+        id: 'bestStreak',
+        label: t('profile.stats.dashboard.summary.bestStreak'),
+        value: String(stats.overall.longestWinStreak),
+        accentClassName: 'bg-bd-mint text-bd-mint-deep',
+      },
     ]
   }, [stats, t])
 
@@ -452,7 +458,7 @@ export default function PlayerStatsDashboard({ userId }: PlayerStatsDashboardPro
     : null
 
   const gameInsightItems = useMemo(() => {
-    if (!selectedGameStats || !stats) return []
+    if (!selectedGameStats) return []
 
     return [
       {
@@ -470,18 +476,8 @@ export default function PlayerStatsDashboard({ userId }: PlayerStatsDashboardPro
         label: t('profile.stats.dashboard.summary.draws'),
         value: selectedGameStats.draws,
       },
-      {
-        id: 'currentStreak',
-        label: t('profile.stats.dashboard.summary.currentStreak'),
-        value: stats.overall.currentWinStreak,
-      },
-      {
-        id: 'bestStreak',
-        label: t('profile.stats.dashboard.summary.bestStreak'),
-        value: stats.overall.longestWinStreak,
-      },
     ]
-  }, [selectedGameStats, stats, t])
+  }, [selectedGameStats, t])
 
   if (loading && !stats) {
     return (

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -234,6 +234,67 @@ export async function sendWelcomeEmail(email: string, name: string) {
   }
 }
 
+export async function sendGameInviteEmail(
+  recipientEmail: string,
+  recipientName: string,
+  senderName: string,
+  lobbyName: string,
+  gameType: string,
+  inviteUrl: string
+) {
+  if (!resend) {
+    logger.warn('RESEND_API_KEY not configured. Skipping email send.')
+    return { success: false, error: 'Email service not configured' }
+  }
+
+  const displayGameType = gameType.replace(/_/g, ' ')
+
+  try {
+    const { error } = await resend.emails.send({
+      from: FROM_EMAIL,
+      to: recipientEmail,
+      subject: `${senderName} invited you to play ${displayGameType} on Boardly`,
+      html: `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          </head>
+          <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="background: #1F1B16; padding: 30px; border-radius: 10px 10px 0 0; text-align: center;">
+              <h1 style="color: #FFC44D; margin: 0; font-size: 28px; font-weight: 900;">boardly</h1>
+            </div>
+            <div style="background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px;">
+              <h2 style="color: #333; margin-top: 0;">Hey ${recipientName}! 🎲</h2>
+              <p><strong>${senderName}</strong> has invited you to join a game of <strong>${displayGameType}</strong>.</p>
+              ${lobbyName ? `<p style="color: #666;">Lobby: <strong>${lobbyName}</strong></p>` : ''}
+              <div style="text-align: center; margin: 30px 0;">
+                <a href="${inviteUrl}" target="_blank" rel="noopener noreferrer" style="background: #FF6B5B; color: white; padding: 14px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
+                  Join Game
+                </a>
+              </div>
+              <p style="color: #666; font-size: 14px;">If the button doesn't work, copy and paste this link into your browser:</p>
+              <p style="color: #FF6B5B; word-break: break-all; font-size: 12px;">${inviteUrl}</p>
+              <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
+              <p style="color: #999; font-size: 12px; margin: 0;">
+                You received this email because ${senderName} invited you to a game. To stop receiving game invite emails, update your notification preferences in your Boardly profile.
+              </p>
+            </div>
+          </body>
+        </html>
+      `,
+    })
+    if (error) {
+      throw new Error((error as { message?: string }).message || 'Unknown error')
+    }
+    return { success: true }
+  } catch (error) {
+    logger.error('Failed to send game invite email:', error as Error)
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}
+
 export async function sendAccountDeletionEmail(email: string, token: string, username: string) {
   if (!resend) {
     logger.warn('RESEND_API_KEY not configured. Skipping email send.')

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -6,6 +6,15 @@ const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KE
 
 const FROM_EMAIL = process.env.EMAIL_FROM || 'Boardly <onboarding@resend.dev>'
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
 export async function sendVerificationEmail(email: string, token: string, username?: string) {
   if (!resend) {
     logger.warn('RESEND_API_KEY not configured. Skipping email send.')
@@ -247,13 +256,16 @@ export async function sendGameInviteEmail(
     return { success: false, error: 'Email service not configured' }
   }
 
-  const displayGameType = gameType.replace(/_/g, ' ')
+  const displayGameType = escapeHtml(gameType.replace(/_/g, ' '))
+  const safeRecipient = escapeHtml(recipientName)
+  const safeSender = escapeHtml(senderName)
+  const safeLobby = lobbyName ? escapeHtml(lobbyName) : ''
 
   try {
     const { error } = await resend.emails.send({
       from: FROM_EMAIL,
       to: recipientEmail,
-      subject: `${senderName} invited you to play ${displayGameType} on Boardly`,
+      subject: `${senderName} invited you to play ${gameType.replace(/_/g, ' ')} on Boardly`,
       html: `
         <!DOCTYPE html>
         <html>
@@ -266,9 +278,9 @@ export async function sendGameInviteEmail(
               <h1 style="color: #FFC44D; margin: 0; font-size: 28px; font-weight: 900;">boardly</h1>
             </div>
             <div style="background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px;">
-              <h2 style="color: #333; margin-top: 0;">Hey ${recipientName}! 🎲</h2>
-              <p><strong>${senderName}</strong> has invited you to join a game of <strong>${displayGameType}</strong>.</p>
-              ${lobbyName ? `<p style="color: #666;">Lobby: <strong>${lobbyName}</strong></p>` : ''}
+              <h2 style="color: #333; margin-top: 0;">Hey ${safeRecipient}! 🎲</h2>
+              <p><strong>${safeSender}</strong> has invited you to join a game of <strong>${displayGameType}</strong>.</p>
+              ${safeLobby ? `<p style="color: #666;">Lobby: <strong>${safeLobby}</strong></p>` : ''}
               <div style="text-align: center; margin: 30px 0;">
                 <a href="${inviteUrl}" target="_blank" rel="noopener noreferrer" style="background: #FF6B5B; color: white; padding: 14px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
                   Join Game
@@ -278,7 +290,7 @@ export async function sendGameInviteEmail(
               <p style="color: #FF6B5B; word-break: break-all; font-size: 12px;">${inviteUrl}</p>
               <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
               <p style="color: #999; font-size: 12px; margin: 0;">
-                You received this email because ${senderName} invited you to a game. To stop receiving game invite emails, update your notification preferences in your Boardly profile.
+                You received this email because ${safeSender} invited you to a game. To stop receiving game invite emails, update your notification preferences in your Boardly profile.
               </p>
             </div>
           </body>

--- a/lib/games/spy-game.ts
+++ b/lib/games/spy-game.ts
@@ -427,17 +427,21 @@ export class SpyGame extends GameEngine {
 
     // Game ends after all rounds are completed
     if (data.currentRound >= data.totalRounds && data.phase === SpyGamePhase.RESULTS) {
-      // Find player with highest score
-      let maxScore = 0
+      let maxScore = -Infinity
       let winnerId = ''
+      let tie = false
 
       for (const [playerId, score] of Object.entries(data.scores)) {
         if (score > maxScore) {
           maxScore = score
           winnerId = playerId
+          tie = false
+        } else if (score === maxScore) {
+          tie = true
         }
       }
 
+      if (tie) return null
       return this.state.players.find((p) => p.id === winnerId) || null
     }
 

--- a/lib/stats-calculator.ts
+++ b/lib/stats-calculator.ts
@@ -1,4 +1,6 @@
-export type GameOutcome = 'win' | 'loss' | 'draw'
+export type { GameOutcome } from '@/lib/stats-core'
+import type { GameOutcome } from '@/lib/stats-core'
+import { roundToOneDecimal, computeWinRate, resolveOutcome } from '@/lib/stats-core'
 
 export interface StatsPlayerInput {
   userId: string
@@ -67,30 +69,14 @@ function toDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value)
 }
 
-function roundToOneDecimal(value: number): number {
-  return Math.round(value * 10) / 10
-}
-
 function toIsoDay(value: Date): string {
   return value.toISOString().slice(0, 10)
 }
 
-function normalizeOutcome(game: StatsGameInput, player: StatsPlayerInput | undefined): GameOutcome | null {
-  if (!player || game.status !== 'finished') {
-    return null
-  }
-
+function normalizeOutcome(game: StatsGameInput, player: StatsPlayerInput | undefined): ReturnType<typeof resolveOutcome> {
+  if (!player) return null
   const winnerCount = game.players.filter((entry) => entry.isWinner).length
-  if (winnerCount === 0) {
-    return 'draw'
-  }
-  if (player.isWinner && winnerCount > 1) {
-    return 'draw'
-  }
-  if (player.isWinner) {
-    return 'win'
-  }
-  return 'loss'
+  return resolveOutcome(game.status, player.isWinner, winnerCount)
 }
 
 export function calculateUserStats(
@@ -196,9 +182,7 @@ export function calculateUserStats(
 
   const byGame = Array.from(byGameMap.entries())
     .map(([gameType, entry]) => {
-      const winRate = (entry.wins + entry.losses) > 0
-        ? roundToOneDecimal((entry.wins / (entry.wins + entry.losses)) * 100)
-        : 0
+      const winRate = computeWinRate(entry.wins, entry.losses)
 
       return {
         gameType,
@@ -254,7 +238,7 @@ export function calculateUserStats(
     wins,
     losses,
     draws,
-    winRate: (wins + losses) > 0 ? roundToOneDecimal((wins / (wins + losses)) * 100) : 0,
+    winRate: computeWinRate(wins, losses),
     avgGameDurationMinutes: durationCount > 0 ? roundToOneDecimal(durationSumMs / durationCount / 60000) : 0,
     favoriteGame,
     currentWinStreak,

--- a/lib/stats-calculator.ts
+++ b/lib/stats-calculator.ts
@@ -164,21 +164,23 @@ export function calculateUserStats(
         lastPlayedAt: null as Date | null,
       }
 
-    byGameEntry.gamesPlayed += 1
-    if (outcome === 'win') byGameEntry.wins += 1
-    if (outcome === 'loss') byGameEntry.losses += 1
-    if (outcome === 'draw') byGameEntry.draws += 1
+    if (outcome !== null) {
+      byGameEntry.gamesPlayed += 1
+      if (outcome === 'win') byGameEntry.wins += 1
+      if (outcome === 'loss') byGameEntry.losses += 1
+      if (outcome === 'draw') byGameEntry.draws += 1
 
-    const normalizedScore = player.finalScore ?? player.score
-    if (Number.isFinite(normalizedScore)) {
-      byGameEntry.scoreSum += normalizedScore
-      byGameEntry.scoreCount += 1
-      byGameEntry.bestScore =
-        byGameEntry.bestScore === null ? normalizedScore : Math.max(byGameEntry.bestScore, normalizedScore)
-    }
+      const normalizedScore = player.finalScore ?? player.score
+      if (Number.isFinite(normalizedScore)) {
+        byGameEntry.scoreSum += normalizedScore
+        byGameEntry.scoreCount += 1
+        byGameEntry.bestScore =
+          byGameEntry.bestScore === null ? normalizedScore : Math.max(byGameEntry.bestScore, normalizedScore)
+      }
 
-    if (!byGameEntry.lastPlayedAt || updatedAt > byGameEntry.lastPlayedAt) {
-      byGameEntry.lastPlayedAt = updatedAt
+      if (!byGameEntry.lastPlayedAt || updatedAt > byGameEntry.lastPlayedAt) {
+        byGameEntry.lastPlayedAt = updatedAt
+      }
     }
 
     byGameMap.set(game.gameType, byGameEntry)

--- a/lib/stats-calculator.ts
+++ b/lib/stats-calculator.ts
@@ -196,8 +196,9 @@ export function calculateUserStats(
 
   const byGame = Array.from(byGameMap.entries())
     .map(([gameType, entry]) => {
-      const denominator = entry.wins + entry.losses + entry.draws
-      const winRate = denominator > 0 ? roundToOneDecimal((entry.wins / denominator) * 100) : 0
+      const winRate = (entry.wins + entry.losses) > 0
+        ? roundToOneDecimal((entry.wins / (entry.wins + entry.losses)) * 100)
+        : 0
 
       return {
         gameType,
@@ -248,13 +249,12 @@ export function calculateUserStats(
     break
   }
 
-  const outcomeDenominator = wins + losses + draws
   const overall: UserOverallStats = {
     totalGames: completedGames.length,
     wins,
     losses,
     draws,
-    winRate: outcomeDenominator > 0 ? roundToOneDecimal((wins / outcomeDenominator) * 100) : 0,
+    winRate: (wins + losses) > 0 ? roundToOneDecimal((wins / (wins + losses)) * 100) : 0,
     avgGameDurationMinutes: durationCount > 0 ? roundToOneDecimal(durationSumMs / durationCount / 60000) : 0,
     favoriteGame,
     currentWinStreak,

--- a/lib/stats-core.ts
+++ b/lib/stats-core.ts
@@ -1,0 +1,42 @@
+// Canonical stats primitives shared by stats-calculator.ts, user-stats-dashboard.ts,
+// and leaderboard/route.ts. Any change to outcome logic or win-rate formula must be
+// reflected in the SQL CASE expressions in those files as well.
+
+export type GameOutcome = 'win' | 'loss' | 'draw'
+
+export function roundToOneDecimal(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+/**
+ * Win rate = wins / (wins + losses). Draws are excluded from the denominator —
+ * they don't count as decisive results.
+ */
+export function computeWinRate(wins: number, losses: number): number {
+  const decisive = wins + losses
+  return decisive > 0 ? roundToOneDecimal((wins / decisive) * 100) : 0
+}
+
+/**
+ * Derive a player's outcome from DB fields.
+ * Mirrors the SQL CASE in user-stats-dashboard.ts buildUserGamesCte:
+ *
+ *   CASE
+ *     WHEN g.status <> 'finished'                          THEN NULL
+ *     WHEN winnerCount = 0                                 THEN 'draw'
+ *     WHEN p.isWinner = true AND winnerCount > 1           THEN 'draw'
+ *     WHEN p.isWinner = true                               THEN 'win'
+ *     ELSE                                                      'loss'
+ *   END
+ */
+export function resolveOutcome(
+  status: string,
+  isWinner: boolean,
+  winnerCount: number
+): GameOutcome | null {
+  if (status !== 'finished') return null
+  if (winnerCount === 0) return 'draw'
+  if (isWinner && winnerCount > 1) return 'draw'
+  if (isWinner) return 'win'
+  return 'loss'
+}

--- a/lib/user-stats-dashboard.ts
+++ b/lib/user-stats-dashboard.ts
@@ -193,16 +193,16 @@ export async function getUserStatsDashboard(
       ${userGamesCte}
       SELECT
         "gameType",
-        COUNT(*)::int AS "gamesPlayed",
+        COUNT(*) FILTER (WHERE outcome IS NOT NULL)::int AS "gamesPlayed",
         COUNT(*) FILTER (WHERE outcome = 'win')::int AS wins,
         COUNT(*) FILTER (WHERE outcome = 'loss')::int AS losses,
         COUNT(*) FILTER (WHERE outcome = 'draw')::int AS draws,
-        ROUND(AVG(COALESCE("finalScore", score))::numeric, 1)::double precision AS "avgScore",
-        MAX(COALESCE("finalScore", score))::int AS "bestScore",
-        MAX("updatedAt") AS "lastPlayed"
+        ROUND((AVG(COALESCE("finalScore", score)) FILTER (WHERE outcome IS NOT NULL))::numeric, 1)::double precision AS "avgScore",
+        (MAX(COALESCE("finalScore", score)) FILTER (WHERE outcome IS NOT NULL))::int AS "bestScore",
+        MAX("updatedAt") FILTER (WHERE outcome IS NOT NULL) AS "lastPlayed"
       FROM user_games
       GROUP BY "gameType"
-      ORDER BY COUNT(*) DESC, "gameType" ASC
+      ORDER BY COUNT(*) FILTER (WHERE outcome IS NOT NULL) DESC, "gameType" ASC
     `),
     client.$queryRaw<TrendRow[]>(Prisma.sql`
       ${userGamesCte}

--- a/lib/user-stats-dashboard.ts
+++ b/lib/user-stats-dashboard.ts
@@ -135,15 +135,13 @@ function normalizeByGameRows(rows: ByGameRow[]): UserByGameStats[] {
     const wins = toFiniteNumber(row.wins)
     const losses = toFiniteNumber(row.losses)
     const draws = toFiniteNumber(row.draws)
-    const denominator = wins + losses + draws
-
     return {
       gameType: row.gameType,
       gamesPlayed,
       wins,
       losses,
       draws,
-      winRate: denominator > 0 ? roundToOneDecimal((wins / denominator) * 100) : 0,
+      winRate: (wins + losses) > 0 ? roundToOneDecimal((wins / (wins + losses)) * 100) : 0,
       avgScore:
         row.avgScore === null || row.avgScore === undefined
           ? null
@@ -272,9 +270,6 @@ export async function getUserStatsDashboard(
   const byGame = normalizeByGameRows(byGameRows)
   const trends = normalizeTrendRows(trendRows)
   const streaks = streakRows[0] ?? { currentWinStreak: 0, longestWinStreak: 0 }
-  const outcomeDenominator =
-    normalizedOverall.wins + normalizedOverall.losses + normalizedOverall.draws
-
   return {
     overall: {
       totalGames: normalizedOverall.totalGames,
@@ -282,8 +277,8 @@ export async function getUserStatsDashboard(
       losses: normalizedOverall.losses,
       draws: normalizedOverall.draws,
       winRate:
-        outcomeDenominator > 0
-          ? roundToOneDecimal((normalizedOverall.wins / outcomeDenominator) * 100)
+        (normalizedOverall.wins + normalizedOverall.losses) > 0
+          ? roundToOneDecimal((normalizedOverall.wins / (normalizedOverall.wins + normalizedOverall.losses)) * 100)
           : 0,
       avgGameDurationMinutes: normalizedOverall.avgGameDurationMinutes,
       favoriteGame: byGame[0]?.gameType ?? null,

--- a/lib/user-stats-dashboard.ts
+++ b/lib/user-stats-dashboard.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@/prisma/client'
 import type { PrismaClient } from '@/prisma/client'
+import { roundToOneDecimal, computeWinRate } from '@/lib/stats-core'
 import type {
   UserByGameStats,
   UserStatsDashboard,
@@ -41,10 +42,6 @@ interface TrendRow {
 interface StreakRow {
   currentWinStreak: number
   longestWinStreak: number
-}
-
-function roundToOneDecimal(value: number): number {
-  return Math.round(value * 10) / 10
 }
 
 function toFiniteNumber(value: unknown, fallback = 0): number {
@@ -141,7 +138,7 @@ function normalizeByGameRows(rows: ByGameRow[]): UserByGameStats[] {
       wins,
       losses,
       draws,
-      winRate: (wins + losses) > 0 ? roundToOneDecimal((wins / (wins + losses)) * 100) : 0,
+      winRate: computeWinRate(wins, losses),
       avgScore:
         row.avgScore === null || row.avgScore === undefined
           ? null
@@ -276,10 +273,7 @@ export async function getUserStatsDashboard(
       wins: normalizedOverall.wins,
       losses: normalizedOverall.losses,
       draws: normalizedOverall.draws,
-      winRate:
-        (normalizedOverall.wins + normalizedOverall.losses) > 0
-          ? roundToOneDecimal((normalizedOverall.wins / (normalizedOverall.wins + normalizedOverall.losses)) * 100)
-          : 0,
+      winRate: computeWinRate(normalizedOverall.wins, normalizedOverall.losses),
       avgGameDurationMinutes: normalizedOverall.avgGameDurationMinutes,
       favoriteGame: byGame[0]?.gameType ?? null,
       currentWinStreak: toFiniteNumber(streaks.currentWinStreak),

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1643,6 +1643,7 @@ const en = {
     rank: 'Rank',
     gamesPlayed: 'Played',
     wins: 'Wins',
+    losses: 'Losses',
     winRate: 'Win %',
     gameFilter: 'Game filter',
     chooseGame: 'Choose game',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1218,6 +1218,7 @@ const en = {
           winRate: 'Win rate',
           avgDuration: 'Avg duration',
           minutesSuffix: 'm',
+          secondsSuffix: 's',
           favoriteGame: 'Favorite game',
           wld: 'Wins / Losses / Draws',
           wins: 'Wins',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -1632,6 +1632,7 @@ const no = {
     rank: 'Rang',
     gamesPlayed: 'Spilt',
     wins: 'Seire',
+    losses: 'Tap',
     winRate: 'Seier %',
     gameFilter: 'Spillfilter',
     chooseGame: 'Velg spill',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -1218,6 +1218,7 @@ const no = {
           winRate: 'Vinnrate',
           avgDuration: 'Snittvarighet',
           minutesSuffix: 'm',
+          secondsSuffix: 's',
           favoriteGame: 'Favorittspill',
           wld: 'Seire / Tap / Uavgjort',
           wins: 'Seire',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -1632,6 +1632,7 @@ const ru = {
     rank: 'Ранг',
     gamesPlayed: 'Игры',
     wins: 'Победы',
+    losses: 'Поражения',
     winRate: 'Победы %',
     gameFilter: 'Фильтр игр',
     chooseGame: 'Выбрать игру',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -1218,6 +1218,7 @@ const ru = {
           winRate: 'Процент побед',
           avgDuration: 'Средняя длительность',
           minutesSuffix: 'м',
+          secondsSuffix: 'с',
           favoriteGame: 'Любимая игра',
           wld: 'Победы / Поражения / Ничьи',
           wins: 'Победы',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -1645,6 +1645,7 @@ const uk: Translation = {
     rank: 'Ранг',
     gamesPlayed: 'Ігри',
     wins: 'Перемоги',
+    losses: 'Поразки',
     winRate: 'Перемоги %',
     gameFilter: 'Фільтр ігор',
     chooseGame: 'Вибрати гру',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -1220,6 +1220,7 @@ const uk: Translation = {
           winRate: 'Відсоток перемог',
           avgDuration: 'Сер. тривалість',
           minutesSuffix: 'хв',
+          secondsSuffix: 'с',
           favoriteGame: 'Улюблена гра',
           wld: 'Перемоги / Поразки / Нічиї',
           wins: 'Перемоги',


### PR DESCRIPTION
## Summary

- **Fix game invite emails** — emails were never actually sent; stub code replaced with real `sendGameInviteEmail()` call
- **Fix profile gamesPlayed** — now counts only finished games (via `completedGamesCount`), not all player rows
- **Fix spy game tie detection** — `checkWinCondition` no longer picks an arbitrary winner when multiple players share the top score; also handles negative scores (`maxScore` init from `0` → `-Infinity`)
- **Fix stats dashboard** — per-game section was showing overall W/L/D instead of the selected game's stats; streaks removed from per-game view
- **Fix gamesPlayed in stats** — abandoned/cancelled games no longer counted toward W/L/D or gamesPlayed in both the JS calculator and SQL dashboard
- **Win rate formula** — changed to `wins / (wins + losses)`, excluding draws from the denominator, across stats calculator, SQL dashboard, and leaderboard
- **Avg duration display** — changed from minutes to seconds in the stats dashboard
- **Leaderboard: add Losses column** — makes the win rate interpretable when most games are draws
- **Leaderboard: responsive fix** — full table now appears at `md` (768px) instead of `sm` (640px) to prevent header wrapping on tablets; mobile stats use a 2×2 grid
- **Refactor: `lib/stats-core.ts`** — canonical `roundToOneDecimal`, `computeWinRate`, `resolveOutcome` shared by `stats-calculator.ts`, `user-stats-dashboard.ts`, and referenced in leaderboard SQL comments

## Test plan

- [ ] 906/906 tests passing (`pnpm test`)
- [ ] CI green on develop
- [ ] Leaderboard shows Played / Wins / Losses / Win % columns
- [ ] Leaderboard table header does not wrap on tablet (~768px)
- [ ] Stats dashboard per-game section shows correct W/L/D for the selected game
- [ ] Profile gamesPlayed matches finished games only
- [ ] Spy game ends correctly when there's a clear score winner after final round