### PR TITLE
fix: mobile UI, auth gate for nav, i18n strings, auth layout

### DIFF
--- a/app/auth/login/LoginForm.tsx
+++ b/app/auth/login/LoginForm.tsx
@@ -314,7 +314,7 @@ export default function LoginForm() {
       minHeight: '100svh', overflowX: 'hidden', overflowY: 'auto',
       background: 'radial-gradient(circle at 12% 8%, rgba(255,196,77,0.18), transparent 35%), radial-gradient(circle at 88% 14%, rgba(155,140,255,0.16), transparent 40%), radial-gradient(circle at 50% 100%, rgba(79,201,166,0.14), transparent 50%), var(--bd-bg)',
     }}>
-      <div style={{ maxWidth: 1280, margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40, alignItems: 'center', padding: '40px 32px', minHeight: '100svh', boxSizing: 'border-box' }}>
+      <div className="grid grid-cols-1 lg:grid-cols-2" style={{ maxWidth: 1280, margin: '0 auto', gap: 40, alignItems: 'center', padding: 'clamp(24px, 5vw, 40px) clamp(20px, 4vw, 32px)', minHeight: '100svh', boxSizing: 'border-box' }}>
 
         {/* LEFT: form */}
         <div style={{ maxWidth: 460, justifySelf: 'center', width: '100%' }}>

--- a/app/auth/register/RegisterForm.tsx
+++ b/app/auth/register/RegisterForm.tsx
@@ -243,7 +243,7 @@ export default function RegisterForm() {
       minHeight: '100svh', overflowX: 'hidden', overflowY: 'auto',
       background: 'radial-gradient(circle at 12% 8%, rgba(255,196,77,0.18), transparent 35%), radial-gradient(circle at 88% 14%, rgba(155,140,255,0.16), transparent 40%), radial-gradient(circle at 50% 100%, rgba(79,201,166,0.14), transparent 50%), var(--bd-bg)',
     }}>
-      <div style={{ maxWidth: 1280, margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40, alignItems: 'center', padding: '40px 32px', minHeight: '100svh', boxSizing: 'border-box' }}>
+      <div className="grid grid-cols-1 lg:grid-cols-2" style={{ maxWidth: 1280, margin: '0 auto', gap: 40, alignItems: 'center', padding: 'clamp(24px, 5vw, 40px) clamp(20px, 4vw, 32px)', minHeight: '100svh', boxSizing: 'border-box' }}>
 
         {/* LEFT: form */}
         <div style={{ maxWidth: 460, justifySelf: 'center', width: '100%' }}>

