### PR TITLE
infra: remove game-ops cron from vercel.json (fixes deployment)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,10 +8,6 @@
     {
       "path": "/api/cron/maintenance",
       "schedule": "0 3 * * *"
-    },
-    {
-      "path": "/api/cron/game-ops",
-      "schedule": "*/5 * * * *"
     }
   ],
   "headers": [


### PR DESCRIPTION
Closes #455

Removes `*/5 * * * *` cron from `vercel.json` — Vercel Hobby plan only supports daily crons. This was blocking all deployments.