### PR TITLE
#491–#499 feat: premium features sprint — gates, limits, themes, profile customization

### DIFF
--- a/app/api/game/[gameId]/replay/route.ts
+++ b/app/api/game/[gameId]/replay/route.ts
@@ -25,6 +25,13 @@ export async function GET(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
+    const dbUser = await prisma.users.findUnique({ where: { id: userId }, select: { premiumUntil: true } })
+    const isPremium = !!dbUser?.premiumUntil && dbUser.premiumUntil > new Date()
+
+    if (!isPremium) {
+      return NextResponse.json({ error: 'Premium required to access replays' }, { status: 403 })
+    }
+
     const { gameId } = await params
     const game = await prisma.games.findUnique({
       where: { id: gameId },

--- a/app/api/lobby/route.ts
+++ b/app/api/lobby/route.ts
@@ -20,7 +20,7 @@ const log = apiLogger('/api/lobby')
 const createLobbySchema = z.object({
   name: z.string().trim().max(50).optional().default(''),
   password: z.string().optional(),
-  maxPlayers: z.number().min(2).max(10).default(6),
+  maxPlayers: z.number().min(2).max(16).default(6),
   allowSpectators: z.boolean().default(false),
   turnTimer: z.number().int().min(30).max(180).default(60), // Turn time in seconds (30-180)
   gameType: z.string().default('yahtzee'),
@@ -29,6 +29,7 @@ const createLobbySchema = z.object({
 })
 
 const createLimiter = rateLimit(rateLimitPresets.lobbyCreation)
+const createLimiterPremium = rateLimit(rateLimitPresets.lobbyCreationPremium)
 const WAITING_LOBBY_STALE_MS = 60 * 60 * 1000
 const NUMERIC_LOBBY_CODE_ATTEMPTS_BEFORE_FALLBACK = 10
 const MAX_LOBBY_CODE_ATTEMPTS = 20
@@ -52,15 +53,11 @@ function isLobbyCodeConflict(error: unknown): boolean {
   return false
 }
 
+const FREE_MAX_PLAYERS = 10
+
 export async function POST(request: NextRequest) {
   if (!verifyCsrfToken(request)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  // Apply rate limiting for lobby creation
-  const rateLimitResult = await createLimiter(request)
-  if (rateLimitResult) {
-    return rateLimitResult
   }
 
   try {
@@ -74,6 +71,22 @@ export async function POST(request: NextRequest) {
         guestId: requestUser.id,
         guestName: requestUser.username,
       })
+    }
+
+    // Single premium check — used for rate limit tier + all premium gates below
+    let isPremium = false
+    if (!requestUser.isGuest) {
+      const dbUser = await prisma.users.findUnique({
+        where: { id: requestUser.id },
+        select: { premiumUntil: true },
+      })
+      isPremium = !!dbUser?.premiumUntil && dbUser.premiumUntil > new Date()
+    }
+
+    // Apply tier-appropriate rate limit
+    const rateLimitResult = await (isPremium ? createLimiterPremium : createLimiter)(request)
+    if (rateLimitResult) {
+      return rateLimitResult
     }
 
     const body = await request.json()
@@ -96,18 +109,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unsupported game type' }, { status: 400 })
     }
 
-    if (allowSpectators) {
-      if (requestUser.isGuest) {
-        return NextResponse.json({ error: 'Premium required to enable spectators' }, { status: 403 })
-      }
-      const dbUser = await prisma.users.findUnique({
-        where: { id: requestUser.id },
-        select: { premiumUntil: true },
-      })
-      const isPremium = !!dbUser?.premiumUntil && dbUser.premiumUntil > new Date()
-      if (!isPremium) {
-        return NextResponse.json({ error: 'Premium required to enable spectators' }, { status: 403 })
-      }
+    if (allowSpectators && !isPremium) {
+      return NextResponse.json({ error: 'Premium required to enable spectators' }, { status: 403 })
+    }
+
+    if (maxPlayers > FREE_MAX_PLAYERS && !isPremium) {
+      return NextResponse.json({ error: 'Premium required to increase player limit beyond 10' }, { status: 403 })
     }
 
     const persistedGameType = toPersistedGameType(gameType)

--- a/app/api/lobby/route.ts
+++ b/app/api/lobby/route.ts
@@ -14,6 +14,7 @@ import { hashLobbyPassword } from '@/lib/lobby-password'
 import { toPersistedGameType } from '@/lib/game-type-storage'
 import { toPersistedGameStateInput } from '@/lib/persisted-game-state'
 import { isTemporarilyUnavailableGameType } from '@/lib/public-game-access'
+import { LOBBY_THEME_IDS, PREMIUM_LOBBY_THEMES, FREE_LOBBY_THEME, type LobbyTheme } from '@/lib/lobby-themes'
 
 const log = apiLogger('/api/lobby')
 
@@ -24,6 +25,7 @@ const createLobbySchema = z.object({
   allowSpectators: z.boolean().default(false),
   turnTimer: z.number().int().min(30).max(180).default(60), // Turn time in seconds (30-180)
   gameType: z.string().default('yahtzee'),
+  theme: z.enum(LOBBY_THEME_IDS as [LobbyTheme, ...LobbyTheme[]]).default(FREE_LOBBY_THEME),
   ticTacToeRounds: z.number().int().min(1).max(100).nullable().optional(),
   memoryDifficulty: z.enum(['easy', 'medium', 'hard']).optional(),
 })
@@ -99,6 +101,7 @@ export async function POST(request: NextRequest) {
       gameType,
       ticTacToeRounds,
       memoryDifficulty,
+      theme,
     } = createLobbySchema.parse(body)
 
     if (isTemporarilyUnavailableGameType(gameType)) {
@@ -115,6 +118,10 @@ export async function POST(request: NextRequest) {
 
     if (maxPlayers > FREE_MAX_PLAYERS && !isPremium) {
       return NextResponse.json({ error: 'Premium required to increase player limit beyond 10' }, { status: 403 })
+    }
+
+    if ((PREMIUM_LOBBY_THEMES as string[]).includes(theme) && !isPremium) {
+      return NextResponse.json({ error: 'Premium required for custom lobby themes' }, { status: 403 })
     }
 
     const persistedGameType = toPersistedGameType(gameType)
@@ -168,6 +175,7 @@ export async function POST(request: NextRequest) {
           spectatorCount: number
           turnTimer: number
           gameType: string
+          theme: string
           creatorId: string | null
         }
       | null = null
@@ -191,6 +199,7 @@ export async function POST(request: NextRequest) {
             spectatorCount: 0,
             turnTimer,
             gameType,
+            theme,
             creatorId: requestUser.id,
             games: {
               create: {
@@ -217,6 +226,7 @@ export async function POST(request: NextRequest) {
             spectatorCount: true,
             turnTimer: true,
             gameType: true,
+            theme: true,
             creatorId: true,
           },
         })

--- a/app/api/lobby/route.ts
+++ b/app/api/lobby/route.ts
@@ -96,6 +96,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unsupported game type' }, { status: 400 })
     }
 
+    if (allowSpectators) {
+      if (requestUser.isGuest) {
+        return NextResponse.json({ error: 'Premium required to enable spectators' }, { status: 403 })
+      }
+      const dbUser = await prisma.users.findUnique({
+        where: { id: requestUser.id },
+        select: { premiumUntil: true },
+      })
+      const isPremium = !!dbUser?.premiumUntil && dbUser.premiumUntil > new Date()
+      if (!isPremium) {
+        return NextResponse.json({ error: 'Premium required to enable spectators' }, { status: 403 })
+      }
+    }
+
     const persistedGameType = toPersistedGameType(gameType)
     const normalizedLobbyName = name.trim()
     const hashedLobbyPassword = await hashLobbyPassword(password)

--- a/app/api/user/[id]/stats/route.ts
+++ b/app/api/user/[id]/stats/route.ts
@@ -46,10 +46,12 @@ export async function GET(
     }
 
     const requesterUserId = session.user.id
-    const requesterDbUser = requesterUserId !== targetUserId
-      ? await prisma.users.findUnique({ where: { id: requesterUserId }, select: { role: true, suspended: true } })
-      : null
+    const requesterDbUser = await prisma.users.findUnique({
+      where: { id: requesterUserId },
+      select: { role: true, suspended: true, premiumUntil: true },
+    })
     const requesterIsAdmin = requesterDbUser?.role === 'admin' && !requesterDbUser?.suspended
+    const isPremium = !!requesterDbUser?.premiumUntil && requesterDbUser.premiumUntil > new Date()
 
     if (requesterUserId !== targetUserId && !requesterIsAdmin) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
@@ -83,10 +85,32 @@ export async function GET(
       to: toDate,
     })
 
+    const hasAdvancedAccess = isPremium || requesterIsAdmin
+    const responsePayload = hasAdvancedAccess
+      ? { overall: payload.overall, byGame: payload.byGame, trends: payload.trends }
+      : {
+          overall: {
+            totalGames: payload.overall.totalGames,
+            wins: payload.overall.wins,
+            losses: payload.overall.losses,
+            draws: payload.overall.draws,
+            winRate: payload.overall.winRate,
+            avgGameDurationMinutes: payload.overall.avgGameDurationMinutes,
+            favoriteGame: payload.overall.favoriteGame,
+            currentWinStreak: null,
+            longestWinStreak: null,
+          },
+          byGame: null,
+          trends: null,
+        }
+
     return NextResponse.json(
       {
         userId: targetUserId,
-        ...payload,
+        ...responsePayload,
+        dateRange: payload.dateRange,
+        generatedAt: payload.generatedAt,
+        isPremium,
       },
       {
         headers: {

--- a/app/api/user/customize/route.ts
+++ b/app/api/user/customize/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/next-auth'
+import { prisma } from '@/lib/db'
+import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
+import { apiLogger } from '@/lib/logger'
+
+const limiter = rateLimit(rateLimitPresets.api)
+const log = apiLogger('/api/user/customize')
+
+const VALID_ACCENT_COLORS = new Set([
+  '#FF6B5B', '#4FA3E8', '#48BB78', '#F6AD55',
+  '#9B8CFF', '#F687B3', '#FC8181', '#68D391',
+])
+
+const VALID_GAME_TYPES = new Set([
+  'yahtzee', 'tic_tac_toe', 'rock_paper_scissors', 'memory',
+  'guess_the_spy', 'connect_four', 'alias', 'liars_party',
+])
+
+export async function GET(request: NextRequest) {
+  const rl = await limiter(request)
+  if (rl) return rl
+
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.users.findUnique({
+    where: { id: session.user.id },
+    select: { bio: true, accentColor: true, featuredGame: true, premiumUntil: true },
+  })
+
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const isPremium = !!user.premiumUntil && user.premiumUntil > new Date()
+
+  return NextResponse.json({
+    bio: user.bio ?? '',
+    accentColor: user.accentColor ?? null,
+    featuredGame: user.featuredGame ?? null,
+    isPremium,
+  })
+}
+
+export async function PATCH(request: NextRequest) {
+  const rl = await limiter(request)
+  if (rl) return rl
+
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = (await request.json()) as {
+    bio?: unknown
+    accentColor?: unknown
+    featuredGame?: unknown
+  }
+
+  const dbUser = await prisma.users.findUnique({
+    where: { id: session.user.id },
+    select: { premiumUntil: true },
+  })
+  const isPremium = !!dbUser?.premiumUntil && dbUser.premiumUntil > new Date()
+
+  const updateData: { bio?: string | null; accentColor?: string | null; featuredGame?: string | null } = {}
+
+  if (body.bio !== undefined) {
+    if (typeof body.bio !== 'string') {
+      return NextResponse.json({ error: 'bio must be a string' }, { status: 400 })
+    }
+    const trimmed = body.bio.trim().slice(0, 160)
+    updateData.bio = trimmed || null
+  }
+
+  if (body.accentColor !== undefined) {
+    if (!isPremium) {
+      return NextResponse.json({ error: 'Premium required to set accent color' }, { status: 403 })
+    }
+    if (body.accentColor !== null && (typeof body.accentColor !== 'string' || !VALID_ACCENT_COLORS.has(body.accentColor))) {
+      return NextResponse.json({ error: 'Invalid accent color' }, { status: 400 })
+    }
+    updateData.accentColor = (body.accentColor as string | null) ?? null
+  }
+
+  if (body.featuredGame !== undefined) {
+    if (!isPremium) {
+      return NextResponse.json({ error: 'Premium required to set featured game' }, { status: 403 })
+    }
+    if (body.featuredGame !== null && (typeof body.featuredGame !== 'string' || !VALID_GAME_TYPES.has(body.featuredGame))) {
+      return NextResponse.json({ error: 'Invalid game type' }, { status: 400 })
+    }
+    updateData.featuredGame = (body.featuredGame as string | null) ?? null
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 })
+  }
+
+  await prisma.users.update({
+    where: { id: session.user.id },
+    data: updateData,
+  })
+
+  log.info('Profile customization updated', { userId: session.user.id, fields: Object.keys(updateData) })
+
+  return NextResponse.json({ success: true, ...updateData })
+}

--- a/app/api/user/games/route.ts
+++ b/app/api/user/games/route.ts
@@ -43,12 +43,20 @@ export async function GET(request: NextRequest) {
 
     const userId = session.user.id
     const { searchParams } = new URL(request.url)
-    
+
+    const dbUser = await prisma.users.findUnique({
+      where: { id: userId },
+      select: { premiumUntil: true },
+    })
+    const isPremium = !!dbUser?.premiumUntil && dbUser.premiumUntil > new Date()
+
     // Parse query params
     const statusParam = searchParams.get('status')
     const gameTypeParam = searchParams.get('gameType')
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    const FREE_GAME_HISTORY_LIMIT = 20
+    const rawLimit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+    const limit = isPremium ? rawLimit : Math.min(rawLimit, FREE_GAME_HISTORY_LIMIT)
+    const offset = isPremium ? parseInt(searchParams.get('offset') || '0') : 0
 
     logger.info('Fetching user game history', {
       userId,
@@ -132,6 +140,8 @@ export async function GET(request: NextRequest) {
       totalCount,
     })
 
+    const visibleTotalCount = isPremium ? totalCount : Math.min(totalCount, FREE_GAME_HISTORY_LIMIT)
+
     return NextResponse.json({
       games: games.map((game) => ({
         id: game.id,
@@ -156,8 +166,8 @@ export async function GET(request: NextRequest) {
       pagination: {
         limit,
         offset,
-        totalCount,
-        hasMore: offset + limit < totalCount,
+        totalCount: visibleTotalCount,
+        hasMore: offset + limit < visibleTotalCount,
       },
     })
   } catch (error) {

--- a/app/lobby/[code]/components/WaitingRoom.tsx
+++ b/app/lobby/[code]/components/WaitingRoom.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from '@/lib/i18n-helpers'
 import type { Game, Lobby, GamePlayer } from '@/types/game'
 import type { GameEngine } from '@/lib/game-engine'
 import type { BotDifficulty } from '@/lib/bot-profiles'
+import { getLobbyTheme } from '@/lib/lobby-themes'
 
 interface WaitingRoomProps {
   game: Game | null
@@ -29,9 +30,25 @@ export default function WaitingRoom({
   const maxPlayers = lobby?.maxPlayers || 4
   const openSlots = Math.max(maxPlayers - playerCount, 0)
   const missingPlayers = Math.max(minPlayers - playerCount, 0)
+  const lobbyTheme = getLobbyTheme(lobby?.theme)
+  const hasCustomTheme = lobby?.theme && lobby.theme !== 'default'
 
   return (
     <div className="space-y-2 px-4 py-4 sm:px-6">
+      {/* Theme accent bar */}
+      {hasCustomTheme && (
+        <div
+          className="mb-2 -mx-4 sm:-mx-6 -mt-4 px-4 sm:px-6 py-2 flex items-center gap-2 text-xs font-semibold"
+          style={{
+            background: lobbyTheme.bg,
+            borderBottom: `3px solid ${lobbyTheme.accent}`,
+            color: lobbyTheme.text,
+          }}
+        >
+          <span style={{ color: lobbyTheme.accent }}>●</span>
+          {lobbyTheme.name} theme
+        </div>
+      )}
       {/* Players */}
       {game?.players?.map((p: GamePlayer, index: number) => {
         const isBot = !!p.user?.bot

--- a/app/lobby/create/page.tsx
+++ b/app/lobby/create/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/lib/analytics'
 import { markPendingLobbyCreateMetric } from '@/lib/lobby-create-metrics'
 import { buildCurrentAuthUrl } from '@/lib/auth-redirect'
+import { LOBBY_THEMES, LOBBY_THEME_IDS, type LobbyTheme } from '@/lib/lobby-themes'
 
 type GameType = SupportedCatalogGameType
 type MemoryDifficulty = 'easy' | 'medium' | 'hard'
@@ -119,6 +120,8 @@ function CreateLobbyPage() {
   const [showFriendsModal, setShowFriendsModal] = useState(false)
   const [selectedFriendIds, setSelectedFriendIds] = useState<string[]>([])
   const [tipsOpen, setTipsOpen] = useState(false)
+  const [selectedTheme, setSelectedTheme] = useState<LobbyTheme>('default')
+  const [isPremiumUser, setIsPremiumUser] = useState(false)
 
   useEffect(() => {
     clientLogger.log('🎮 Game type selected:', selectedGameType)
@@ -141,6 +144,15 @@ function CreateLobbyPage() {
       router.push('/')
     }
   }, [status, isGuest, router])
+
+  useEffect(() => {
+    if (status === 'authenticated') {
+      fetch('/api/user/customize', { cache: 'no-store' })
+        .then((r) => r.json())
+        .then((d) => { if (d.isPremium) setIsPremiumUser(true) })
+        .catch(() => {})
+    }
+  }, [status])
 
   const handlePartySelection = async (friendIds: string[]) => {
     setSelectedFriendIds(friendIds)
@@ -193,6 +205,7 @@ function CreateLobbyPage() {
         allowSpectators: formData.allowSpectators,
         turnTimer: formData.turnTimer,
         gameType: formData.gameType,
+        theme: selectedTheme,
         ...(formData.gameType === 'tic_tac_toe' ? {
           ticTacToeRounds: formData.ticTacToeRounds,
           boardSize,
@@ -782,6 +795,52 @@ function CreateLobbyPage() {
                 )}
               </>
             )}
+
+            {/* Lobby theme — premium */}
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <label className="text-sm font-semibold text-bd-ink">🎨 Lobby Theme</label>
+                {!isPremiumUser && <span className="text-[11px] font-bold text-amber-500">👑 Premium</span>}
+              </div>
+              <div className="flex gap-2 flex-wrap">
+                {LOBBY_THEME_IDS.map((themeId) => {
+                  const t = LOBBY_THEMES[themeId]
+                  const isPremiumTheme = themeId !== 'default'
+                  const isLocked = isPremiumTheme && !isPremiumUser
+                  const isSelected = selectedTheme === themeId
+                  return (
+                    <button
+                      key={themeId}
+                      type="button"
+                      disabled={isLocked}
+                      onClick={() => !isLocked && setSelectedTheme(themeId)}
+                      title={isLocked ? `${t.name} — Premium only` : t.name}
+                      style={{
+                        position: 'relative',
+                        width: 40, height: 40, borderRadius: 10, flexShrink: 0,
+                        background: t.bg,
+                        border: isSelected ? `3px solid ${t.accent}` : '2px solid var(--bd-line)',
+                        boxShadow: isSelected ? `0 0 0 2px ${t.accent}40` : undefined,
+                        cursor: isLocked ? 'not-allowed' : 'pointer',
+                        opacity: isLocked ? 0.5 : 1,
+                        overflow: 'hidden',
+                        transition: 'all 0.15s',
+                      }}
+                    >
+                      <span style={{
+                        position: 'absolute', bottom: 0, left: 0, right: 0,
+                        height: 8, background: t.accent,
+                      }} />
+                      {isLocked && <span style={{ position: 'absolute', top: 1, right: 1, fontSize: 9 }}>👑</span>}
+                    </button>
+                  )
+                })}
+              </div>
+              <p className="text-[12px] text-bd-ink-muted">
+                {selectedTheme === 'default' ? 'Classic warm look' : `${LOBBY_THEMES[selectedTheme].name} theme selected`}
+                {!isPremiumUser && ' · Upgrade to unlock custom themes'}
+              </p>
+            </div>
 
             {/* Lobby options */}
             <div className="flex items-center gap-3 pt-1">

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -184,6 +184,12 @@ export default function ProfilePage() {
   const tabButtonRefs = useRef<Partial<Record<TabType, HTMLButtonElement | null>>>({})
   const sessionUserName = profileSummary?.username || session?.user?.name || ''
 
+  // Profile customization state
+  const [profileBio, setProfileBio] = useState('')
+  const [profileAccentColor, setProfileAccentColor] = useState<string | null>(null)
+  const [profileFeaturedGame, setProfileFeaturedGame] = useState<string | null>(null)
+  const [customizeSaving, setCustomizeSaving] = useState(false)
+
   // Settings state
   const [notificationsSaving, setNotificationsSaving] = useState(false)
   const [accountPreferencesSaving, setAccountPreferencesSaving] = useState(false)
@@ -264,9 +270,10 @@ export default function ProfilePage() {
   )
 
   const fetchProfileSummary = useCallback(async () => {
-    const [profileRes, purchasesRes] = await Promise.all([
+    const [profileRes, purchasesRes, customizeRes] = await Promise.all([
       fetch('/api/user/profile', { cache: 'no-store' }),
       fetch('/api/user/purchases', { cache: 'no-store' }),
+      fetch('/api/user/customize', { cache: 'no-store' }),
     ])
     const data = await profileRes.json()
 
@@ -281,6 +288,12 @@ export default function ProfilePage() {
       setPremiumCancelAtPeriodEnd(purchasesData.cancelAtPeriodEnd === true)
       setPremiumUntilDate(purchasesData.premiumUntil ? new Date(purchasesData.premiumUntil) : null)
       setHasSubscriptionId(purchasesData.hasSubscriptionId === true)
+    }
+    if (customizeRes.ok) {
+      const customizeData = await customizeRes.json()
+      setProfileBio(customizeData.bio ?? '')
+      setProfileAccentColor(customizeData.accentColor ?? null)
+      setProfileFeaturedGame(customizeData.featuredGame ?? null)
     }
     return data.user as ProfileSummary
   }, [t])
@@ -312,6 +325,26 @@ export default function ProfilePage() {
       setPremiumActionLoading(false)
     }
   }, [fetchProfileSummary])
+
+  const handleSaveCustomization = useCallback(async (fields: { bio?: string; accentColor?: string | null; featuredGame?: string | null }) => {
+    setCustomizeSaving(true)
+    try {
+      const res = await fetch('/api/user/customize', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(fields),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed')
+      }
+      showToast.success('toast.saved')
+    } catch (err) {
+      showToast.error('errors.generic', err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setCustomizeSaving(false)
+    }
+  }, [])
 
   const handleManageBilling = useCallback(async () => {
     try {
@@ -2579,6 +2612,118 @@ export default function ProfilePage() {
                     <span>Get Premium — $2.99/mo</span>
                   </button>
                 )}
+              </div>
+
+              {/* Profile Customization */}
+              <div className={profileSurfaceClassName}>
+                <h3 className="mb-1 text-lg font-bold text-bd-ink dark:text-white">Profile Customization</h3>
+                <p className="mb-5 text-sm text-bd-ink-muted dark:text-slate-400">
+                  Personalize your public profile.
+                </p>
+
+                {/* Bio — free */}
+                <div className="mb-5">
+                  <label className="mb-1.5 block text-sm font-semibold text-bd-ink dark:text-white">
+                    Bio <span className="text-xs font-normal text-bd-ink-muted">(max 160 chars · free)</span>
+                  </label>
+                  <textarea
+                    value={profileBio}
+                    onChange={(e) => setProfileBio(e.target.value.slice(0, 160))}
+                    placeholder="Tell others about yourself..."
+                    rows={3}
+                    className="w-full rounded-xl border border-bd-line bg-white px-3 py-2.5 text-sm text-bd-ink placeholder:text-bd-ink-muted focus:border-bd-ink focus:outline-none dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:placeholder:text-slate-500"
+                  />
+                  <div className="mt-1 flex items-center justify-between">
+                    <span className="text-xs text-bd-ink-muted">{profileBio.length}/160</span>
+                    <button
+                      type="button"
+                      disabled={customizeSaving}
+                      onClick={() => void handleSaveCustomization({ bio: profileBio })}
+                      className="rounded-lg bg-bd-ink px-3 py-1.5 text-xs font-semibold text-bd-bg transition hover:opacity-80 disabled:opacity-50"
+                    >
+                      {customizeSaving ? '...' : 'Save bio'}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Accent color — premium */}
+                <div className="mb-5">
+                  <div className="mb-1.5 flex items-center gap-2">
+                    <label className="text-sm font-semibold text-bd-ink dark:text-white">Profile Accent Color</label>
+                    {!hasUploadPack && <span className="text-xs font-bold text-amber-500">👑 Premium</span>}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {['#FF6B5B', '#4FA3E8', '#48BB78', '#F6AD55', '#9B8CFF', '#F687B3', '#FC8181', '#68D391'].map((color) => (
+                      <button
+                        key={color}
+                        type="button"
+                        disabled={!hasUploadPack}
+                        onClick={() => {
+                          const next = profileAccentColor === color ? null : color
+                          setProfileAccentColor(next)
+                          void handleSaveCustomization({ accentColor: next })
+                        }}
+                        title={hasUploadPack ? color : 'Premium required'}
+                        style={{
+                          width: 32, height: 32, borderRadius: 8, background: color, border: 'none',
+                          outline: profileAccentColor === color ? `3px solid ${color}` : '2px solid transparent',
+                          outlineOffset: 2, cursor: hasUploadPack ? 'pointer' : 'not-allowed',
+                          opacity: hasUploadPack ? 1 : 0.4,
+                          transition: 'all 0.15s',
+                        }}
+                      />
+                    ))}
+                  </div>
+                  {profileAccentColor && (
+                    <p className="mt-1.5 text-xs text-bd-ink-muted">
+                      Active: <span style={{ color: profileAccentColor, fontWeight: 700 }}>{profileAccentColor}</span>
+                    </p>
+                  )}
+                </div>
+
+                {/* Featured game — premium */}
+                <div>
+                  <div className="mb-1.5 flex items-center gap-2">
+                    <label className="text-sm font-semibold text-bd-ink dark:text-white">Featured Game</label>
+                    {!hasUploadPack && <span className="text-xs font-bold text-amber-500">👑 Premium</span>}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {[
+                      { id: 'yahtzee', label: '🎲 Yahtzee' },
+                      { id: 'connect_four', label: '🔴 Connect Four' },
+                      { id: 'tic_tac_toe', label: '✕ Tic-Tac-Toe' },
+                      { id: 'memory', label: '🃏 Memory' },
+                      { id: 'guess_the_spy', label: '🕵️ Spy' },
+                      { id: 'alias', label: '💬 Alias' },
+                      { id: 'rock_paper_scissors', label: '✊ RPS' },
+                      { id: 'liars_party', label: '🃏 Liar\'s Party' },
+                    ].map(({ id, label }) => (
+                      <button
+                        key={id}
+                        type="button"
+                        disabled={!hasUploadPack}
+                        onClick={() => {
+                          const next = profileFeaturedGame === id ? null : id
+                          setProfileFeaturedGame(next)
+                          void handleSaveCustomization({ featuredGame: next })
+                        }}
+                        className={`rounded-xl border px-3 py-1.5 text-xs font-semibold transition ${
+                          profileFeaturedGame === id
+                            ? 'border-bd-ink bg-bd-ink text-bd-bg'
+                            : 'border-bd-line bg-white text-bd-ink hover:border-bd-ink dark:border-slate-600 dark:bg-slate-800 dark:text-white'
+                        }`}
+                        style={{ opacity: hasUploadPack ? 1 : 0.4, cursor: hasUploadPack ? 'pointer' : 'not-allowed' }}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                  {profileFeaturedGame && (
+                    <p className="mt-1.5 text-xs text-bd-ink-muted">
+                      Shown on your public profile
+                    </p>
+                  )}
+                </div>
               </div>
             </div>
           )}

--- a/lib/lobby-themes.ts
+++ b/lib/lobby-themes.ts
@@ -1,0 +1,19 @@
+export const LOBBY_THEMES = {
+  default:  { name: 'Default',  bg: '#FFF8EC', accent: '#FF6B5B', border: '#E8DDC8', text: '#1F1B16', dark: false },
+  ocean:    { name: 'Ocean',    bg: '#EEF6FF', accent: '#4FA3E8', border: '#B3D4F5', text: '#1a3a5c', dark: false },
+  forest:   { name: 'Forest',   bg: '#F0FFF4', accent: '#48BB78', border: '#9AE6B4', text: '#1a3a2a', dark: false },
+  sunset:   { name: 'Sunset',   bg: '#FFFAF0', accent: '#F6AD55', border: '#FBD38D', text: '#3a2a1a', dark: false },
+  midnight: { name: 'Midnight', bg: '#1A202C', accent: '#9B8CFF', border: '#4A5568', text: '#E2E8F0', dark: true  },
+} as const
+
+export type LobbyTheme = keyof typeof LOBBY_THEMES
+
+export const LOBBY_THEME_IDS = Object.keys(LOBBY_THEMES) as LobbyTheme[]
+
+export const FREE_LOBBY_THEME: LobbyTheme = 'default'
+export const PREMIUM_LOBBY_THEMES = LOBBY_THEME_IDS.filter((t) => t !== FREE_LOBBY_THEME)
+
+export function getLobbyTheme(theme: string | null | undefined) {
+  if (theme && theme in LOBBY_THEMES) return LOBBY_THEMES[theme as LobbyTheme]
+  return LOBBY_THEMES.default
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -251,6 +251,13 @@ export const rateLimitPresets = {
     windowMs: 60 * 60 * 1000, // 1 hour
     maxRequests: 10,
     message: 'Too many lobbies created. Please try again later.'
+  },
+
+  // Relaxed limit for premium lobby creation
+  lobbyCreationPremium: {
+    windowMs: 60 * 60 * 1000, // 1 hour
+    maxRequests: 30,
+    message: 'Too many lobbies created. Please try again later.'
   }
 }
 

--- a/prisma/migrations/20260512000000_add_premium_customization/migration.sql
+++ b/prisma/migrations/20260512000000_add_premium_customization/migration.sql
@@ -1,0 +1,7 @@
+-- AddColumn Users: bio, accentColor, featuredGame
+ALTER TABLE "Users" ADD COLUMN "bio" TEXT;
+ALTER TABLE "Users" ADD COLUMN "accentColor" TEXT;
+ALTER TABLE "Users" ADD COLUMN "featuredGame" TEXT;
+
+-- AddColumn Lobbies: theme
+ALTER TABLE "Lobbies" ADD COLUMN "theme" TEXT NOT NULL DEFAULT 'default';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,9 @@ model Users {
   passwordHash    String?
   image           String?
   avatarUrl         String?
+  bio             String?
+  accentColor     String?
+  featuredGame    String?
   stripeCustomerId      String?   @unique
   stripeSubscriptionId  String?   @unique
   premiumUntil          DateTime? @db.Timestamptz(3)
@@ -166,6 +169,7 @@ model Lobbies {
   turnTimer       Int            @default(60) // Turn time limit in seconds (30, 60, 90, 120)
   isActive        Boolean        @default(true)
   gameType        String         @default("yahtzee")
+  theme           String         @default("default")
   createdAt       DateTime       @default(now()) @db.Timestamptz(3)
   creatorId       String?
   creator         Users?         @relation("LobbyCreator", fields: [creatorId], references: [id], onDelete: SetNull)

--- a/types/game.ts
+++ b/types/game.ts
@@ -101,6 +101,7 @@ export interface Lobby {
   creatorId?: string | null
   allowSpectators?: boolean
   isActive?: boolean
+  theme?: string
   games?: Game[]
   creator?: { username?: string; email?: string }
   spectatorCount?: number


### PR DESCRIPTION
## Summary

Full premium features sprint — all gating, limits, and customization for the Boardly premium tier ($2.99/mo).

- **#491** Gate `allowSpectators` to premium lobby creators (`POST /api/lobby`)
- **#492** Limit free users to last 20 games in history (`GET /api/user/games`)
- **#493** Gate advanced stats (streaks, trends, per-game) to premium (`GET /api/user/[id]/stats`)
- **#494** Gate game replays to premium (`GET /api/game/[gameId]/replay`)
- **#495** Higher player limit — free: 10, premium: 16 (`POST /api/lobby`)
- **#496** Higher lobby creation rate limit — free: 10/hr, premium: 30/hr
- **#498** Custom lobby themes — 5 themes (Default, Ocean, Forest, Sunset, Midnight); DB migration, API gate, picker UI in create lobby, accent bar in WaitingRoom
- **#499** Profile customization — bio (free), accent color + featured game (premium); new `GET/PATCH /api/user/customize`

## Schema changes

New migration `20260512000000_add_premium_customization`:
- `Users`: added `bio TEXT`, `accentColor TEXT`, `featuredGame TEXT`
- `Lobbies`: added `theme TEXT NOT NULL DEFAULT 'default'`

## Test plan

- [ ] Free user cannot create lobby with `allowSpectators: true` → 403
- [ ] Free user cannot set `maxPlayers > 10` → 403
- [ ] Free user cannot apply Ocean/Forest/Sunset/Midnight theme → 403
- [ ] Free user hits rate limit after 10 lobby creates/hr
- [ ] Premium user gets all of the above unlocked
- [ ] Game history for free user caps at 20, no pagination past that
- [ ] Stats endpoint returns `byGame: null`, `trends: null` for free users
- [ ] Replay endpoint returns 403 for free users
- [ ] Profile customization: bio saves for all users; accent color + featured game blocked for free users
- [ ] Lobby theme accent bar appears in WaitingRoom for non-default themes