### PR TITLE
#481 feat: premium avatar pack with locked state in picker

### DIFF
--- a/app/api/user/avatar/route.ts
+++ b/app/api/user/avatar/route.ts
@@ -12,12 +12,25 @@ const limiter = rateLimit(rateLimitPresets.api)
 const DEFAULT_AVATAR_IDS = [1, 2, 3, 4, 5, 6, 7, 8] as const
 type DefaultAvatarId = (typeof DEFAULT_AVATAR_IDS)[number]
 
+const PREMIUM_AVATAR_IDS = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'] as const
+type PremiumAvatarId = (typeof PREMIUM_AVATAR_IDS)[number]
+
+const PREMIUM_PACK_ID = 'premium-pack-1'
+
 function isDefaultAvatarId(id: unknown): id is DefaultAvatarId {
   return DEFAULT_AVATAR_IDS.includes(id as DefaultAvatarId)
 }
 
+function isPremiumAvatarId(id: unknown): id is PremiumAvatarId {
+  return PREMIUM_AVATAR_IDS.includes(id as PremiumAvatarId)
+}
+
 function defaultAvatarUrl(id: DefaultAvatarId): string {
   return `/avatars/defaults/avatar-${id}.svg`
+}
+
+function premiumAvatarUrl(id: PremiumAvatarId): string {
+  return `/avatars/premium/avatar-${id}.svg`
 }
 
 // POST — select default avatar or upload custom
