### PR TITLE
seo: guides, FAQ schema, internal linking, Vercel fix

### DIFF
--- a/app/games/components/GameDetailPage.tsx
+++ b/app/games/components/GameDetailPage.tsx
@@ -34,6 +34,8 @@ type GameDetailPageProps = {
   steps: DetailStep[]
   benefitsTitle: string
   benefits: string[]
+  guideHref?: string
+  guideLabel?: string
 }
 
 function GameDetailIcon({
@@ -87,6 +89,8 @@ export default function GameDetailPage({
   steps,
   benefitsTitle,
   benefits,
+  guideHref,
+  guideLabel,
 }: GameDetailPageProps) {
   const { t } = useTranslation()
   return (
@@ -189,6 +193,17 @@ export default function GameDetailPage({
             </ul>
           </div>
         </section>
+
+        {guideHref && (
+          <div className="mt-8 flex items-center justify-between gap-4 rounded-2xl border border-bd-line bg-bd-bg2 px-6 py-4">
+            <p className="text-sm font-semibold text-bd-ink-soft">
+              {guideLabel ?? `Want to learn the rules and strategy for ${gameName}?`}
+            </p>
+            <Link href={guideHref} className="bd-btn bd-btn-soft shrink-0 text-sm">
+              Read the guide →
+            </Link>
+          </div>
+        )}
 
         <div className="py-10 text-center">
           {primaryCtaDisabled ? (

--- a/app/games/components/GameDetailPage.tsx
+++ b/app/games/components/GameDetailPage.tsx
@@ -35,7 +35,6 @@ type GameDetailPageProps = {
   benefitsTitle: string
   benefits: string[]
   guideHref?: string
-  guideLabel?: string
 }
 
 function GameDetailIcon({
@@ -90,7 +89,6 @@ export default function GameDetailPage({
   benefitsTitle,
   benefits,
   guideHref,
-  guideLabel,
 }: GameDetailPageProps) {
   const { t } = useTranslation()
   return (
@@ -197,10 +195,10 @@ export default function GameDetailPage({
         {guideHref && (
           <div className="mt-8 flex items-center justify-between gap-4 rounded-2xl border border-bd-line bg-bd-bg2 px-6 py-4">
             <p className="text-sm font-semibold text-bd-ink-soft">
-              {guideLabel ?? `Want to learn the rules and strategy for ${gameName}?`}
+              {t('games.guideCallout', { gameName })}
             </p>
             <Link href={guideHref} className="bd-btn bd-btn-soft shrink-0 text-sm">
-              Read the guide →
+              {t('games.readGuide')}
             </Link>
           </div>
         )}

--- a/app/games/memory/MemoryDetailContent.tsx
+++ b/app/games/memory/MemoryDetailContent.tsx
@@ -41,6 +41,8 @@ export default function MemoryDetailContent() {
         t('games.memory.detail.benefit3'),
         t('games.memory.detail.benefit4'),
       ]}
+      guideHref="/guides/how-to-play-memory-card-game-online"
+      guideLabel="New to Memory? Read the full rules, difficulty levels, and strategy tips."
     />
   )
 }

--- a/app/games/memory/MemoryDetailContent.tsx
+++ b/app/games/memory/MemoryDetailContent.tsx
@@ -42,7 +42,6 @@ export default function MemoryDetailContent() {
         t('games.memory.detail.benefit4'),
       ]}
       guideHref="/guides/how-to-play-memory-card-game-online"
-      guideLabel="New to Memory? Read the full rules, difficulty levels, and strategy tips."
     />
   )
 }

--- a/app/games/spy/SpyDetailContent.tsx
+++ b/app/games/spy/SpyDetailContent.tsx
@@ -42,7 +42,6 @@ export default function SpyDetailContent() {
         t('games.spy.detail.benefit4'),
       ]}
       guideHref="/guides/how-to-play-spy-game-online"
-      guideLabel="New to Guess the Spy? Read the full rules and strategy guide."
     />
   )
 }

--- a/app/games/spy/SpyDetailContent.tsx
+++ b/app/games/spy/SpyDetailContent.tsx
@@ -41,6 +41,8 @@ export default function SpyDetailContent() {
         t('games.spy.detail.benefit3'),
         t('games.spy.detail.benefit4'),
       ]}
+      guideHref="/guides/how-to-play-spy-game-online"
+      guideLabel="New to Guess the Spy? Read the full rules and strategy guide."
     />
   )
 }

--- a/app/games/tic-tac-toe/TicTacToeDetailContent.tsx
+++ b/app/games/tic-tac-toe/TicTacToeDetailContent.tsx
@@ -43,7 +43,6 @@ export default function TicTacToeDetailContent() {
         t('games.tictactoe.detail.benefit4'),
       ]}
       guideHref="/guides/how-to-play-tic-tac-toe-online"
-      guideLabel="New to Tic Tac Toe? Learn the rules, winning lines, and strategies."
     />
   )
 }

--- a/app/games/tic-tac-toe/TicTacToeDetailContent.tsx
+++ b/app/games/tic-tac-toe/TicTacToeDetailContent.tsx
@@ -42,6 +42,8 @@ export default function TicTacToeDetailContent() {
         t('games.tictactoe.detail.benefit3'),
         t('games.tictactoe.detail.benefit4'),
       ]}
