### PR TITLE
Post-merge fixes: i18n, email security, leaderboard responsive & draw logic

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -137,7 +137,9 @@ function LeaderboardPageContent() {
                   style={{ fontFamily: 'var(--bd-font-display)' }}
                 >
                   {t('leaderboard.title', 'Leaderboard')}
-                  <span className="block text-bd-coral">{selectedFilter.label}</span>
+                  <span className="block text-bd-coral">
+                    {selectedFilter.value ? selectedFilter.label : t('leaderboard.allGames')}
+                  </span>
                 </h1>
                 <p className="mt-4 max-w-2xl text-base leading-7 text-bd-ink-soft sm:text-lg">
                   {t('leaderboard.subtitle', 'Top players ranked by win rate (min 10 games)')}
@@ -201,7 +203,9 @@ function LeaderboardPageContent() {
                       </span>
                       <span className="min-w-0">
                         <span className="bd-kicker block text-[10px]">{t('leaderboard.gameFilter')}</span>
-                        <span className="block truncate text-sm font-bold text-bd-ink">{selectedFilter.label}</span>
+                        <span className="block truncate text-sm font-bold text-bd-ink">
+                          {selectedFilter.value ? selectedFilter.label : t('leaderboard.allGames')}
+                        </span>
                       </span>
                     </span>
                     <span
@@ -227,7 +231,7 @@ function LeaderboardPageContent() {
                         {GAME_FILTERS.map((f) => {
                           const meta = f.value ? getGameMetadata(f.value) : null
                           const icon = f.value ? getCompactGameIcon(f.value, meta?.icon ?? f.icon) : f.displayIcon
-                          const label = meta?.name ?? f.label
+                          const label = f.value ? (meta?.name ?? f.label) : t('leaderboard.allGames')
                           const selected = selectedFilter.value === f.value
                           return (
                             <button

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -138,7 +138,7 @@ function LeaderboardPageContent() {
                 >
                   {t('leaderboard.title', 'Leaderboard')}
                   <span className="block text-bd-coral">
-                    {selectedFilter.value ? selectedFilter.label : t('leaderboard.allGames')}
+                    {selectedFilter.value ? selectedFilter.label : t('leaderboard.allGames', 'All Games')}
                   </span>
                 </h1>
                 <p className="mt-4 max-w-2xl text-base leading-7 text-bd-ink-soft sm:text-lg">
@@ -204,7 +204,7 @@ function LeaderboardPageContent() {
                       <span className="min-w-0">
                         <span className="bd-kicker block text-[10px]">{t('leaderboard.gameFilter')}</span>
                         <span className="block truncate text-sm font-bold text-bd-ink">
-                          {selectedFilter.value ? selectedFilter.label : t('leaderboard.allGames')}
+                          {selectedFilter.value ? selectedFilter.label : t('leaderboard.allGames', 'All Games')}
                         </span>
                       </span>
                     </span>
@@ -231,7 +231,7 @@ function LeaderboardPageContent() {
                         {GAME_FILTERS.map((f) => {
                           const meta = f.value ? getGameMetadata(f.value) : null
                           const icon = f.value ? getCompactGameIcon(f.value, meta?.icon ?? f.icon) : f.displayIcon
-                          const label = f.value ? (meta?.name ?? f.label) : t('leaderboard.allGames')
+                          const label = f.value ? (meta?.name ?? f.label) : t('leaderboard.allGames', 'All Games')
                           const selected = selectedFilter.value === f.value
                           return (
                             <button

--- a/app/leaderboard/use-leaderboard.ts
+++ b/app/leaderboard/use-leaderboard.ts
@@ -22,7 +22,7 @@ const COMPACT_GAME_ICONS: Record<string, string> = {
 export const getCompactGameIcon = (type: string, icon: string) => COMPACT_GAME_ICONS[type] ?? icon
 
 export const GAME_FILTERS = [
-  { value: '', label: 'All Games', icon: '🎮', displayIcon: '🎮' },
+  { value: '', label: '', icon: '🎮', displayIcon: '🎮' },
   ...getAvailableGameTypes().map((type) => {
     const meta = getGameMetadata(type)
     const icon = meta?.icon ?? '🎮'

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1641,6 +1641,7 @@ const en = {
     player: 'Player',
     players: 'Players',
     rank: 'Rank',
+    allGames: 'All Games',
     gamesPlayed: 'Played',
     wins: 'Wins',
     losses: 'Losses',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -1630,6 +1630,7 @@ const no = {
     player: 'Spiller',
     players: 'Spillere',
     rank: 'Rang',
+    allGames: 'Alle spill',
     gamesPlayed: 'Spilt',
     wins: 'Seire',
     losses: 'Tap',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -1630,6 +1630,7 @@ const ru = {
     player: 'Игрок',
     players: 'Игроки',
     rank: 'Ранг',
+    allGames: 'Все игры',
     gamesPlayed: 'Игры',
     wins: 'Победы',
     losses: 'Поражения',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -1643,6 +1643,7 @@ const uk: Translation = {
     player: 'Гравець',
     players: 'Гравці',
     rank: 'Ранг',
+    allGames: 'Всі ігри',
     gamesPlayed: 'Ігри',
     wins: 'Перемоги',
     losses: 'Поразки',


### PR DESCRIPTION
## Summary

- **i18n: translate "All Games" filter label** — leaderboard filter was showing hardcoded English; added `leaderboard.allGames` key to all 4 locales (en/uk/ru/no)
- **Security: HTML-escape email invite fields** — `senderName`, `recipientName`, `lobbyName`, `displayGameType` are now escaped via `escapeHtml()` before injection into the HTML template
- **Leaderboard draw logic fix** — `isDraw` now covers multi-winner draws (`winner_count > 1`) in addition to no-winner games (`winner_count = 0`), matching `resolveOutcome()` in `lib/stats-core.ts`
- **Leaderboard responsive fix** — full table layout moved from `sm` (640px) to `md` (768px) breakpoint to prevent header wrapping on tablets; mobile stats use a 2×2 grid
- **Test fixes** — updated 4 tests to reflect the losses column, secondsSuffix, gamesPlayed-only-finished, and spy tie detection changes

## Test plan

- [ ] 906/906 tests passing
- [ ] CI green on develop
- [ ] "All Games" label translates correctly on leaderboard in all languages
- [ ] Leaderboard table header does not wrap on tablet

🤖 Generated with [Claude Code](https://claude.com/claude-code)