--- a/app/friends/page.tsx
+++ b/app/friends/page.tsx
@@ -5,10 +5,12 @@ import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import Friends from '@/components/Friends'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import { useTranslation } from '@/lib/i18n-helpers'
 
 function FriendsPageContent() {
   const { status } = useSession()
   const router = useRouter()
+  const { t } = useTranslation()
 
   if (status === 'loading') {
     return (
@@ -30,13 +32,13 @@ function FriendsPageContent() {
           {/* Header */}
           <div className="mb-8 flex flex-wrap items-end justify-between gap-5">
             <div>
-              <span className="bd-kicker">Social</span>
+              <span className="bd-kicker">{t('profile.friends.pageKicker')}</span>
               <h1
                 className="mt-3 text-[clamp(2.5rem,7vw,4rem)] font-extrabold leading-[0.95] text-bd-ink"
                 style={{ fontFamily: 'var(--bd-font-display)' }}
               >
-                Friends{' '}
-                <span style={{ color: 'var(--bd-coral)' }}>and crew</span>
+                {t('profile.friends.title')}{' '}
+                <span style={{ color: 'var(--bd-coral)' }}>{t('profile.friends.pageSubtitle')}</span>
               </h1>
             </div>
           </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1235,28 +1235,28 @@ export default function ProfilePage() {
   const achievementItems = [
     {
       id: 'first-game',
-      label: 'First finish',
+      label: t('profile.achievements.firstFinish'),
       mark: '1',
       className: 'bg-bd-coral text-white',
       earned: completedGamesCount > 0,
     },
     {
       id: 'social',
-      label: 'First friend',
+      label: t('profile.achievements.firstFriend'),
       mark: String(Math.min(profileSummary?.friendsCount ?? 0, 9)),
       className: 'bg-bd-mint text-bd-ink',
       earned: (profileSummary?.friendsCount ?? 0) > 0,
     },
     {
       id: 'first-win',
-      label: 'First win',
+      label: t('profile.achievements.firstWin'),
       mark: String(Math.min(winsCount, 9)),
       className: 'bg-bd-lav text-white',
       earned: winsCount > 0,
     },
     {
       id: 'verified',
-      label: 'Verified',
+      label: t('profile.achievements.verified'),
       mark: 'V',
       className: 'bg-bd-sun text-bd-ink',
       earned: effectiveEmailVerified,
@@ -1545,10 +1545,10 @@ export default function ProfilePage() {
 
                         <div className="flex flex-wrap justify-center gap-2 pt-2 sm:justify-start">
                           <span className="inline-flex items-center rounded-full bg-bd-mint/20 px-3 py-1.5 text-xs font-bold text-bd-mint-deep">
-                            {profileSummary?.gamesPlayed ?? 0} games
+                            {t('profile.chips.games', { count: profileSummary?.gamesPlayed ?? 0 })}
                           </span>
                           <span className="inline-flex items-center rounded-full bg-bd-sun/25 px-3 py-1.5 text-xs font-bold text-[#9b6b00]">
-                            {profileSummary?.friendsCount ?? 0} friends
+                            {t('profile.chips.friends', { count: profileSummary?.friendsCount ?? 0 })}
                           </span>
                           <span className="inline-flex items-center rounded-full bg-bd-coral/15 px-3 py-1.5 text-xs font-bold text-bd-coral-deep">
                             {effectiveEmailVerified ? t('profile.verified') : t('profile.verificationBanner.title')}
@@ -1618,7 +1618,7 @@ export default function ProfilePage() {
                     <div className="rounded-3xl border-[1.5px] border-bd-line bg-white p-5 shadow-[0_4px_14px_rgba(31,27,22,0.07)] dark:border-slate-700 dark:bg-slate-800">
                       <div className="flex items-center justify-between gap-3">
                         <h2 className="font-display text-2xl font-bold text-bd-ink dark:text-white">
-                          Achievements
+                          {t('profile.achievements.title')}
                         </h2>
                         <span className="rounded-full bg-bd-bg2 px-3 py-1 text-xs font-bold text-bd-ink-soft dark:bg-slate-700 dark:text-slate-200">
                           {achievementItems.filter((item) => item.earned).length} / {achievementItems.length}

--- a/components/AuthGateModal.tsx
+++ b/components/AuthGateModal.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useGuest } from '@/contexts/GuestContext'
+import { buildAuthUrl } from '@/lib/auth-redirect'
+import { useTranslation } from '@/lib/i18n-helpers'
+
+interface AuthGateModalProps {
+  dest: string
+  onClose: () => void
+}
+
+export function AuthGateModal({ dest, onClose }: AuthGateModalProps) {
+  const router = useRouter()
+  const { t } = useTranslation()
+  const { setGuestMode } = useGuest()
+  const [name, setName] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canSubmit = name.trim().length >= 2
+
+  async function handleGuestPlay() {
+    if (!canSubmit || loading) return
+    setLoading(true)
+    setError(null)
+    try {
+      await setGuestMode(name.trim())
+      onClose()
+      router.push(dest)
+    } catch {
+      setError(t('guest.startFailed'))
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4"
+      style={{ background: 'rgba(31,27,22,0.55)', backdropFilter: 'blur(4px)' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div
+        className="w-full max-w-sm"
+        style={{
+          background: 'var(--bd-bg)',
+          border: '2px solid var(--bd-ink)',
+          borderRadius: 24,
+          boxShadow: '6px 6px 0 var(--bd-ink)',
+          padding: '28px 24px',
+        }}
+      >
+        {/* Header */}
+        <div style={{ textAlign: 'center', marginBottom: 20 }}>
+          <div style={{
+            width: 56, height: 56, margin: '0 auto 14px',
+            borderRadius: 16, background: 'var(--bd-sun)',
+            border: '2px solid var(--bd-ink)', boxShadow: '3px 3px 0 var(--bd-ink)',
+            display: 'grid', placeItems: 'center', fontSize: 28,
+          }}>🎮</div>
+          <h2 style={{
+            fontFamily: 'var(--bd-font-display)', fontWeight: 800, fontSize: 22,
+            color: 'var(--bd-ink)', letterSpacing: '-0.02em', margin: '0 0 8px',
+          }}>
+            {t('header.authGateTitle')}
+          </h2>
+          <p style={{ fontSize: 14, color: 'var(--bd-ink-soft)', lineHeight: 1.5, margin: 0 }}>
+            {t('header.authGateDesc')}
+          </p>
+        </div>
+
+        {/* Guest name input */}
+        <div style={{ marginBottom: 12 }}>
+          <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: 'var(--bd-ink)', marginBottom: 7 }}>
+            {t('guest.enterName')}
+          </label>
+          <input
+            className="bd-input"
+            type="text"
+            placeholder={t('guest.namePlaceholder')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleGuestPlay() }}
+            disabled={loading}
+            maxLength={20}
+            autoFocus
+          />
+        </div>
+
+        {error && (
+          <div style={{
+            marginBottom: 12, padding: '10px 14px', borderRadius: 12,
+            background: 'rgba(255,80,60,0.08)', border: '1.5px solid rgba(255,80,60,0.25)',
+            fontSize: 13, color: 'var(--bd-coral-deep)', fontWeight: 500,
+          }}>
+            {error}
+          </div>
+        )}
+
+        <button
+          onClick={handleGuestPlay}
+          disabled={!canSubmit || loading}
+          className="bd-btn bd-btn-primary w-full justify-center"
+          style={{ marginBottom: 18, width: '100%' }}
+        >
+          {loading ? '...' : t('guest.playAsGuest')}
+        </button>
+
+        {/* Divider */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+          <div style={{ flex: 1, height: 1, background: 'var(--bd-line)' }} />
+          <span style={{ fontSize: 13, color: 'var(--bd-ink-muted)' }}>or</span>
+          <div style={{ flex: 1, height: 1, background: 'var(--bd-line)' }} />
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          <button
+            onClick={() => { onClose(); router.push(buildAuthUrl('login', dest)) }}
+            className="bd-btn bd-btn-soft w-full justify-center"
+          >
+            {t('header.login')}
+          </button>
+          <button
+            onClick={() => { onClose(); router.push(buildAuthUrl('register', dest)) }}
+            className="bd-btn bd-btn-ghost w-full justify-center"
+          >
+            {t('header.signUp')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import { useGuest } from '@/contexts/GuestContext'
 import { HeaderNavigation } from './Header/HeaderNavigation'
 import { HeaderActions } from './Header/HeaderActions'
+import { AuthGateModal } from './AuthGateModal'
 import { useProfileNavigationTracking } from '@/lib/profile-navigation'
 
 const MobileMenu = dynamic(
@@ -32,6 +33,7 @@ export default function Header() {
   const router = useRouter()
   const pathname = usePathname()
   const [isGuestUiReady, setIsGuestUiReady] = useState(false)
+  const [authGateDest, setAuthGateDest] = useState<string | null>(null)
   useProfileNavigationTracking(pathname)
 
   useEffect(() => {
@@ -52,6 +54,7 @@ export default function Header() {
   const isGuestSession = isAuthUiReady && isGuest && !isAuthenticated
 
   return (
+    <>
     <header
       className="site-header sticky top-0 z-50"
       style={{
@@ -96,6 +99,7 @@ export default function Header() {
               isAuthenticated={effectiveIsAuthenticated}
               isAdmin={effectiveIsAdmin}
               isGuest={isGuestSession}
+              onUnauthClick={setAuthGateDest}
             />
           </div>
 
@@ -138,10 +142,19 @@ export default function Header() {
               userName={session?.user?.name}
               userEmail={session?.user?.email}
               userImage={session?.user?.image}
+              onUnauthClick={setAuthGateDest}
             />
           </div>
         </div>
       </nav>
     </header>
+
+    {authGateDest && (
+      <AuthGateModal
+        dest={authGateDest}
+        onClose={() => setAuthGateDest(null)}
+      />
+    )}
+  </>
   )
 }

--- a/components/Header/HeaderNavigation.tsx
+++ b/components/Header/HeaderNavigation.tsx
@@ -7,9 +7,10 @@ interface HeaderNavigationProps {
   isAuthenticated: boolean
   isAdmin?: boolean
   isGuest?: boolean
+  onUnauthClick?: (dest: string) => void
 }
 
-export function HeaderNavigation({ isAuthenticated, isAdmin = false, isGuest }: HeaderNavigationProps) {
+export function HeaderNavigation({ isAuthenticated, isAdmin = false, isGuest, onUnauthClick }: HeaderNavigationProps) {
   const router = useRouter()
   const pathname = usePathname()
   const { t } = useTranslation()
@@ -23,6 +24,14 @@ export function HeaderNavigation({ isAuthenticated, isAdmin = false, isGuest }: 
         : 'text-bd-ink-soft hover:bg-bd-bg2 hover:text-bd-ink'
     }`
 
+  const navigate = (dest: string) => {
+    if (!isAuthenticated && !isGuest) {
+      onUnauthClick?.(dest)
+    } else {
+      router.push(dest)
+    }
+  }
+
   return (
     <div className="hidden lg:flex" style={{ marginLeft: 'clamp(30px, 3vw, 50px)', gap: 'clamp(4px, 0.5vw, 8px)' }}>
       <button
@@ -32,15 +41,13 @@ export function HeaderNavigation({ isAuthenticated, isAdmin = false, isGuest }: 
       >
         {t('header.home', 'Home')}
       </button>
-      {(isAuthenticated || isGuest) && (
-        <button
-          onClick={() => router.push('/games')}
-          className={navBtn(!!pathname?.startsWith('/games'))}
-          style={{ padding: 'clamp(6px, 0.6vh, 10px) clamp(10px, 1vw, 16px)', fontSize: 'clamp(13px, 0.95vw, 15px)' }}
-        >
-          {t('header.games', 'Games')}
-        </button>
-      )}
+      <button
+        onClick={() => navigate('/games')}
+        className={navBtn(!!pathname?.startsWith('/games'))}
+        style={{ padding: 'clamp(6px, 0.6vh, 10px) clamp(10px, 1vw, 16px)', fontSize: 'clamp(13px, 0.95vw, 15px)' }}
+      >
+        {t('header.games', 'Games')}
+      </button>
       {isAuthenticated && isAdmin && (
         <button
           onClick={() => router.push('/analytics')}
@@ -51,14 +58,14 @@ export function HeaderNavigation({ isAuthenticated, isAdmin = false, isGuest }: 
         </button>
       )}
       <button
-        onClick={() => router.push('/lobby')}
+        onClick={() => navigate('/lobby')}
         className={navBtn(!!pathname?.startsWith('/lobby'))}
         style={{ padding: 'clamp(6px, 0.6vh, 10px) clamp(10px, 1vw, 16px)', fontSize: 'clamp(13px, 0.95vw, 15px)' }}
       >
         {t('header.lobbies', 'Lobbies')}
       </button>
       <button
-        onClick={() => router.push('/leaderboard')}
+        onClick={() => navigate('/leaderboard')}
         className={navBtn(!!pathname?.startsWith('/leaderboard'))}
         style={{ padding: 'clamp(6px, 0.6vh, 10px) clamp(10px, 1vw, 16px)', fontSize: 'clamp(13px, 0.95vw, 15px)' }}
       >

--- a/components/Header/MobileMenu.tsx
+++ b/components/Header/MobileMenu.tsx
@@ -17,6 +17,7 @@ interface MobileMenuProps {
   userName?: string | null
   userEmail?: string | null
   userImage?: string | null
+  onUnauthClick?: (dest: string) => void
 }
 
 export function MobileMenu({
@@ -25,6 +26,7 @@ export function MobileMenu({
   userName,
   userEmail,
   userImage,
+  onUnauthClick,
 }: MobileMenuProps) {
   const { t } = useTranslation()
   const router = useRouter()
@@ -35,7 +37,15 @@ export function MobileMenu({
   const previousPathnameRef = useRef(pathname)
   const { isGuest, guestName, clearGuestMode } = useGuest()
   const isGuestSession = isGuest && !isAuthenticated
-  const canAccessGames = isAuthenticated || isGuestSession
+
+  const navigateMobile = (dest: string) => {
+    if (!isAuthenticated && !isGuestSession) {
+      closeMenuImmediately()
+      onUnauthClick?.(dest)
+    } else {
+      router.push(dest)
+    }
+  }
 
   const isActive = (path: string) => pathname === path
   const isActiveStart = (path: string) => !!pathname?.startsWith(path)
@@ -316,28 +326,24 @@ export function MobileMenu({
                 {t('header.home')}
               </button>
 
-              {canAccessGames && (
-                <>
-                  <button onClick={() => router.push('/games')} style={navBtn(isActiveStart('/games'))}>
-                    {t('header.games')}
-                  </button>
-                  <button onClick={() => router.push('/lobby')} style={navBtn(isActiveStart('/lobby'))}>
-                    {t('header.lobbies')}
-                  </button>
-                  <button onClick={() => router.push('/leaderboard')} style={navBtn(isActiveStart('/leaderboard'))}>
-                    {t('header.leaderboard')}
-                  </button>
-                  {isAuthenticated && (
-                    <button onClick={() => router.push('/friends')} style={navBtn(isActiveStart('/friends'))}>
-                      {t('header.friends')}
-                    </button>
-                  )}
-                  {isAuthenticated && isAdmin && (
-                    <button onClick={() => router.push('/analytics')} style={navBtn(isActiveStart('/analytics'))}>
-                      {t('header.analytics')}
-                    </button>
-                  )}
-                </>
+              <button onClick={() => navigateMobile('/games')} style={navBtn(isActiveStart('/games'))}>
+                {t('header.games')}
+              </button>
+              <button onClick={() => navigateMobile('/lobby')} style={navBtn(isActiveStart('/lobby'))}>
+                {t('header.lobbies')}
+              </button>
+              <button onClick={() => navigateMobile('/leaderboard')} style={navBtn(isActiveStart('/leaderboard'))}>
+                {t('header.leaderboard')}
+              </button>
+              {isAuthenticated && (
+                <button onClick={() => router.push('/friends')} style={navBtn(isActiveStart('/friends'))}>
+                  {t('header.friends')}
+                </button>
+              )}
+              {isAuthenticated && isAdmin && (
+                <button onClick={() => router.push('/analytics')} style={navBtn(isActiveStart('/analytics'))}>
+                  {t('header.analytics')}
+                </button>
               )}
 
               <div style={{ height: 1, background: 'var(--bd-line)', margin: '8px 0' }} />

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -54,6 +54,11 @@ export default function HeroDemoConnectFour() {
   const [board, setBoard] = useState<Board>(makeBoard)
   const [winner, setWinner] = useState<'red' | 'yellow' | 'draw' | null>(null)
   const [hoverCol, setHoverCol] = useState<number | null>(null)
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    setIsMobile(window.innerWidth <= 767)
+  }, [])
 
   const reset = useCallback(() => {
     setBoard(makeBoard())
@@ -87,16 +92,16 @@ export default function HeroDemoConnectFour() {
     : winner === 'draw' ? "Draw!"
     : 'Drop a piece'
 
-  const CELL = 28
-  const GAP = 4
-  const PADDING = 7
+  const CELL = isMobile ? 22 : 28
+  const GAP = isMobile ? 3 : 4
+  const PADDING = isMobile ? 5 : 7
 
   return (
     <div style={{
       width: '100%', height: '100%',
       display: 'flex', flexDirection: 'column',
       alignItems: 'center', justifyContent: 'center',
-      gap: 8, padding: '10px 8px',
+      gap: isMobile ? 6 : 8, padding: isMobile ? '6px 8px' : '10px 8px',
     }}>
       {/* coming soon badge */}
       <div style={{
@@ -111,33 +116,35 @@ export default function HeroDemoConnectFour() {
 
       <div style={{
         fontFamily: 'var(--bd-font-display)', fontWeight: 600, fontSize: 11,
-        color: 'rgba(31,27,22,0.55)', minHeight: 16, textAlign: 'center', width: '100%',
+        color: 'rgba(31,27,22,0.55)', minHeight: isMobile ? 0 : 16, textAlign: 'center', width: '100%',
       }}>
         {statusText}
       </div>
 
       <div style={{ position: 'relative' }}>
-        {/* drop indicators */}
-        <div style={{ display: 'flex', gap: GAP, marginBottom: 4, paddingLeft: PADDING, paddingRight: PADDING }}>
-          {Array.from({ length: COLS }, (_, c) => (
-            <div
-              key={c}
-              onClick={() => handleColClick(c)}
-              onMouseEnter={() => setHoverCol(c)}
-              onMouseLeave={() => setHoverCol(null)}
-              style={{
-                width: CELL, height: 16,
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                cursor: winner || board[0][c] ? 'default' : 'pointer',
-                fontSize: 13, fontWeight: 900,
-                color: hoverCol === c && !board[0][c] && !winner ? 'var(--bd-coral)' : 'transparent',
-                transition: 'color 0.1s',
-              }}
-            >
-              ▼
-            </div>
-          ))}
-        </div>
+        {/* drop indicators — hidden on mobile (no hover on touch) */}
+        {!isMobile && (
+          <div style={{ display: 'flex', gap: GAP, marginBottom: 4, paddingLeft: PADDING, paddingRight: PADDING }}>
+            {Array.from({ length: COLS }, (_, c) => (
+              <div
+                key={c}
+                onClick={() => handleColClick(c)}
+                onMouseEnter={() => setHoverCol(c)}
+                onMouseLeave={() => setHoverCol(null)}
+                style={{
+                  width: CELL, height: 16,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  cursor: winner || board[0][c] ? 'default' : 'pointer',
+                  fontSize: 13, fontWeight: 900,
+                  color: hoverCol === c && !board[0][c] && !winner ? 'var(--bd-coral)' : 'transparent',
+                  transition: 'color 0.1s',
+                }}
+              >
+                ▼
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* grid */}
         <div style={{

--- a/components/HomePage/HeroDemoMemory.tsx
+++ b/components/HomePage/HeroDemoMemory.tsx
@@ -19,6 +19,11 @@ export default function HeroDemoMemory() {
   const [cards, setCards] = useState<Card[]>(makeCards)
   const [flipped, setFlipped] = useState<number[]>([])
   const [locked, setLocked] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    setIsMobile(window.innerWidth <= 767)
+  }, [])
 
   const reset = useCallback(() => {
     setCards(makeCards())
@@ -53,21 +58,25 @@ export default function HeroDemoMemory() {
     }
   }
 
+  const CARD_W = isMobile ? 38 : 48
+  const CARD_H = isMobile ? 44 : 54
+  const GRID_GAP = isMobile ? 5 : 7
+
   return (
     <div style={{
       width: '100%', height: '100%',
       display: 'flex', flexDirection: 'column',
       alignItems: 'center', justifyContent: 'center',
-      gap: 12, padding: '16px 8px',
+      gap: isMobile ? 8 : 12, padding: '10px 8px',
     }}>
       <div style={{
-        fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 14,
-        color: 'rgba(31,27,22,0.8)', minHeight: 22,
+        fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: isMobile ? 12 : 14,
+        color: 'rgba(31,27,22,0.8)', minHeight: isMobile ? 18 : 22,
       }}>
         {allMatched ? '🎉 All matched!' : `${matchedCount} / ${PAIRS.length} pairs`}
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 48px)', gridTemplateRows: 'repeat(3, 54px)', gap: 7 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: `repeat(4, ${CARD_W}px)`, gridTemplateRows: `repeat(3, ${CARD_H}px)`, gap: GRID_GAP }}>
         {cards.map((card, i) => {
           const isFlipped = flipped.includes(i) || card.matched
           return (
@@ -75,7 +84,7 @@ export default function HeroDemoMemory() {
               key={card.id + '-' + i}
               onClick={() => handleFlip(i)}
               style={{
-                width: 48, height: 54,
+                width: CARD_W, height: CARD_H,
                 background: card.matched
                   ? 'rgba(255,255,255,0.85)'
                   : isFlipped

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -301,6 +301,8 @@ const en = {
     settings: 'Settings',
     analytics: 'Analytics',
     signUp: 'Sign Up',
+    authGateTitle: 'Join the game',
+    authGateDesc: 'Pick a name and play as a guest, or sign in to save your progress.',
     exitGuest: 'Exit Guest',
     guestSession: 'Guest session',
     language: 'Language',
@@ -1168,6 +1170,17 @@ const en = {
     loading: 'Loading profile...',
     playerFallback: 'Player',
     verified: 'Verified',
+    chips: {
+      games: '{{count}} games',
+      friends: '{{count}} friends',
+    },
+    achievements: {
+      title: 'Achievements',
+      firstFinish: 'First finish',
+      firstFriend: 'First friend',
+      firstWin: 'First win',
+      verified: 'Verified',
+    },
     saving: 'Saving...',
     sending: 'Sending...',
     memberSince: 'Member Since',
@@ -1530,6 +1543,8 @@ const en = {
     },
     friends: {
       title: 'Friends',
+      pageKicker: 'Social',
+      pageSubtitle: 'and crew',
       tabs: {
         friends: 'Friends',
         requests: 'Requests',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -301,6 +301,8 @@ const no = {
     settings: 'Innstillinger',
     analytics: 'Analyse',
     signUp: 'Registrer deg',
+    authGateTitle: 'Bli med i spillet',
+    authGateDesc: 'Velg et navn og spill som gjest, eller logg inn for å lagre fremgangen din.',
     exitGuest: 'Avslutt gjest',
     guestSession: 'Gjesteøkt',
     language: 'Språk',
@@ -1168,6 +1170,17 @@ const no = {
     loading: 'Laster profil...',
     playerFallback: 'Spiller',
     verified: 'Bekreftet',
+    chips: {
+      games: '{{count}} spill',
+      friends: '{{count}} venner',
+    },
+    achievements: {
+      title: 'Prestasjoner',
+      firstFinish: 'Første mål',
+      firstFriend: 'Første venn',
+      firstWin: 'Første seier',
+      verified: 'Bekreftet',
+    },
     saving: 'Lagrer...',
     sending: 'Sender...',
     memberSince: 'Medlem siden',
@@ -1519,6 +1532,8 @@ const no = {
     },
     friends: {
       title: 'Venner',
+      pageKicker: 'Sosialt',
+      pageSubtitle: 'og venner',
       tabs: {
         friends: 'Venner',
         requests: 'Forespørsler',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -301,6 +301,8 @@ const ru = {
     settings: 'Настройки',
     analytics: 'Аналитика',
     signUp: 'Регистрация',
+    authGateTitle: 'Войдите в игру',
+    authGateDesc: 'Выберите имя и играйте как гость, или войдите чтобы сохранить прогресс.',
     exitGuest: 'Выйти из гостевого режима',
     guestSession: 'Гостевой режим',
     language: 'Язык',
@@ -1168,6 +1170,17 @@ const ru = {
     loading: 'Загрузка профиля...',
     playerFallback: 'Игрок',
     verified: 'Подтверждено',
+    chips: {
+      games: '{{count}} игр',
+      friends: '{{count}} друзей',
+    },
+    achievements: {
+      title: 'Достижения',
+      firstFinish: 'Первое завершение',
+      firstFriend: 'Первый друг',
+      firstWin: 'Первая победа',
+      verified: 'Подтверждено',
+    },
     saving: 'Сохранение...',
     sending: 'Отправка...',
     memberSince: 'Участник с',
@@ -1519,6 +1532,8 @@ const ru = {
     },
     friends: {
       title: 'Друзья',
+      pageKicker: 'Социальное',
+      pageSubtitle: 'и команда',
       tabs: {
         friends: 'Друзья',
         requests: 'Запросы',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -303,6 +303,8 @@ const uk: Translation = {
     settings: 'Налаштування',
     analytics: 'Аналітика',
     signUp: 'Реєстрація',
+    authGateTitle: 'Приєднайтесь до гри',
+    authGateDesc: 'Оберіть імʼя і грайте як гість, або увійдіть щоб зберегти прогрес.',
     exitGuest: 'Вийти з гостьового режиму',
     guestSession: 'Гостьовий режим',
     language: 'Мова',
@@ -1170,6 +1172,17 @@ const uk: Translation = {
     loading: 'Завантаження профілю...',
     playerFallback: 'Гравець',
     verified: 'Підтверджено',
+    chips: {
+      games: '{{count}} ігор',
+      friends: '{{count}} друзів',
+    },
+    achievements: {
+      title: 'Досягнення',
+      firstFinish: 'Перше завершення',
+      firstFriend: 'Перший друг',
+      firstWin: 'Перша перемога',
+      verified: 'Підтверджено',
+    },
     saving: 'Збереження...',
     sending: 'Надсилання...',
     memberSince: 'Учасник з',
@@ -1532,6 +1545,8 @@ const uk: Translation = {
     },
     friends: {
       title: 'Друзі',
+      pageKicker: 'Соціальне',
+      pageSubtitle: 'і команда',
       tabs: {
         friends: 'Друзі',
         requests: 'Запити',


### PR DESCRIPTION
## Summary

- **Hero board mobile**: Memory cards scaled down (48×54→38×44), Connect Four grid scaled down (CELL 28→22) with drop indicators hidden on touch screens
- **Nav auth gate**: Games/Lobbies/Leaderboard now visible to all users; unauthenticated clicks open `AuthGateModal` (guest name entry + login/register with `returnUrl`)
- **Auth layout**: Login/register 2-col grid changed from inline `1fr 1fr` to `grid-cols-1 lg:grid-cols-2` — form fills full width on mobile
- **i18n**: Replaced hardcoded English in `/friends` page header, profile chips (games/friends counts), Achievements heading, and 4 achievement labels; all keys added to en/no/ru/uk locale files

## Test plan

- [x] `pnpm test` — 906 tests, 0 failures
- [x] `npm run ci:quick` — lint (0 errors), typecheck clean, arch audit passed
- [x] GitHub Actions CI on develop — green