+      guideHref="/guides/how-to-play-tic-tac-toe-online"
+      guideLabel="New to Tic Tac Toe? Learn the rules, winning lines, and strategies."
     />
   )
 }

--- a/app/games/yahtzee/YahtzeeDetailContent.tsx
+++ b/app/games/yahtzee/YahtzeeDetailContent.tsx
@@ -42,7 +42,6 @@ export default function YahtzeeDetailContent() {
         t('games.yahtzee.detail.benefit4'),
       ]}
       guideHref="/guides/how-to-play-yahtzee-online"
-      guideLabel="New to Yahtzee? Read the full rules and scoring guide."
     />
   )
 }

--- a/app/games/yahtzee/YahtzeeDetailContent.tsx
+++ b/app/games/yahtzee/YahtzeeDetailContent.tsx
@@ -41,6 +41,8 @@ export default function YahtzeeDetailContent() {
         t('games.yahtzee.detail.benefit3'),
         t('games.yahtzee.detail.benefit4'),
       ]}
+      guideHref="/guides/how-to-play-yahtzee-online"
+      guideLabel="New to Yahtzee? Read the full rules and scoring guide."
     />
   )
 }

--- a/app/guides/best-free-multiplayer-browser-games/page.tsx
+++ b/app/guides/best-free-multiplayer-browser-games/page.tsx
@@ -49,6 +49,38 @@ const breadcrumbJsonLd = {
   ],
 }
 
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What are the best free multiplayer browser games?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The best free multiplayer browser games in 2026 include Yahtzee (1–4 players), Guess the Spy (3–10 players), Memory Card Game (2–4 players), and Tic Tac Toe (2 players). All are available on Boardly with no download or account required.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Do I need an account to play multiplayer browser games?',
+      acceptedAnswer: { '@type': 'Answer', text: 'No. All games on Boardly support guest play — just open the game, share the lobby link with friends, and start playing immediately. No account, no email, no download required.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Can I play these browser games on mobile?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Yes. All Boardly games work on desktop, tablet, and mobile browsers. No app download is needed — just open the link on any device.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the best browser game for large groups?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Guess the Spy is the best browser game for large groups — it supports 3–10 players and works best with 5–8. Yahtzee supports up to 4 players and is great for smaller groups.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Why play browser games instead of downloading an app?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Browser games require zero setup. You share one link and everyone is in the same game within seconds — no installs, no updates, no storage used. This makes them ideal for spontaneous group play with friends on any device.' },
+    },
+  ],
+}
+
 const games = [
   {
     rank: 1,
@@ -93,6 +125,7 @@ export default function BestBrowserGamesGuide() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
 
       <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
@@ -191,6 +224,8 @@ export default function BestBrowserGamesGuide() {
             <div className="flex flex-col gap-3">
               <Link href="/guides/how-to-play-yahtzee-online" className="text-white hover:underline text-sm">→ How to Play Yahtzee Online with Friends</Link>
               <Link href="/guides/how-to-play-spy-game-online" className="text-white hover:underline text-sm">→ How to Play Guess the Spy Online</Link>
+              <Link href="/guides/how-to-play-memory-card-game-online" className="text-white hover:underline text-sm">→ How to Play Memory Card Game Online</Link>
+              <Link href="/guides/how-to-play-tic-tac-toe-online" className="text-white hover:underline text-sm">→ How to Play Tic Tac Toe Online</Link>
             </div>
           </div>
         </div>

--- a/app/guides/how-to-play-memory-card-game-online/page.tsx
+++ b/app/guides/how-to-play-memory-card-game-online/page.tsx
@@ -49,11 +49,44 @@ const breadcrumbJsonLd = {
   ],
 }
 
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is the Memory card game?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Memory (also called Concentration) is a card-matching game where all cards start face-down. Players take turns flipping two cards — if they match, the player keeps the pair and goes again. The player with the most pairs at the end wins.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How many players can play Memory?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Memory on Boardly supports 2–4 players in real-time multiplayer. All players share the same board and take turns flipping cards.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What are the difficulty levels in Memory?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Boardly Memory has three difficulty levels: Easy (4×4 grid, 8 pairs), Medium (4×6 grid, 12 pairs), and Hard (5×6 grid, 15 pairs). Medium is the standard competitive level for most groups.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What happens when you find a matching pair in Memory?',
+      acceptedAnswer: { '@type': 'Answer', text: 'When two flipped cards match, the active player scores the pair and immediately gets another turn. Consecutive matches let you keep going until you flip a non-matching pair.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the best strategy for Memory?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The key strategy in Memory is paying attention when other players flip cards — their misses reveal card positions you can use on your turn. Scan the board systematically section by section rather than clicking randomly.' },
+    },
+  ],
+}
+
 export default function HowToPlayMemoryGuide() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
 
       <div className="min-h-[100dvh] bg-gradient-to-br from-emerald-500 via-teal-600 to-cyan-700">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">