@@ -32,10 +45,24 @@ export async function POST(request: NextRequest) {
 
   const contentType = request.headers.get('content-type') ?? ''
 
-  // --- Default avatar selection ---
+  // --- Default or premium avatar selection ---
   if (contentType.includes('application/json')) {
     const body = await request.json()
     const { avatarId } = body
+
+    if (isPremiumAvatarId(avatarId)) {
+      const purchase = await prisma.userPurchases.findUnique({
+        where: { userId_packId: { userId: session.user.id, packId: PREMIUM_PACK_ID } },
+        select: { id: true },
+      })
+      if (!purchase) {
+        return NextResponse.json({ error: 'Premium pack not purchased' }, { status: 403 })
+      }
+      const avatarUrl = premiumAvatarUrl(avatarId)
+      await prisma.users.update({ where: { id: session.user.id }, data: { avatarUrl } })
+      log.info('Premium avatar selected', { userId: session.user.id, avatarId })
+      return NextResponse.json({ avatarUrl })
+    }
 
     if (!isDefaultAvatarId(avatarId)) {
       return NextResponse.json({ error: 'Invalid avatar ID' }, { status: 400 })

--- a/app/api/user/purchases/route.ts
+++ b/app/api/user/purchases/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getRequestAuthUser } from '@/lib/request-auth'
+import { prisma } from '@/lib/db'
+
+export async function GET(req: NextRequest) {
+  const user = await getRequestAuthUser(req)
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const purchases = await prisma.userPurchases.findMany({
+    where: { userId: user.id },
+    select: { packId: true },
+  })
+
+  return NextResponse.json({ purchases: purchases.map((p) => p.packId) })
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -160,6 +160,7 @@ export default function ProfilePage() {
   const [linkedAccounts, setLinkedAccounts] = useState<LinkedAccounts>({})
   const [loadingLinkedAccounts, setLoadingLinkedAccounts] = useState(true)
   const [profileSummary, setProfileSummary] = useState<ProfileSummary | null>(null)
+  const [hasPremiumPack, setHasPremiumPack] = useState(false)
   const [showPublicProfilePreview, setShowPublicProfilePreview] = useState(false)
   const [publicProfilePreviewTransitionPhase, setPublicProfilePreviewTransitionPhase] =
     useState<PublicProfilePreviewTransitionPhase>('idle')
@@ -250,14 +251,21 @@ export default function ProfilePage() {
   )
 
   const fetchProfileSummary = useCallback(async () => {
-    const res = await fetch('/api/user/profile', { cache: 'no-store' })
-    const data = await res.json()
+    const [profileRes, purchasesRes] = await Promise.all([
+      fetch('/api/user/profile', { cache: 'no-store' }),
+      fetch('/api/user/purchases', { cache: 'no-store' }),
+    ])
+    const data = await profileRes.json()
 
-    if (!res.ok) {
+    if (!profileRes.ok) {
       throw new Error(data.error || t('profile.errors.loadFailed'))
     }
 
     setProfileSummary(data.user)
+    if (purchasesRes.ok) {
+      const purchasesData = await purchasesRes.json()
+      setHasPremiumPack((purchasesData.purchases as string[]).includes('premium-pack-1'))
+    }
     return data.user as ProfileSummary
   }, [t])
 
@@ -1743,9 +1751,13 @@ export default function ProfilePage() {
                     currentImage={profileSummary?.image ?? null}
                     username={profileSummary?.username ?? null}
                     email={profileSummary?.email ?? null}
+                    hasPremiumPack={hasPremiumPack}
                     onSaved={(avatarUrl) =>
                       setProfileSummary((prev) => prev ? { ...prev, avatarUrl } : prev)
                     }
+                    onUnlockPremium={() => {
+                      showToast.error('errors.generic', 'Stripe checkout coming soon!')
+                    }}
                   />
                 </div>
 

--- a/components/AvatarPicker.tsx
+++ b/components/AvatarPicker.tsx
@@ -6,13 +6,18 @@ import { UserAvatar } from '@/components/Header/UserAvatar'
 import { showToast } from '@/lib/i18n-toast'
 
 const DEFAULT_AVATARS = [1, 2, 3, 4, 5, 6, 7, 8] as const
+const PREMIUM_AVATARS = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'] as const
+export const PREMIUM_PACK_ID = 'premium-pack-1'
+export const PREMIUM_PACK_PRICE = '$2.99'
 
 type AvatarPickerProps = {
   currentAvatarUrl: string | null
   currentImage: string | null
   username: string | null
   email: string | null
+  hasPremiumPack: boolean
   onSaved: (avatarUrl: string | null) => void
+  onUnlockPremium?: () => void
 }
 
 export default function AvatarPicker({
@@ -20,7 +25,9 @@ export default function AvatarPicker({
   currentImage,
   username,
   email,
+  hasPremiumPack,
   onSaved,
+  onUnlockPremium,
 }: AvatarPickerProps) {
   const [saving, setSaving] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -28,7 +35,7 @@ export default function AvatarPicker({
 
   const displayAvatar = currentAvatarUrl || currentImage
 
-  async function selectDefault(avatarId: number) {
+  async function selectAvatar(avatarId: number | string) {
     setSaving(true)
     try {
       const res = await fetch('/api/user/avatar', {
@@ -120,7 +127,7 @@ export default function AvatarPicker({
       {/* Default avatar grid */}
       <div>
         <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-          Default avatars
+          Free avatars
         </p>
         <div className="flex flex-wrap gap-2">
           {DEFAULT_AVATARS.map((id) => {
@@ -129,7 +136,7 @@ export default function AvatarPicker({
             return (
               <button
                 key={id}
-                onClick={() => selectDefault(id)}
+                onClick={() => selectAvatar(id)}
                 disabled={saving}
                 className={`h-12 w-12 overflow-hidden rounded-full border-2 transition-all hover:scale-105 disabled:opacity-50 ${
                   isSelected
@@ -143,6 +150,68 @@ export default function AvatarPicker({
               </button>
             )
           })}
+        </div>
+      </div>
+
+      {/* Premium avatar grid */}
+      <div>
+        <div className="mb-2 flex items-center gap-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Premium avatars
+          </p>
+          {hasPremiumPack ? (
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-bold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+              UNLOCKED
+            </span>
+          ) : (
+            <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold text-slate-500 dark:bg-slate-700 dark:text-slate-400">
+              {PREMIUM_PACK_PRICE}
+            </span>
+          )}
+        </div>
+
+        <div className="relative">
+          <div className={`flex flex-wrap gap-2 ${!hasPremiumPack ? 'pointer-events-none' : ''}`}>
+            {PREMIUM_AVATARS.map((id) => {
+              const url = `/avatars/premium/avatar-${id}.svg`
+              const isSelected = currentAvatarUrl === url
+              return (
+                <button
+                  key={id}
+                  onClick={() => selectAvatar(id)}
+                  disabled={saving || !hasPremiumPack}
+                  className={`relative h-12 w-12 overflow-hidden rounded-full border-2 transition-all ${
+                    hasPremiumPack
+                      ? `hover:scale-105 disabled:opacity-50 ${
+                          isSelected
+                            ? 'border-amber-500 shadow-[0_0_0_2px_#f59e0b]'
+                            : 'border-transparent hover:border-amber-300'
+                        }`
+                      : 'border-transparent opacity-50'
+                  }`}
+                  aria-label={`Premium avatar ${id}`}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={url} alt={`Premium avatar ${id}`} className="h-full w-full" />
+                </button>
+              )
+            })}
+          </div>
+
+          {/* Locked overlay */}
+          {!hasPremiumPack && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center rounded-xl bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
+              <span className="text-xl">🔒</span>
+              <p className="mt-1 text-xs font-semibold text-bd-ink dark:text-white">Premium Pack</p>
+              <button
+                type="button"
+                onClick={onUnlockPremium}
+                className="mt-2 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm transition hover:bg-amber-600 active:scale-95"
+              >
+                Unlock for {PREMIUM_PACK_PRICE}
+              </button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/public/avatars/premium/avatar-p1.svg
+++ b/public/avatars/premium/avatar-p1.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#ef4444"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="50" fill="url(#g)"/>
+  <!-- Dragon -->
+  <!-- Body -->
+  <ellipse cx="50" cy="58" rx="18" ry="14" fill="white" opacity="0.95"/>
+  <!-- Head -->
+  <circle cx="50" cy="38" r="13" fill="white" opacity="0.95"/>
+  <!-- Snout -->
+  <ellipse cx="50" cy="44" rx="6" ry="4" fill="white" opacity="0.95"/>
+  <!-- Left wing -->
+  <path d="M32 52 Q18 38 22 26 Q30 42 36 48 Z" fill="white" opacity="0.85"/>
+  <!-- Right wing -->
+  <path d="M68 52 Q82 38 78 26 Q70 42 64 48 Z" fill="white" opacity="0.85"/>
+  <!-- Eyes -->
+  <circle cx="45" cy="35" r="2.5" fill="#ef4444" opacity="0.8"/>
+  <circle cx="55" cy="35" r="2.5" fill="#ef4444" opacity="0.8"/>
+  <!-- Nostrils -->
+  <circle cx="47.5" cy="44" r="1" fill="#f59e0b" opacity="0.7"/>
+  <circle cx="52.5" cy="44" r="1" fill="#f59e0b" opacity="0.7"/>
+  <!-- Tail -->
+  <path d="M62 66 Q72 72 68 80 Q64 74 60 72 Z" fill="white" opacity="0.85"/>
+</svg>

--- a/public/avatars/premium/avatar-p2.svg
+++ b/public/avatars/premium/avatar-p2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="50" fill="url(#g)"/>
+  <!-- Rocket -->
+  <!-- Body -->
+  <path d="M50 18 Q60 28 62 50 L50 56 L38 50 Q40 28 50 18 Z" fill="white" opacity="0.95"/>
+  <!-- Nose cone tip -->
+  <circle cx="50" cy="18" r="3" fill="white" opacity="0.95"/>
+  <!-- Left fin -->
+  <path d="M38 50 L28 66 L40 60 Z" fill="white" opacity="0.85"/>
+  <!-- Right fin -->
+  <path d="M62 50 L72 66 L60 60 Z" fill="white" opacity="0.85"/>
+  <!-- Window -->
+  <circle cx="50" cy="40" r="7" fill="#06b6d4" opacity="0.4"/>
+  <circle cx="50" cy="40" r="5" fill="white" opacity="0.2"/>
+  <!-- Flame -->
+  <path d="M44 60 Q50 75 56 60 Q53 68 50 72 Q47 68 44 60 Z" fill="#f59e0b" opacity="0.9"/>
+  <path d="M46 60 Q50 70 54 60 Q52 65 50 68 Q48 65 46 60 Z" fill="white" opacity="0.8"/>
+</svg>

--- a/public/avatars/premium/avatar-p3.svg
+++ b/public/avatars/premium/avatar-p3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10b981"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="50" fill="url(#g)"/>
+  <!-- Skull (gaming/skull icon) -->
+  <!-- Head -->
+  <path d="M26 48 Q26 26 50 26 Q74 26 74 48 Q74 62 66 66 L66 74 L34 74 L34 66 Q26 62 26 48 Z" fill="white" opacity="0.95"/>
+  <!-- Eyes -->
+  <ellipse cx="40" cy="46" rx="7" ry="8" fill="#10b981" opacity="0.5"/>
+  <ellipse cx="60" cy="46" rx="7" ry="8" fill="#10b981" opacity="0.5"/>
+  <circle cx="40" cy="46" r="4" fill="#1a1a2e" opacity="0.8"/>
+  <circle cx="60" cy="46" r="4" fill="#1a1a2e" opacity="0.8"/>
+  <!-- Nose -->
+  <path d="M47 56 L50 60 L53 56 Z" fill="#10b981" opacity="0.4"/>
+  <!-- Teeth -->
+  <rect x="36" y="66" width="6" height="8" rx="1" fill="#10b981" opacity="0.3"/>
+  <rect x="47" y="66" width="6" height="8" rx="1" fill="#10b981" opacity="0.3"/>
+  <rect x="58" y="66" width="6" height="8" rx="1" fill="#10b981" opacity="0.3"/>
+</svg>

--- a/public/avatars/premium/avatar-p4.svg
+++ b/public/avatars/premium/avatar-p4.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="50" fill="url(#g)"/>
+  <!-- Wizard hat + face -->
+  <!-- Hat brim -->
+  <ellipse cx="50" cy="46" rx="24" ry="6" fill="white" opacity="0.95"/>
+  <!-- Hat body -->
+  <path d="M36 46 Q40 20 50 14 Q60 20 64 46 Z" fill="white" opacity="0.95"/>
+  <!-- Hat star -->
+  <polygon points="50,22 51.5,27 56.5,27 52.5,30 54,35 50,32 46,35 47.5,30 43.5,27 48.5,27" fill="#ec4899" opacity="0.6"/>
+  <!-- Face -->
+  <circle cx="50" cy="60" r="16" fill="white" opacity="0.95"/>
+  <!-- Eyes -->
+  <circle cx="44" cy="58" r="3" fill="#8b5cf6" opacity="0.7"/>
+  <circle cx="56" cy="58" r="3" fill="#8b5cf6" opacity="0.7"/>
+  <!-- Smile -->
+  <path d="M43 65 Q50 71 57 65" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
+  <!-- Beard -->
+  <path d="M38 70 Q42 78 50 76 Q58 78 62 70" fill="white" opacity="0.8"/>
+</svg>

--- a/public/avatars/premium/avatar-p5.svg
+++ b/public/avatars/premium/avatar-p5.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e40af"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="50" fill="url(#g)"/>
+  <!-- Ninja/Mask -->
+  <!-- Head wrap -->
+  <circle cx="50" cy="45" r="22" fill="white" opacity="0.15"/>
+  <!-- Face mask - top half -->
+  <path d="M28 40 Q28 25 50 25 Q72 25 72 40 L72 48 Q72 54 50 54 Q28 54 28 48 Z" fill="white" opacity="0.95"/>
+  <!-- Eyes slit -->
+  <rect x="33" y="40" width="34" height="6" rx="3" fill="#0f172a" opacity="0.15"/>
+  <!-- Left eye glow -->
+  <ellipse cx="42" cy="43" rx="5" ry="3" fill="#3b82f6" opacity="0.8"/>
+  <ellipse cx="42" cy="43" rx="3" ry="2" fill="white" opacity="0.9"/>
+  <!-- Right eye glow -->
+  <ellipse cx="58" cy="43" rx="5" ry="3" fill="#3b82f6" opacity="0.8"/>
+  <ellipse cx="58" cy="43" rx="3" ry="2" fill="white" opacity="0.9"/>
+  <!-- Lower face wrap -->
+  <path d="M28 48 Q28 70 50 72 Q72 70 72 48 L72 54 Q72 74 50 76 Q28 74 28 54 Z" fill="white" opacity="0.85"/>
+  <!-- Headband knot -->
+  <circle cx="82" cy="36" r="6" fill="white" opacity="0.9"/>
+  <path d="M76 36 Q80 28 82 30 Q84 28 88 36" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/public/avatars/premium/avatar-p6.svg
+++ b/public/avatars/premium/avatar-p6.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#dc2626"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="50" fill="url(#g)"/>
+  <!-- Viking helmet -->
+  <!-- Helmet dome -->
+  <path d="M22 50 Q22 24 50 24 Q78 24 78 50 L74 54 L26 54 Z" fill="white" opacity="0.95"/>
+  <!-- Nose guard -->
+  <rect x="47" y="48" width="6" height="18" rx="3" fill="white" opacity="0.9"/>
+  <!-- Left horn -->
+  <path d="M26 38 Q10 24 14 14 Q20 28 28 34 Z" fill="white" opacity="0.9"/>
+  <!-- Right horn -->
+  <path d="M74 38 Q90 24 86 14 Q80 28 72 34 Z" fill="white" opacity="0.9"/>
+  <!-- Visor band -->
+  <rect x="22" y="48" width="56" height="8" rx="4" fill="white" opacity="0.7"/>
+  <!-- Eyes visible through visor -->
+  <circle cx="39" cy="52" r="3" fill="#dc2626" opacity="0.5"/>
+  <circle cx="61" cy="52" r="3" fill="#dc2626" opacity="0.5"/>
+  <!-- Cheek guards -->
+  <path d="M22 54 L22 72 Q26 76 34 74 L34 54 Z" fill="white" opacity="0.8"/>
+  <path d="M78 54 L78 72 Q74 76 66 74 L66 54 Z" fill="white" opacity="0.8"/>
+</svg>

--- a/public/avatars/premium/avatar-p7.svg
+++ b/public/avatars/premium/avatar-p7.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d9488"/>
+      <stop offset="100%" stop-color="#065f46"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="50" fill="url(#g)"/>
+  <!-- Alien -->
+  <!-- Head (large oval) -->
+  <ellipse cx="50" cy="42" rx="26" ry="30" fill="white" opacity="0.95"/>
+  <!-- Large eyes -->
+  <ellipse cx="40" cy="38" rx="9" ry="11" fill="#0d9488" opacity="0.5"/>
+  <ellipse cx="60" cy="38" rx="9" ry="11" fill="#0d9488" opacity="0.5"/>
+  <ellipse cx="40" cy="38" rx="6" ry="8" fill="#065f46" opacity="0.7"/>
+  <ellipse cx="60" cy="38" rx="6" ry="8" fill="#065f46" opacity="0.7"/>
+  <circle cx="40" cy="36" r="2" fill="white" opacity="0.6"/>
+  <circle cx="60" cy="36" r="2" fill="white" opacity="0.6"/>
+  <!-- Small mouth -->
+  <path d="M44 56 Q50 60 56 56" fill="none" stroke="#0d9488" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <!-- Antenna left -->
+  <line x1="38" y1="14" x2="34" y2="6" stroke="white" stroke-width="2" stroke-linecap="round" opacity="0.9"/>
+  <circle cx="33" cy="5" r="3" fill="white" opacity="0.9"/>
+  <!-- Antenna right -->
+  <line x1="62" y1="14" x2="66" y2="6" stroke="white" stroke-width="2" stroke-linecap="round" opacity="0.9"/>
+  <circle cx="67" cy="5" r="3" fill="white" opacity="0.9"/>
+</svg>

--- a/public/avatars/premium/avatar-p8.svg
+++ b/public/avatars/premium/avatar-p8.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#d97706"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="50" fill="url(#g)"/>
+  <!-- Robot -->
+  <!-- Head box -->
+  <rect x="30" y="24" width="40" height="36" rx="6" fill="white" opacity="0.95"/>
+  <!-- Antenna -->
+  <rect x="48" y="16" width="4" height="10" rx="2" fill="white" opacity="0.9"/>
+  <circle cx="50" cy="15" r="4" fill="white" opacity="0.9"/>
+  <!-- Eyes (screens) -->
+  <rect x="35" y="32" width="12" height="10" rx="3" fill="#f59e0b" opacity="0.4"/>
+  <rect x="53" y="32" width="12" height="10" rx="3" fill="#f59e0b" opacity="0.4"/>
+  <circle cx="41" cy="37" r="3" fill="#d97706" opacity="0.8"/>
+  <circle cx="59" cy="37" r="3" fill="#d97706" opacity="0.8"/>
+  <!-- Mouth panel -->
+  <rect x="36" y="48" width="28" height="6" rx="3" fill="#f59e0b" opacity="0.3"/>
+  <rect x="38" y="50" width="4" height="2" rx="1" fill="#d97706" opacity="0.7"/>
+  <rect x="44" y="50" width="4" height="2" rx="1" fill="#d97706" opacity="0.7"/>
+  <rect x="50" y="50" width="4" height="2" rx="1" fill="#d97706" opacity="0.7"/>
+  <rect x="56" y="50" width="4" height="2" rx="1" fill="#d97706" opacity="0.7"/>
+  <!-- Body -->
+  <rect x="34" y="62" width="32" height="20" rx="6" fill="white" opacity="0.9"/>
+  <!-- Chest button -->
+  <circle cx="50" cy="72" r="5" fill="#f59e0b" opacity="0.5"/>
+</svg>


### PR DESCRIPTION
## Summary
- 8 premium SVG avatars in `public/avatars/premium/` (dragon, rocket, skull, wizard, ninja, viking, alien, robot)
- `AvatarPicker` now shows a **Premium avatars** section with locked overlay if user hasn't purchased
- Locked state shows avatar previews blurred behind a 🔒 overlay with \"Unlock for \$2.99\" CTA
- Unlocked state (after purchase) shows avatars selectable with amber highlight
- `GET /api/user/purchases` — returns list of purchased pack IDs for the current user
- `POST /api/user/avatar` — now also handles premium avatar IDs (`p1`–`p8`) with purchase gate
- Profile page fetches purchases on load alongside profile data

## Test plan
- [ ] Profile → Avatar section shows 8 free + 8 premium (locked) avatars
- [ ] Clicking \"Unlock\" shows \"coming soon\" toast (Stripe wired in #482)
- [ ] `GET /api/user/purchases` returns `{ purchases: [] }` for user without purchase
- [ ] Selecting a premium avatar without purchase returns 403
- [ ] CI passes