### PR TITLE
#478 feat: display avatars in lobby waiting room and leaderboard

### DIFF
--- a/app/api/game/create/route.ts
+++ b/app/api/game/create/route.ts
@@ -529,7 +529,9 @@ export async function POST(request: NextRequest) {
           user: {
             id: p.user.id,
             username: p.user.username,
-            bot: p.user.bot, // Include bot relation for bot detection
+            image: p.user.image,
+            avatarUrl: p.user.avatarUrl,
+            bot: p.user.bot,
           },
         })),
       }

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -63,6 +63,8 @@ export async function GET(req: NextRequest) {
       userId: string
       username: string | null
       publicProfileId: string | null
+      avatarUrl: string | null
+      image: string | null
       gamesPlayed: bigint
       wins: bigint
       losses: bigint
@@ -84,6 +86,8 @@ export async function GET(req: NextRequest) {
           u.id AS "userId",
           u.username,
           u."publicProfileId",
+          u."avatarUrl",
+          u.image,
           p.id AS "playerId",
           (
             p."isWinner" = true
@@ -111,6 +115,8 @@ export async function GET(req: NextRequest) {
         "userId",
         username,
         "publicProfileId",
+        "avatarUrl",
+        image,
         COUNT("playerId")                                                        AS "gamesPlayed",
         COUNT("playerId") FILTER (WHERE "isWinner" = true AND NOT "isDraw")      AS wins,
         COUNT("playerId") FILTER (WHERE NOT "isWinner" AND NOT "isDraw")        AS losses,
@@ -124,7 +130,7 @@ export async function GET(req: NextRequest) {
           1
         )::float                                                                 AS "winRate"
       FROM leaderboard_rows
-      GROUP BY "userId", username, "publicProfileId"
+      GROUP BY "userId", username, "publicProfileId", "avatarUrl", image
       HAVING COUNT("playerId") >= ${minGames}
       ORDER BY
         COUNT("playerId") FILTER (WHERE "isWinner" = true AND NOT "isDraw")::numeric
@@ -143,6 +149,7 @@ export async function GET(req: NextRequest) {
       userId: r.userId,
       username: r.username ?? 'Player',
       publicProfileId: r.publicProfileId ?? null,
+      avatarUrl: r.avatarUrl ?? r.image ?? null,
       gamesPlayed: Number(r.gamesPlayed),
       wins: Number(r.wins),
       losses: Number(r.losses),

--- a/app/api/lobby/[code]/route.ts
+++ b/app/api/lobby/[code]/route.ts
@@ -203,6 +203,8 @@ export async function GET(
                     id: true,
                     username: true,
                     isGuest: true,
+                    image: true,
+                    avatarUrl: true,
                     bot: {
                       select: {
                         difficulty: true,

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -65,11 +65,24 @@ function LeaderboardRow({ entry, isLast, t }: { entry: LeaderboardEntry; isLast:
         </span>
         <span className="text-xs font-bold uppercase tracking-[0.1em] text-bd-ink-muted md:hidden">{t('leaderboard.rank')}</span>
       </div>
-      <div className="min-w-0">
-        <span className="block truncate text-base font-bold text-bd-ink">{entry.username}</span>
-        {entry.publicProfileId && (
-          <span className="text-xs font-semibold text-bd-ink-muted">{t('leaderboard.viewProfile')}</span>
+      <div className="flex min-w-0 items-center gap-3">
+        {entry.avatarUrl ? (
+          <img
+            src={entry.avatarUrl}
+            alt={entry.username}
+            className="h-9 w-9 shrink-0 rounded-xl border-2 border-bd-ink object-cover shadow-[1px_1px_0_#1F1B16]"
+          />
+        ) : (
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border-2 border-bd-ink bg-bd-bg2 text-sm font-extrabold text-bd-ink-muted shadow-[1px_1px_0_#1F1B16]">
+            {entry.username.charAt(0).toUpperCase()}
+          </div>
         )}
+        <div className="min-w-0">
+          <span className="block truncate text-base font-bold text-bd-ink">{entry.username}</span>
+          {entry.publicProfileId && (
+            <span className="text-xs font-semibold text-bd-ink-muted">{t('leaderboard.viewProfile')}</span>
+          )}
+        </div>
       </div>
       <div className="grid grid-cols-2 gap-2 md:contents">
         <span className="rounded-xl bg-bd-bg2 px-3 py-2 text-left text-sm font-semibold text-bd-ink-soft md:bg-transparent md:p-0 md:text-right">

--- a/app/leaderboard/use-leaderboard.ts
+++ b/app/leaderboard/use-leaderboard.ts
@@ -8,6 +8,7 @@ export interface LeaderboardEntry {
   userId: string
   username: string
   publicProfileId: string | null
+  avatarUrl: string | null
   gamesPlayed: number
   wins: number
   losses: number

--- a/app/lobby/[code]/components/MemoryGameBoard.tsx
+++ b/app/lobby/[code]/components/MemoryGameBoard.tsx
@@ -20,6 +20,8 @@ interface LobbyPlayer {
     username?: string | null
     name?: string | null
     email?: string | null
+    image?: string | null
+    avatarUrl?: string | null
     bot?: unknown
   } | null
   name?: string | null
@@ -134,6 +136,14 @@ export default function MemoryGameBoard({
     }
     return result
   }, [players, parsedState.players])
+
+  const avatarByUserId = useMemo(() => {
+    const result = new Map<string, string | null>()
+    for (const player of players) {
+      result.set(player.userId, player.user?.avatarUrl ?? player.user?.image ?? null)
+    }
+    return result
+  }, [players])
 
   // Remove optimistic IDs once server state catches up (card appears in flippedCardIds or isFlipped)
   useEffect(() => {
@@ -454,9 +464,17 @@ export default function MemoryGameBoard({
                   const isCurrent = player.id === currentPlayerId
                   return (
                     <div key={player.id} className={`memory-score-row ${isCurrent ? 'memory-score-row-active' : ''}`}>
-                      <span className="bd-avatar bd-avatar-sun h-9 w-9">
-                        {(displayNameByUserId.get(player.id) || player.name || '?').charAt(0).toUpperCase()}
-                      </span>
+                      {avatarByUserId.get(player.id) ? (
+                        <img
+                          src={avatarByUserId.get(player.id)!}
+                          alt={displayNameByUserId.get(player.id) || '?'}
+                          className="h-9 w-9 shrink-0 rounded-xl border-2 border-bd-ink object-cover"
+                        />
+                      ) : (
+                        <span className="bd-avatar bd-avatar-sun h-9 w-9">
+                          {(displayNameByUserId.get(player.id) || player.name || '?').charAt(0).toUpperCase()}
+                        </span>
+                      )}
                       <div className="min-w-0 flex-1">
                         <p className="truncate font-bold">{displayNameByUserId.get(player.id) || player.name || t('games.memory.game.unknownPlayer')}</p>
                         <p className="text-xs font-semibold opacity-70">{t('games.memory.game.pairsLabel', { count: score })}</p>

--- a/app/lobby/[code]/components/SpyGameBoard.tsx
+++ b/app/lobby/[code]/components/SpyGameBoard.tsx
@@ -133,12 +133,13 @@ export default function SpyGameBoard({
         id: player.userId,
         name: player.user?.username || player.name || 'Player',
         score: player.score || 0,
+        avatarSrc: player.user?.avatarUrl ?? player.user?.image ?? null,
       })),
     [players]
   )
 
   const playersById = React.useMemo(() => {
-    const map = new Map<string, { id: string; name: string; score: number }>()
+    const map = new Map<string, { id: string; name: string; score: number; avatarSrc: string | null }>()
     for (const player of normalizedPlayers) {
       map.set(player.id, player)
     }
@@ -680,7 +681,11 @@ export default function SpyGameBoard({
                     const isCurrent = player.id === data.currentQuestionerId
                     return (
                       <div key={player.id} className={`spy-player-row ${isCurrent ? 'spy-player-row-active' : ''}`}>
-                        <span className="bd-avatar bd-avatar-sky h-8 w-8">{player.name.charAt(0).toUpperCase()}</span>
+                        {player.avatarSrc ? (
+                          <img src={player.avatarSrc} alt={player.name} className="h-8 w-8 shrink-0 rounded-xl border-2 border-bd-ink object-cover" />
+                        ) : (
+                          <span className="bd-avatar bd-avatar-sky h-8 w-8">{player.name.charAt(0).toUpperCase()}</span>
+                        )}
                         <span className="min-w-0 flex-1 truncate font-bold">{player.name}</span>
                         <span className="font-black">{scores[player.id] || 0}</span>
                       </div>

--- a/app/lobby/[code]/components/WaitingRoom.tsx
+++ b/app/lobby/[code]/components/WaitingRoom.tsx
@@ -39,6 +39,7 @@ export default function WaitingRoom({
         const isCurrentUser = p.userId === getCurrentUserId()
         const botDifficulty = p.user?.bot?.difficulty as BotDifficulty | undefined
         const difficultyLabel = botDifficulty ? t(`game.ui.botDifficulty${botDifficulty.charAt(0).toUpperCase() + botDifficulty.slice(1)}` as Parameters<typeof t>[0]) : null
+        const avatarSrc = p.user?.avatarUrl ?? p.user?.image ?? null
 
         const canClickProfile = onProfileClick && !isBot
 
@@ -55,9 +56,17 @@ export default function WaitingRoom({
                   : 'border-bd-line bg-white'
             } ${canClickProfile ? 'cursor-pointer transition-colors hover:border-bd-ink hover:bg-bd-card-warm' : ''}`}
           >
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border-2 border-bd-ink bg-bd-sun text-xs font-extrabold text-bd-ink shadow-[2px_2px_0_var(--bd-ink)]">
-              {index + 1}
-            </div>
+            {avatarSrc ? (
+              <img
+                src={avatarSrc}
+                alt={playerName}
+                className="h-8 w-8 shrink-0 rounded-xl border-2 border-bd-ink object-cover shadow-[2px_2px_0_var(--bd-ink)]"
+              />
+            ) : (
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border-2 border-bd-ink bg-bd-sun text-xs font-extrabold text-bd-ink shadow-[2px_2px_0_var(--bd-ink)]">
+                {index + 1}
+              </div>
+            )}
             <div className="flex-1 min-w-0 flex flex-wrap items-center gap-1.5">
               <span className="truncate text-sm font-bold text-bd-ink">{playerName}</span>
               {isCurrentUser && !isBot && (

--- a/app/lobby/[code]/connect-four-page.tsx
+++ b/app/lobby/[code]/connect-four-page.tsx
@@ -155,9 +155,9 @@ function C4Board({ board, winningLine, hoverCol, onColHover, onColClick, disable
     )
 }
 
-function C4PlayerCard({ name, disc, isActive, isWinner, wins, side, isLocalPlayer, t }: {
+function C4PlayerCard({ name, disc, isActive, isWinner, wins, side, isLocalPlayer, avatarSrc, t }: {
     name: string; disc: PlayerDisc; isActive: boolean; isWinner: boolean; wins: number; side: 'left' | 'right';
-    isLocalPlayer: boolean; t: (k: TranslationKeys) => string
+    isLocalPlayer: boolean; avatarSrc?: string | null; t: (k: TranslationKeys) => string
 }) {
     const discColor = disc === 1 ? DISC_RED : DISC_YELLOW
     return (
@@ -169,8 +169,14 @@ function C4PlayerCard({ name, disc, isActive, isWinner, wins, side, isLocalPlaye
             flexDirection: side === 'right' ? 'row-reverse' : 'row',
             transition: 'all 0.2s', minWidth: 0,
         }}>
-            {/* Avatar + disc badge — mirrors TttPlayerCard's avatar + symbol badge */}
+            {/* Avatar + disc badge */}
             <div style={{ position: 'relative', flexShrink: 0 }}>
+                {avatarSrc ? (
+                    <img src={avatarSrc} alt={name} style={{
+                        width: 42, height: 42, borderRadius: '50%', objectFit: 'cover',
+                        border: '2px solid white', boxShadow: '0 0 0 2px var(--bd-ink)',
+                    }} />
+                ) : (
                 <div style={{
                     width: 42, height: 42, borderRadius: '50%', background: discColor,
                     display: 'grid', placeItems: 'center', border: '2px solid white',
@@ -179,6 +185,7 @@ function C4PlayerCard({ name, disc, isActive, isWinner, wins, side, isLocalPlaye
                 }}>
                     {name.charAt(0).toUpperCase()}
                 </div>
+                )}
                 {/* Disc icon badge */}
                 <div style={{
                     position: 'absolute', bottom: -3, right: -3, width: 20, height: 20,
@@ -878,6 +885,12 @@ export default function ConnectFourLobbyPage({ code }: ConnectFourLobbyPageProps
 
     const p1Name = state.players[0] ? getDisplayName(state.players[0].id) : 'Player 1'
     const p2Name = state.players[1] ? getDisplayName(state.players[1].id) : 'Player 2'
+    const getPlayerAvatar = (userId: string): string | null => {
+        const p = players.find(lp => lp.userId === userId)
+        return p?.user?.avatarUrl ?? p?.user?.image ?? null
+    }
+    const p1Avatar = state.players[0] ? getPlayerAvatar(state.players[0].id) : null
+    const p2Avatar = state.players[1] ? getPlayerAvatar(state.players[1].id) : null
 
     const p1Wins = state.players[0]?.score ?? 0
     const p2Wins = state.players[1]?.score ?? 0
@@ -940,7 +953,7 @@ export default function ConnectFourLobbyPage({ code }: ConnectFourLobbyPageProps
     const headerSection = (
         <div className="ttt-card" style={{ background: 'linear-gradient(135deg, white 0%, rgba(255,196,77,0.08) 100%)', padding: '12px 16px', overflow: 'hidden' }}>
             <div style={{ position: 'relative', display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: 12 }}>
-                <C4PlayerCard name={p1Name} disc={1} isActive={!isFinished && gameData.currentDisc === 1} isWinner={!isDraw && winnerDisc === 1} wins={p1Wins} side="left" isLocalPlayer={myDisc === 1} t={t} />
+                <C4PlayerCard name={p1Name} disc={1} isActive={!isFinished && gameData.currentDisc === 1} isWinner={!isDraw && winnerDisc === 1} wins={p1Wins} side="left" isLocalPlayer={myDisc === 1} avatarSrc={p1Avatar} t={t} />
                 <div style={{ textAlign: 'center' }}>
                     <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 4 }}>
                         <GameIcon gameId="connect-four" accentColor={DISC_RED} size={18} />
@@ -952,7 +965,7 @@ export default function ConnectFourLobbyPage({ code }: ConnectFourLobbyPageProps
                         wins
                     </div>
                 </div>
-                <C4PlayerCard name={p2Name} disc={2} isActive={!isFinished && gameData.currentDisc === 2} isWinner={!isDraw && winnerDisc === 2} wins={p2Wins} side="right" isLocalPlayer={myDisc === 2} t={t} />
+                <C4PlayerCard name={p2Name} disc={2} isActive={!isFinished && gameData.currentDisc === 2} isWinner={!isDraw && winnerDisc === 2} wins={p2Wins} side="right" isLocalPlayer={myDisc === 2} avatarSrc={p2Avatar} t={t} />
             </div>
         </div>
     )

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -99,8 +99,8 @@ function TttBoard({ board, winningLine, onCellClick, disabled, testId }: {
     )
 }
 
-function TttPlayerCard({ name, symbol, isActive, isWinner, side, t }: {
-    name: string; symbol: 'X' | 'O'; isActive: boolean; isWinner: boolean; side: 'left' | 'right'; t: (key: TranslationKeys) => string
+function TttPlayerCard({ name, symbol, isActive, isWinner, side, avatarSrc, t }: {
+    name: string; symbol: 'X' | 'O'; isActive: boolean; isWinner: boolean; side: 'left' | 'right'; avatarSrc?: string | null; t: (key: TranslationKeys) => string
 }) {
     const bg = symbol === 'X' ? 'var(--bd-coral)' : 'var(--bd-lav)'
     return (
@@ -113,6 +113,12 @@ function TttPlayerCard({ name, symbol, isActive, isWinner, side, t }: {
             transition: 'all 0.2s', minWidth: 0,
         }}>
             <div style={{ position: 'relative', flexShrink: 0 }}>
+                {avatarSrc ? (
+                    <img src={avatarSrc} alt={name} style={{
+                        width: 42, height: 42, borderRadius: '50%', objectFit: 'cover',
+                        border: '2px solid white', boxShadow: '0 0 0 2px var(--bd-ink)',
+                    }} />
+                ) : (
                 <div style={{
                     width: 42, height: 42, borderRadius: '50%', background: bg,
                     display: 'grid', placeItems: 'center', border: '2px solid white',
@@ -121,6 +127,7 @@ function TttPlayerCard({ name, symbol, isActive, isWinner, side, t }: {
                 }}>
                     {name.charAt(0).toUpperCase()}
                 </div>
+                )}
                 <div style={{
                     position: 'absolute', bottom: -3, right: -3, width: 22, height: 22, borderRadius: 7,
                     background: 'white', border: '2px solid var(--bd-ink)', display: 'grid', placeItems: 'center',
@@ -900,6 +907,12 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
     }
     const xName = state.players[0] ? getDisplayName(state.players[0].id) : 'Player X'
     const oName = state.players[1] ? getDisplayName(state.players[1].id) : 'Player O'
+    const getPlayerAvatar = (userId: string): string | null => {
+        const p = players.find(lp => lp.userId === userId)
+        return p?.user?.avatarUrl ?? p?.user?.image ?? null
+    }
+    const xAvatar = state.players[0] ? getPlayerAvatar(state.players[0].id) : null
+    const oAvatar = state.players[1] ? getPlayerAvatar(state.players[1].id) : null
 
     const winnerSymbol = gameData.winner
     const isDraw = winnerSymbol === 'draw'
@@ -975,7 +988,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
                 <TttBgGrid />
             </div>
             <div style={{ position: 'relative', display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: 16 }}>
-                <TttPlayerCard name={xName} symbol="X" isActive={!isFinished && gameData.currentSymbol === 'X'} isWinner={!isDraw && winnerSymbol === 'X'} side="left" t={t} />
+                <TttPlayerCard name={xName} symbol="X" isActive={!isFinished && gameData.currentSymbol === 'X'} isWinner={!isDraw && winnerSymbol === 'X'} side="left" avatarSrc={xAvatar} t={t} />
                 <div style={{ textAlign: 'center' }}>
                     <div style={{ fontSize: 10, color: 'var(--bd-ink-muted)', textTransform: 'uppercase', letterSpacing: '0.1em', fontFamily: 'ui-monospace,monospace', marginBottom: 2 }}>
                         Round {roundNum}
@@ -987,7 +1000,7 @@ export default function TicTacToeLobbyPage({ code }: TicTacToeLobbyPageProps) {
                         {drawsCount} draws{targetRounds ? ` · BO${targetRounds}` : ''}
                     </div>
                 </div>
-                <TttPlayerCard name={oName} symbol="O" isActive={!isFinished && gameData.currentSymbol === 'O'} isWinner={!isDraw && winnerSymbol === 'O'} side="right" t={t} />
+                <TttPlayerCard name={oName} symbol="O" isActive={!isFinished && gameData.currentSymbol === 'O'} isWinner={!isDraw && winnerSymbol === 'O'} side="right" avatarSrc={oAvatar} t={t} />
             </div>
         </div>
     )

--- a/lib/lobby-response.ts
+++ b/lib/lobby-response.ts
@@ -3,6 +3,8 @@ interface RawLobbyUserLike {
   username?: unknown
   isGuest?: unknown
   isBot?: unknown
+  image?: unknown
+  avatarUrl?: unknown
   bot?: {
     difficulty?: unknown
   } | null
@@ -18,6 +20,8 @@ export interface LobbyApiUserIdentity {
   username: string
   isGuest: boolean
   isBot: boolean
+  image: string | null
+  avatarUrl: string | null
   bot: { difficulty?: string } | null
 }
 
@@ -42,7 +46,8 @@ export function sanitizeLobbyUserIdentity(user: unknown): LobbyApiUserIdentity |
     username: typeof rawUser.username === 'string' && rawUser.username.trim().length > 0 ? rawUser.username : 'Player',
     isGuest: rawUser.isGuest === true,
     isBot,
-    // Keep compact legacy-compatible bot shape for existing client checks.
+    image: typeof rawUser.image === 'string' ? rawUser.image : null,
+    avatarUrl: typeof rawUser.avatarUrl === 'string' ? rawUser.avatarUrl : null,
     bot: isBot ? (botDifficulty ? { difficulty: botDifficulty } : {}) : null,
   }
 }

--- a/types/game.ts
+++ b/types/game.ts
@@ -27,6 +27,8 @@ export interface GamePlayer {
     id: string
     username: string
     email?: string
+    image?: string | null
+    avatarUrl?: string | null
     bot?: {
       id: string
       userId: string


### PR DESCRIPTION
## Summary
- Adds `image` and `avatarUrl` to the user select in the lobby API route so player avatar data is included in game snapshots
- Extends `GamePlayer.user` type with `image` and `avatarUrl` fields
- **WaitingRoom**: shows player avatar image instead of position number; falls back to numbered box for bots/guests without an avatar
- **Leaderboard**: adds `avatarUrl` to raw SQL query, `LeaderboardEntry` type, and row UI — shows avatar or initial-letter fallback

## Bug fixes
- `sanitizeLobbyUserIdentity` was stripping `image`/`avatarUrl` before they reached the client — fixed in `lib/lobby-response.ts`
- `game/create` route response omitted `image`/`avatarUrl` from `player.user` — now included
- **TicTacToe**: `TttPlayerCard` now shows avatar image when available, falls back to initial
- **Connect Four**: `C4PlayerCard` same fix
- **Memory**: builds `avatarByUserId` map and shows avatar in scoreboard
- **Spy**: includes `avatarSrc` in `normalizedPlayers`, shows in player list

## Test plan
- [ ] Join a lobby waiting room — players with avatars show their avatar, bots/guests show a number
- [ ] Start a TicTacToe or Connect Four game — avatar appears in the player header card
- [ ] Start a Memory or Spy game — avatar appears in the scoreboard
- [ ] Check leaderboard — rows with avatars show the image, rows without show a letter fallback
- [ ] Verify CI passes