--- a/app/guides/how-to-play-memory-card-game-online/page.tsx
+++ b/app/guides/how-to-play-memory-card-game-online/page.tsx
@@ -1,0 +1,186 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'How to Play Memory Card Game Online - Rules & Strategy Guide',
+  description:
+    'Learn how to play Memory card matching game online. Rules explained, difficulty levels compared, strategy tips to win, and how to play multiplayer with friends for free.',
+  keywords: [
+    'how to play memory card game online',
+    'memory game rules',
+    'memory card game strategy',
+    'concentration card game how to play',
+    'memory matching game tips',
+    'memory game difficulty levels',
+    'play memory online multiplayer',
+    'memory game for beginners',
+  ],
+  openGraph: {
+    title: 'How to Play Memory Card Game Online | Boardly',
+    description: 'Complete Memory card game guide — rules, difficulty levels, strategy tips. Free multiplayer in your browser.',
+    url: 'https://boardly.online/guides/how-to-play-memory-card-game-online',
+    type: 'article',
+  },
+  alternates: {
+    canonical: 'https://boardly.online/guides/how-to-play-memory-card-game-online',
+  },
+}
+
+const articleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to Play Memory Card Game Online — Rules & Strategy Guide',
+  description: 'Complete guide to playing Memory card matching game online — rules, difficulty levels, and strategy tips.',
+  url: 'https://boardly.online/guides/how-to-play-memory-card-game-online',
+  image: 'https://boardly.online/opengraph-image',
+  datePublished: '2026-05-07',
+  dateModified: '2026-05-07',
+  author: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
+}
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://boardly.online/guides' },
+    { '@type': 'ListItem', position: 3, name: 'How to Play Memory Card Game Online', item: 'https://boardly.online/guides/how-to-play-memory-card-game-online' },
+  ],
+}
+
+export default function HowToPlayMemoryGuide() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+
+      <div className="min-h-[100dvh] bg-gradient-to-br from-emerald-500 via-teal-600 to-cyan-700">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-6 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/guides" className="hover:text-white transition-colors">Guides</Link>
+            <span>/</span>
+            <span className="text-white">How to Play Memory Card Game</span>
+          </nav>
+
+          {/* Header */}
+          <header className="mb-8 sm:mb-12">
+            <div className="text-5xl sm:text-6xl mb-4">🧠</div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight break-words">
+              How to Play Memory Card Game Online
+            </h1>
+            <p className="text-white/70 text-sm">4 min read · Free to play on Boardly · 2–4 players</p>
+          </header>
+
+          {/* Intro */}
+          <div className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <p className="text-white/90 leading-relaxed text-lg">
+              Memory (also called Concentration) is a classic card-matching game. All cards start face-down. On your turn, flip two cards — if they match, you keep them and go again. If they don't match, both cards flip back. The player with the most matched pairs at the end wins.
+            </p>
+          </div>
+
+          {/* What you need */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">What You Need</h2>
+            <ul className="space-y-2 text-white/85">
+              <li>✅ 2–4 players</li>
+              <li>✅ A browser — desktop, tablet, or mobile</li>
+              <li>✅ No account required (guest play available)</li>
+              <li>✅ Free — no ads, no download</li>
+            </ul>
+          </section>
+
+          {/* Rules */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">How to Play — Step by Step</h2>
+            <div className="space-y-4">
+              {[
+                { step: '1', title: 'Start the game', desc: 'All cards are placed face-down in a grid. The grid size depends on the difficulty level you chose.' },
+                { step: '2', title: 'Flip two cards', desc: 'On your turn, click any card to reveal it, then click a second card. Both cards are visible to all players for a moment.' },
+                { step: '3', title: 'Match or miss', desc: 'If the two cards show the same image, you score a pair and get another turn. If they don\'t match, both cards flip back face-down and it\'s the next player\'s turn.' },
+                { step: '4', title: 'Remember positions', desc: 'This is the skill — memorize where unmatched cards are so you can complete pairs on future turns.' },
+                { step: '5', title: 'Win the game', desc: 'When all pairs are found, the player with the most matches wins. Ties are possible.' },
+              ].map(({ step, title, desc }) => (
+                <div key={step} className="flex gap-4">
+                  <div className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center text-sm font-bold shrink-0 mt-0.5">{step}</div>
+                  <div>
+                    <strong className="block mb-1">{title}</strong>
+                    <p className="text-white/75 text-sm">{desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Difficulty levels */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Difficulty Levels</h2>
+            <p className="text-white/80 text-sm mb-6">Boardly Memory has three difficulty levels that change the grid size and number of pairs.</p>
+            <div className="space-y-4">
+              {[
+                { level: 'Easy', grid: '4×4', pairs: '8 pairs', best: 'Quick games, playing with younger players, or learning the game' },
+                { level: 'Medium', grid: '4×6', pairs: '12 pairs', best: 'Standard competitive play — the sweet spot for most groups' },
+                { level: 'Hard', grid: '5×6', pairs: '15 pairs', best: 'Serious players who want a longer, more demanding game' },
+              ].map(({ level, grid, pairs, best }) => (
+                <div key={level} className="border border-white/20 rounded-2xl p-4">
+                  <div className="flex justify-between items-center mb-2">
+                    <strong>{level}</strong>
+                    <span className="text-white/60 text-sm">{grid} grid · {pairs}</span>
+                  </div>
+                  <p className="text-white/65 text-sm">{best}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Strategy tips */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Strategy Tips</h2>
+            <ul className="space-y-4">
+              {[
+                { tip: 'Scan before you click', detail: 'Don\'t rush your first flip. Take a second to plan which area of the board you haven\'t explored yet. Systematic scanning beats random clicking every time.' },
+                { tip: 'Use the grid like a map', detail: 'Mentally divide the grid into sections. Clear one section at a time instead of clicking randomly across the board — it\'s easier to track positions this way.' },
+                { tip: 'Watch your opponents', detail: 'When other players flip cards, you see them too. Pay attention — their misses are hints about where unmatched pairs are hiding.' },
+                { tip: 'Delay taking easy pairs', detail: 'Once you remember where a pair is, you don\'t have to grab it immediately. Sometimes it\'s better to flip a new unknown card first to get more information.' },
+                { tip: 'Go for streaks', detail: 'Consecutive matches give you extra turns. If you\'re on a streak, prioritise pairs you\'re sure about over guesses — a missed flip ends your turn.' },
+              ].map(({ tip, detail }) => (
+                <li key={tip} className="border-b border-white/10 pb-4 last:border-0 last:pb-0">
+                  <strong className="block mb-1">💡 {tip}</strong>
+                  <p className="text-white/75 text-sm">{detail}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* CTA */}
+          <div className="text-center">
+            <p className="text-white/80 mb-4">Ready to test your memory?</p>
+            <Link
+              href="/games/memory"
+              className="inline-block px-10 py-4 bg-white text-emerald-600 rounded-2xl font-bold text-lg hover:bg-emerald-50 transition-all duration-300 shadow-xl hover:scale-105"
+            >
+              Play Memory Now →
+            </Link>
+            <p className="text-white/50 text-sm mt-3">Free · No account required · 2–4 players</p>
+          </div>
+
+          {/* Related */}
+          <div className="mt-12 pt-8 border-t border-white/20">
+            <h3 className="text-white/70 text-sm font-semibold mb-4 uppercase tracking-wide">More guides</h3>
+            <div className="flex flex-col gap-3">
+              <Link href="/guides/how-to-play-yahtzee-online" className="text-white hover:underline text-sm">→ How to Play Yahtzee Online with Friends</Link>
+              <Link href="/guides/how-to-play-spy-game-online" className="text-white hover:underline text-sm">→ How to Play Guess the Spy Online</Link>
+              <Link href="/guides/how-to-play-tic-tac-toe-online" className="text-white hover:underline text-sm">→ How to Play Tic Tac Toe Online</Link>
+              <Link href="/guides/best-free-multiplayer-browser-games" className="text-white hover:underline text-sm">→ Best Free Multiplayer Browser Games in 2026</Link>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/guides/how-to-play-spy-game-online/page.tsx
+++ b/app/guides/how-to-play-spy-game-online/page.tsx
@@ -49,11 +49,44 @@ const breadcrumbJsonLd = {
   ],
 }
 
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is Guess the Spy?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Guess the Spy is a social deduction party game where all players except one are told a secret location. The spy has no idea where everyone is and must bluff through questioning to survive — while the others try to identify and vote out the spy.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How many players do you need for Guess the Spy?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Guess the Spy works with 3–10 players. It plays best with 5–8 players, giving enough voices to make questioning interesting without becoming too chaotic.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How does the spy win in Guess the Spy?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The spy can win in two ways: either survive the entire round without being voted out, or correctly guess the secret location before being eliminated. A correct location guess wins the round for the spy even if they were about to be caught.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What happens if players vote out the wrong person?',
+      acceptedAnswer: { '@type': 'Answer', text: 'If the majority votes to accuse someone who is not the spy, the group loses the round. The spy is immediately revealed and wins. This is why rushing the vote is risky.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How long is a round of Guess the Spy?',
+      acceptedAnswer: { '@type': 'Answer', text: 'A typical round lasts 5–8 minutes. Rounds are short enough that you can easily play multiple in one session.' },
+    },
+  ],
+}
+
 export default function HowToPlaySpyGuide() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
 
       <div className="min-h-[100dvh] bg-gradient-to-br from-red-500 via-pink-600 to-purple-700">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
@@ -184,7 +217,9 @@ export default function HowToPlaySpyGuide() {
             <h3 className="text-white/70 text-sm font-semibold mb-4 uppercase tracking-wide">More guides</h3>
             <div className="flex flex-col gap-3">
               <Link href="/guides/how-to-play-yahtzee-online" className="text-white hover:underline text-sm">→ How to Play Yahtzee Online with Friends</Link>
-              <Link href="/guides/best-free-multiplayer-browser-games" className="text-white hover:underline text-sm">→ Best Free Multiplayer Browser Games in 2025</Link>
+              <Link href="/guides/how-to-play-memory-card-game-online" className="text-white hover:underline text-sm">→ How to Play Memory Card Game Online</Link>
+              <Link href="/guides/how-to-play-tic-tac-toe-online" className="text-white hover:underline text-sm">→ How to Play Tic Tac Toe Online</Link>
+              <Link href="/guides/best-free-multiplayer-browser-games" className="text-white hover:underline text-sm">→ Best Free Multiplayer Browser Games in 2026</Link>
             </div>
           </div>
         </div>

--- a/app/guides/how-to-play-tic-tac-toe-online/page.tsx
+++ b/app/guides/how-to-play-tic-tac-toe-online/page.tsx
@@ -1,0 +1,209 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'How to Play Tic Tac Toe Online - Rules & Winning Strategy',
+  description:
+    'Learn how to play Tic Tac Toe online. Rules explained, winning strategies for X and O, how to never lose, AI opponent tips, and how to play multiplayer with friends for free.',
+  keywords: [
+    'how to play tic tac toe online',
+    'tic tac toe rules',
+    'tic tac toe strategy',
+    'tic tac toe winning strategy',
+    'noughts and crosses rules',
+    'tic tac toe tips',
+    'play tic tac toe with friends online',
+    'tic tac toe guide',
+  ],
+  openGraph: {
+    title: 'How to Play Tic Tac Toe Online | Boardly',
+    description: 'Complete Tic Tac Toe guide — rules, winning strategies, and tips to never lose. Free multiplayer in your browser.',
+    url: 'https://boardly.online/guides/how-to-play-tic-tac-toe-online',
+    type: 'article',
+  },
+  alternates: {
+    canonical: 'https://boardly.online/guides/how-to-play-tic-tac-toe-online',
+  },
+}
+
+const articleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to Play Tic Tac Toe Online — Rules & Winning Strategy',
+  description: 'Complete guide to Tic Tac Toe — rules, winning strategies for X and O, and tips to never lose.',
+  url: 'https://boardly.online/guides/how-to-play-tic-tac-toe-online',
+  image: 'https://boardly.online/opengraph-image',
+  datePublished: '2026-05-07',
+  dateModified: '2026-05-07',
+  author: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
+  publisher: { '@type': 'Organization', name: 'Boardly', url: 'https://boardly.online' },
+}
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://boardly.online' },
+    { '@type': 'ListItem', position: 2, name: 'Guides', item: 'https://boardly.online/guides' },
+    { '@type': 'ListItem', position: 3, name: 'How to Play Tic Tac Toe Online', item: 'https://boardly.online/guides/how-to-play-tic-tac-toe-online' },
+  ],
+}
+
+export default function HowToPlayTicTacToeGuide() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+
+      <div className="min-h-[100dvh] bg-gradient-to-br from-orange-500 via-red-500 to-pink-600">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
+
+          {/* Breadcrumb */}
+          <nav className="mb-6 text-white/60 text-sm flex items-center gap-2 flex-wrap" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-white transition-colors">Home</Link>
+            <span>/</span>
+            <Link href="/guides" className="hover:text-white transition-colors">Guides</Link>
+            <span>/</span>
+            <span className="text-white">How to Play Tic Tac Toe Online</span>
+          </nav>
+
+          {/* Header */}
+          <header className="mb-8 sm:mb-12">
+            <div className="text-5xl sm:text-6xl mb-4">⭕</div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-white mb-4 drop-shadow-lg leading-tight break-words">
+              How to Play Tic Tac Toe Online
+            </h1>
+            <p className="text-white/70 text-sm">4 min read · Free to play on Boardly · 2 players or vs AI</p>
+          </header>
+
+          {/* Intro */}
+          <div className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <p className="text-white/90 leading-relaxed text-lg">
+              Tic Tac Toe (also called Noughts and Crosses) is one of the most widely known two-player games in the world. Two players take turns placing their mark (X or O) on a 3×3 grid. The first to get three in a row — horizontally, vertically, or diagonally — wins. Sounds simple, but with the right strategy you can guarantee you never lose.
+            </p>
+          </div>
+
+          {/* What you need */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">What You Need</h2>
+            <ul className="space-y-2 text-white/85">
+              <li>✅ 2 players — or play solo against AI</li>
+              <li>✅ A browser — desktop, tablet, or mobile</li>
+              <li>✅ No account required (guest play available)</li>
+              <li>✅ Free — no ads, no download</li>
+            </ul>
+          </section>
+
+          {/* Rules */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">The Rules</h2>
+            <div className="space-y-4">
+              {[
+                { step: '1', title: 'Choose your mark', desc: 'One player is X, the other is O. X always goes first.' },
+                { step: '2', title: 'Take turns', desc: 'Players alternate placing their mark in any empty cell on the 3×3 grid.' },
+                { step: '3', title: 'Win with three in a row', desc: 'Get three of your marks in a row — horizontally, vertically, or diagonally — and you win.' },
+                { step: '4', title: 'Draw', desc: 'If all 9 cells are filled and neither player has three in a row, the game is a draw. With perfect play from both sides, every game ends in a draw.' },
+              ].map(({ step, title, desc }) => (
+                <div key={step} className="flex gap-4">
+                  <div className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center text-sm font-bold shrink-0 mt-0.5">{step}</div>
+                  <div>
+                    <strong className="block mb-1">{title}</strong>
+                    <p className="text-white/75 text-sm">{desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Winning positions */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">All 8 Winning Lines</h2>
+            <p className="text-white/80 text-sm mb-4">There are exactly 8 ways to win. Three in any of these lines wins the game:</p>
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              {[
+                'Top row (1-2-3)',
+                'Middle row (4-5-6)',
+                'Bottom row (7-8-9)',
+                'Left column (1-4-7)',
+                'Middle column (2-5-8)',
+                'Right column (3-6-9)',
+                'Diagonal (1-5-9)',
+                'Diagonal (3-5-7)',
+              ].map((line) => (
+                <div key={line} className="bg-white/10 rounded-xl px-3 py-2 text-white/80">{line}</div>
+              ))}
+            </div>
+          </section>
+
+          {/* Strategy */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Strategy — How to Never Lose</h2>
+            <ul className="space-y-4">
+              {[
+                {
+                  tip: 'Start in the center (as X)',
+                  detail: 'The center square (5) is part of 4 winning lines — more than any other cell. Taking it first as X gives you the most winning options and forces your opponent to play defensively.',
+                },
+                {
+                  tip: 'Take a corner if center is taken',
+                  detail: 'Corners are each part of 3 winning lines. If your opponent takes center, play a corner. This sets up diagonal threats they must respond to.',
+                },
+                {
+                  tip: 'Block before attacking',
+                  detail: 'If your opponent has two in a row, block the third cell immediately. Missing a block almost always loses the game.',
+                },
+                {
+                  tip: 'Create a fork',
+                  detail: 'A fork means you have two different ways to win at once. Your opponent can only block one, so you win the other. To fork: place your mark so it threatens two different winning lines simultaneously.',
+                },
+                {
+                  tip: 'Block forks',
+                  detail: 'If your opponent is setting up a fork, block it — either by playing the cell they need, or by creating a threat that forces them to defend elsewhere.',
+                },
+              ].map(({ tip, detail }) => (
+                <li key={tip} className="border-b border-white/10 pb-4 last:border-0 last:pb-0">
+                  <strong className="block mb-1">💡 {tip}</strong>
+                  <p className="text-white/75 text-sm">{detail}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* Playing on Boardly */}
+          <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
+            <h2 className="text-2xl font-bold mb-4">Playing on Boardly</h2>
+            <div className="space-y-3 text-white/85 text-sm">
+              <p><strong className="text-white">vs AI:</strong> Play solo against a bot — great for practising strategy without waiting for an opponent.</p>
+              <p><strong className="text-white">vs Friend:</strong> Share a lobby link and play in real time. No account needed for either player.</p>
+              <p><strong className="text-white">Match mode:</strong> Play a series of rounds to determine the overall winner — best of 3 or best of 5.</p>
+            </div>
+          </section>
+
+          {/* CTA */}
+          <div className="text-center">
+            <p className="text-white/80 mb-4">Ready to put your strategy to the test?</p>
+            <Link
+              href="/games/tic-tac-toe"
+              className="inline-block px-10 py-4 bg-white text-orange-600 rounded-2xl font-bold text-lg hover:bg-orange-50 transition-all duration-300 shadow-xl hover:scale-105"
+            >
+              Play Tic Tac Toe Now →
+            </Link>
+            <p className="text-white/50 text-sm mt-3">Free · No account required · vs AI or 2 players</p>
+          </div>
+
+          {/* Related */}
+          <div className="mt-12 pt-8 border-t border-white/20">
+            <h3 className="text-white/70 text-sm font-semibold mb-4 uppercase tracking-wide">More guides</h3>
+            <div className="flex flex-col gap-3">
+              <Link href="/guides/how-to-play-yahtzee-online" className="text-white hover:underline text-sm">→ How to Play Yahtzee Online with Friends</Link>
+              <Link href="/guides/how-to-play-memory-card-game-online" className="text-white hover:underline text-sm">→ How to Play Memory Card Game Online</Link>
+              <Link href="/guides/how-to-play-spy-game-online" className="text-white hover:underline text-sm">→ How to Play Guess the Spy Online</Link>
+              <Link href="/guides/best-free-multiplayer-browser-games" className="text-white hover:underline text-sm">→ Best Free Multiplayer Browser Games in 2026</Link>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/guides/how-to-play-tic-tac-toe-online/page.tsx
+++ b/app/guides/how-to-play-tic-tac-toe-online/page.tsx
@@ -49,11 +49,44 @@ const breadcrumbJsonLd = {
   ],
 }
 
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is Tic Tac Toe?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Tic Tac Toe (also called Noughts and Crosses) is a two-player game played on a 3×3 grid. Players take turns placing their mark (X or O) and the first to get three in a row — horizontally, vertically, or diagonally — wins.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How do you win at Tic Tac Toe?',
+      acceptedAnswer: { '@type': 'Answer', text: 'You win Tic Tac Toe by placing three of your marks in a row — horizontally across any of the 3 rows, vertically down any of the 3 columns, or diagonally across the board. There are 8 total winning lines.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the best first move in Tic Tac Toe?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The best first move is the center square (position 5). It is part of 4 winning lines — more than any other cell — giving you the most attacking options and forcing your opponent to play defensively.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Can Tic Tac Toe always end in a draw?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Yes. With perfect play from both sides, every game of Tic Tac Toe ends in a draw. The game is mathematically solved — neither player can force a win if the opponent plays optimally.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is a fork in Tic Tac Toe?',
+      acceptedAnswer: { '@type': 'Answer', text: 'A fork is when you create two different ways to win at the same time. Your opponent can only block one threat, so you win with the other. Forks are the key technique for winning against players who are not using perfect strategy.' },
+    },
+  ],
+}
+
 export default function HowToPlayTicTacToeGuide() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
 
       <div className="min-h-[100dvh] bg-gradient-to-br from-orange-500 via-red-500 to-pink-600">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">

--- a/app/guides/how-to-play-yahtzee-online/page.tsx
+++ b/app/guides/how-to-play-yahtzee-online/page.tsx
@@ -186,7 +186,9 @@ export default function HowToPlayYahtzeeGuide() {
             <h3 className="text-white/70 text-sm font-semibold mb-4 uppercase tracking-wide">More guides</h3>
             <div className="flex flex-col gap-3">
               <Link href="/guides/how-to-play-spy-game-online" className="text-white hover:underline text-sm">→ How to Play Guess the Spy Online</Link>
-              <Link href="/guides/best-free-multiplayer-browser-games" className="text-white hover:underline text-sm">→ Best Free Multiplayer Browser Games in 2025</Link>
+              <Link href="/guides/how-to-play-memory-card-game-online" className="text-white hover:underline text-sm">→ How to Play Memory Card Game Online</Link>
+              <Link href="/guides/how-to-play-tic-tac-toe-online" className="text-white hover:underline text-sm">→ How to Play Tic Tac Toe Online</Link>
+              <Link href="/guides/best-free-multiplayer-browser-games" className="text-white hover:underline text-sm">→ Best Free Multiplayer Browser Games in 2026</Link>
             </div>
           </div>
         </div>

--- a/app/guides/how-to-play-yahtzee-online/page.tsx
+++ b/app/guides/how-to-play-yahtzee-online/page.tsx
@@ -48,11 +48,44 @@ const breadcrumbJsonLd = {
   ],
 }
 
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is Yahtzee?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Yahtzee is a classic dice-rolling game where players roll five dice up to three times per turn and try to score the highest by filling 15 scoring categories. The player with the highest total score wins.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How many players can play Yahtzee online?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Yahtzee on Boardly supports 1–4 players. You can play solo against an AI or in real-time multiplayer with up to 3 friends.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the upper section bonus in Yahtzee?',
+      acceptedAnswer: { '@type': 'Answer', text: 'If your combined score in the upper section (Aces through Sixes) totals 63 or more, you earn a 35-point bonus. The easiest way to reach 63 is to score at least 3 of each number.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is a Yahtzee?',
+      acceptedAnswer: { '@type': 'Answer', text: 'A Yahtzee is when all five dice show the same number. It scores 50 points. Each additional Yahtzee after the first scores a 100-point bonus.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How many scoring categories are in Yahtzee?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Boardly Yahtzee has 15 scoring categories: 6 in the upper section (Ones through Sixes) and 9 in the lower section (One Pair, Two Pairs, Three of a Kind, Four of a Kind, Full House, Small Straight, Large Straight, Yahtzee, and Chance).' },
+    },
+  ],
+}
+
 export default function HowToPlayYahtzeeGuide() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
 
       <div className="min-h-[100dvh] bg-gradient-to-br from-blue-500 via-purple-600 to-pink-500">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 md:py-16">
@@ -78,7 +111,7 @@ export default function HowToPlayYahtzeeGuide() {
           {/* Intro */}
           <div className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
             <p className="text-white/90 leading-relaxed text-lg">
-              Yahtzee is one of the most popular dice games in the world — and on Boardly, you can play it online with friends in real-time, completely free. This guide covers everything you need to know: the rules, all 13 scoring categories, and tips to improve your strategy.
+              Yahtzee is one of the most popular dice games in the world — and on Boardly, you can play it online with friends in real-time, completely free. This guide covers everything you need to know: the rules, all 15 scoring categories, and tips to improve your strategy.
             </p>
           </div>
 
@@ -97,7 +130,7 @@ export default function HowToPlayYahtzeeGuide() {
           <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
             <h2 className="text-2xl font-bold mb-4">The Basic Rules</h2>
             <p className="text-white/85 leading-relaxed mb-4">
-              Each turn, you roll five dice. You may re-roll any or all of them up to two more times (three rolls total). After your rolls, you must assign your result to one of 13 scoring categories. Once a category is filled, it cannot be changed. The game ends when all 13 categories are filled by every player.
+              Each turn, you roll five dice. You may re-roll any or all of them up to two more times (three rolls total). After your rolls, you must assign your result to one of 15 scoring categories. Once a category is filled, it cannot be changed. The game ends when all 15 categories are filled by every player.
             </p>
             <p className="text-white/85 leading-relaxed">
               The player with the highest total score wins. A bonus of 35 points is awarded if your upper section score (Aces through Sixes) totals 63 or more.
@@ -106,7 +139,7 @@ export default function HowToPlayYahtzeeGuide() {
 
           {/* Scoring categories */}
           <section className="bg-white/10 backdrop-blur-md rounded-3xl p-8 mb-8 text-white">
-            <h2 className="text-2xl font-bold mb-6">All 13 Scoring Categories</h2>
+            <h2 className="text-2xl font-bold mb-6">All 15 Scoring Categories</h2>
 
             <h3 className="text-lg font-semibold mb-3 text-white/90">Upper Section</h3>
             <div className="space-y-3 mb-6">
@@ -131,6 +164,8 @@ export default function HowToPlayYahtzeeGuide() {
             <h3 className="text-lg font-semibold mb-3 text-white/90">Lower Section</h3>
             <div className="space-y-3">
               {[
+                { name: 'One Pair', desc: 'At least two identical dice — score is sum of the highest pair', example: 'e.g. 5+5+1+2+3 = 10 pts' },
+                { name: 'Two Pairs', desc: 'Two different pairs — score is sum of both pairs', example: 'e.g. 5+5+3+3+1 = 16 pts' },
                 { name: 'Three of a Kind', desc: 'At least 3 identical dice — score is sum of all 5 dice', example: 'e.g. 3+3+3+5+6 = 20 pts' },
                 { name: 'Four of a Kind', desc: 'At least 4 identical dice — score is sum of all 5 dice', example: 'e.g. 4+4+4+4+2 = 18 pts' },
                 { name: 'Full House', desc: 'Three of one number + two of another', example: '25 pts fixed' },

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -55,6 +55,20 @@ const guides = [
     emoji: '🕵️',
     readTime: '4 min read',
   },
+  {
+    slug: 'how-to-play-memory-card-game-online',
+    title: 'How to Play Memory Card Game Online',
+    description: 'Rules, difficulty levels, and strategy tips for the classic card-matching game. Free multiplayer in your browser.',
+    emoji: '🧠',
+    readTime: '4 min read',
+  },
+  {
+    slug: 'how-to-play-tic-tac-toe-online',
+    title: 'How to Play Tic Tac Toe Online',
+    description: 'Complete Tic Tac Toe guide — rules, all 8 winning lines, and strategies to never lose. Free vs AI or 2 players.',
+    emoji: '⭕',
+    readTime: '4 min read',
+  },
 ]
 
 const collectionJsonLd = {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -34,6 +34,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     page('/guides', { changeFrequency: 'weekly', priority: 0.8 }),
     page('/guides/how-to-play-yahtzee-online', { changeFrequency: 'monthly', priority: 0.8 }),
     page('/guides/how-to-play-spy-game-online', { changeFrequency: 'monthly', priority: 0.75 }),
+    page('/guides/how-to-play-memory-card-game-online', { changeFrequency: 'monthly', priority: 0.75 }),
+    page('/guides/how-to-play-tic-tac-toe-online', { changeFrequency: 'monthly', priority: 0.75 }),
     page('/guides/best-free-multiplayer-browser-games', { changeFrequency: 'monthly', priority: 0.75 }),
 
     // Legal

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -378,6 +378,8 @@ const en = {
     startPlaying: 'Start playing',
     noDownloadNeeded: 'You can play as a guest. No app download needed.',
     stillBeingPolished: 'This game is still being polished.',
+    guideCallout: 'New to {{gameName}}? Read the full rules and strategy guide.',
+    readGuide: 'Read the guide →',
     detail: {
       labels: {
         players: 'Players',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -378,6 +378,8 @@ const no = {
     startPlaying: 'Begynn å spille',
     noDownloadNeeded: 'Spill som gjest. Ingen nedlasting nødvendig.',
     stillBeingPolished: 'Dette spillet er fortsatt under utvikling.',
+    guideCallout: 'Ny i {{gameName}}? Les de fullstendige reglene og tipsene.',
+    readGuide: 'Les guiden →',
     detail: {
       labels: {
         players: 'Spillere',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -378,6 +378,8 @@ const ru = {
     startPlaying: 'Начать играть',
     noDownloadNeeded: 'Играй как гость. Ничего скачивать не нужно.',
     stillBeingPolished: 'Эта игра ещё разрабатывается.',
+    guideCallout: 'Впервые в {{gameName}}? Читай полные правила и советы.',
+    readGuide: 'Читать гайд →',
     detail: {
       labels: {
         players: 'Игроки',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -380,6 +380,8 @@ const uk: Translation = {
     startPlaying: 'Почати грати',
     noDownloadNeeded: 'Грай як гість. Завантажувати нічого не потрібно.',
     stillBeingPolished: 'Ця гра ще розробляється.',
+    guideCallout: 'Вперше в {{gameName}}? Читай повні правила та поради.',
+    readGuide: 'Читати гайд →',
     detail: {
       labels: {
         players: 'Гравці',


### PR DESCRIPTION
## Summary

- New guide pages: Memory card game and Tic Tac Toe (with Article + BreadcrumbList JSON-LD)
- FAQPage JSON-LD added to all 5 guide pages (5 Q&As each) for featured snippet eligibility
- Internal linking: `guideHref` prop on `GameDetailPage` → guide callout strip on all 4 active game pages
- Sitemap updated to 15 pages (was ~13)
- Guides index updated with all 5 guides + collectionJsonLd.hasPart
- Fixed Yahtzee guide: 13 → 15 scoring categories (Boardly uses Yatzy variant with One Pair + Two Pairs)
- Fixed Vercel cron: removed `game-ops` (incompatible with Hobby plan, was blocking deploys)
- Fixed 2025 → 2026 in related links across guides
- Both GSC verification tokens in layout.tsx (www + non-www)

## Test plan

- [ ] All guide pages render correctly (check /guides, /guides/how-to-play-yahtzee-online, /guides/how-to-play-memory-card-game-online, /guides/how-to-play-tic-tac-toe-online, /guides/how-to-play-spy-game-online, /guides/best-free-multiplayer-browser-games)
- [ ] Game pages show guide callout strip (check /games/yahtzee, /games/memory, /games/spy, /games/tic-tac-toe)
- [ ] Sitemap returns 15 entries at /sitemap.xml
- [ ] Validate JSON-LD on any guide page via Google Rich Results Test
- [ ] Vercel deployment succeeds (no cron errors)