### PR TITLE
#480 feat: UserPurchases table for avatar pack purchases

### DIFF
--- a/prisma/migrations/20260510000000_add_user_purchases/migration.sql
+++ b/prisma/migrations/20260510000000_add_user_purchases/migration.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "public"."UserPurchases" (
+    "id"              TEXT NOT NULL,
+    "userId"          TEXT NOT NULL,
+    "packId"          TEXT NOT NULL,
+    "price"           INTEGER NOT NULL,
+    "stripePaymentId" TEXT,
+    "createdAt"       TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserPurchases_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "UserPurchases_stripePaymentId_key" ON "public"."UserPurchases"("stripePaymentId");
+CREATE UNIQUE INDEX "UserPurchases_userId_packId_key"   ON "public"."UserPurchases"("userId", "packId");
+CREATE INDEX "UserPurchases_userId_idx"                 ON "public"."UserPurchases"("userId");
+
+ALTER TABLE "public"."UserPurchases"
+    ADD CONSTRAINT "UserPurchases_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "public"."Users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Users {
   receivedLobbyInvites    LobbyInvites[]           @relation("LobbyInvitesReceived")
   adminAuditLogs          AdminAuditLogs[]         @relation("AdminAuditLogsActor")
   accountPreferences      AccountPreferences?
+  purchases               UserPurchases[]
   notificationPreferences NotificationPreferences?
   notifications           Notifications[]
   feedback                Feedback[]
@@ -461,5 +462,19 @@ model Feedback {
   createdAt DateTime @default(now()) @db.Timestamptz(3)
 
   @@index([type, createdAt])
+  @@index([userId])
+}
+
+model UserPurchases {
+  id               String   @id @default(cuid())
+  userId           String
+  packId           String   // e.g. "premium-pack-1"
+  price            Int      // in cents
+  stripePaymentId  String?  @unique
+  createdAt        DateTime @default(now()) @db.Timestamptz(3)
+
+  user Users @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, packId])
   @@index([userId])
 }


### PR DESCRIPTION
## Summary
- Adds `UserPurchases` model to `prisma/schema.prisma`
- Migration creates `UserPurchases` table with `userId`, `packId`, `price`, `stripePaymentId`, `createdAt`
- Unique constraint on `(userId, packId)` prevents duplicate purchases
- Unique constraint on `stripePaymentId` for idempotent webhook handling

## Test plan
- [ ] Migration applies cleanly (`npm run db:migrate`)
- [ ] Prisma client generates without errors
- [ ] CI passes