### PR TITLE
#555 fix: architecture audit quick fixes

### DIFF
--- a/app/api/friends/request/route.ts
+++ b/app/api/friends/request/route.ts
@@ -8,7 +8,7 @@ import { apiLogger } from '@/lib/logger'
 import { extractPublicProfileId } from '@/lib/public-profile'
 import { createInAppNotification } from '@/lib/in-app-notifications'
 
-const limiter = rateLimit(rateLimitPresets.api)
+const limiter = rateLimit(rateLimitPresets.friendRequest)
 const log = apiLogger('/api/friends/request')
 
 // POST /api/friends/request - Send friend request

--- a/app/api/lobby/[code]/kick-player/route.ts
+++ b/app/api/lobby/[code]/kick-player/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import { prisma } from '@/lib/db'
 import { apiLogger } from '@/lib/logger'
 import { getRequestAuthUser } from '@/lib/request-auth'
 import { broadcastToLobby } from '@/lib/supabase-server'
 import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
+
+const kickPlayerSchema = z.object({
+  playerId: z.string().uuid(),
+})
 
 const limiter = rateLimit(rateLimitPresets.api)
 
@@ -24,11 +29,11 @@ export async function POST(
     }
 
     const { code } = await params
-    const { playerId } = await request.json() as { playerId?: string }
-
-    if (!playerId) {
-      return NextResponse.json({ error: 'playerId is required' }, { status: 400 })
+    const body = kickPlayerSchema.safeParse(await request.json())
+    if (!body.success) {
+      return NextResponse.json({ error: 'Invalid playerId' }, { status: 400 })
     }
+    const { playerId } = body.data
 
     const lobby = await prisma.lobbies.findUnique({
       where: { code },

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import * as Sentry from '@sentry/nextjs'
 import { clientLogger } from '@/lib/client-logger'
 import BoardlyErrorState from '@/components/BoardlyErrorState'
 
@@ -12,8 +13,8 @@ export default function Error({
   reset: () => void
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
     clientLogger.error('Error boundary caught:', error)
+    Sentry.captureException(error)
   }, [error])
 
   return <BoardlyErrorState error={error} onRetry={reset} kicker="Boardly · Recovery" />

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,7 @@
   --bd-card-warm: #FFF8EC;
   --bd-input-bg: #ffffff;
   --bd-font-display: Georgia, serif;
+  --bd-premium: #F59E0B;
 }
 
 html.dark {

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -722,7 +722,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               background: 'rgba(255,255,255,0.55)', border: '1.5px solid var(--bd-line)',
             }}>
               <BdAvatar name={p.name} color={i === 0 ? accent : undefined} />
-              <span style={{ fontWeight: 600, fontSize: 15, color: p.user?.isPremium ? '#F59E0B' : undefined }}>
+              <span style={{ fontWeight: 600, fontSize: 15, color: p.user?.isPremium ? 'var(--bd-premium)' : undefined }}>
                 {p.name}
                 {p.user?.isPremium && <span style={{ marginLeft: 4, fontSize: 12 }} title="Premium">👑</span>}
                 {p.userId === currentUserId && (
@@ -915,7 +915,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
                           border: isYou ? `1.5px solid ${accent}` : '1.5px solid var(--bd-line)',
                         }}>
                           <BdAvatar name={name} color={isYou ? accent : undefined} size={32} />
-                          <span style={{ fontWeight: 600, fontSize: 14, color: isPremiumPlayer ? '#F59E0B' : undefined }}>
+                          <span style={{ fontWeight: 600, fontSize: 14, color: isPremiumPlayer ? 'var(--bd-premium)' : undefined }}>
                             {name}
                             {isPremiumPlayer && <span style={{ marginLeft: 4, fontSize: 12 }} title="Premium">👑</span>}
                           </span>

--- a/app/lobby/[code]/connect-four-page.tsx
+++ b/app/lobby/[code]/connect-four-page.tsx
@@ -197,7 +197,7 @@ function C4PlayerCard({ name, disc, isActive, isWinner, wins, side, isLocalPlaye
             </div>
             <div style={{ textAlign: side === 'right' ? 'right' : 'left', minWidth: 0, overflow: 'hidden' }}>
                 <div style={{ display: 'flex', gap: 6, alignItems: 'center', justifyContent: side === 'right' ? 'flex-end' : 'flex-start' }}>
-                    <span style={{ fontWeight: 700, fontSize: 14, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: isPremium ? '#F59E0B' : undefined }}>
+                    <span style={{ fontWeight: 700, fontSize: 14, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: isPremium ? 'var(--bd-premium)' : undefined }}>
                         {name}
                     </span>
                     {isPremium && <span style={{ fontSize: 12, flexShrink: 0 }} title="Premium">👑</span>}

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -139,7 +139,7 @@ function TttPlayerCard({ name, symbol, isActive, isWinner, side, avatarSrc, isPr
             </div>
             <div style={{ textAlign: side === 'right' ? 'right' : 'left', minWidth: 0, overflow: 'hidden' }}>
                 <div style={{ display: 'flex', gap: 6, alignItems: 'center', justifyContent: side === 'right' ? 'flex-end' : 'flex-start' }}>
-                    <span style={{ fontWeight: 700, fontSize: 14, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: isPremium ? '#F59E0B' : undefined }}>{name}</span>
+                    <span style={{ fontWeight: 700, fontSize: 14, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: isPremium ? 'var(--bd-premium)' : undefined }}>{name}</span>
                     {isPremium && <span style={{ fontSize: 12, flexShrink: 0 }} title="Premium">👑</span>}
                     {isWinner && (
                         <span style={{

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -258,6 +258,13 @@ export const rateLimitPresets = {
     windowMs: 60 * 60 * 1000, // 1 hour
     maxRequests: 30,
     message: 'Too many lobbies created. Please try again later.'
+  },
+
+  // Strict limit for friend requests (abuse prevention)
+  friendRequest: {
+    windowMs: 60 * 60 * 1000, // 1 hour
+    maxRequests: 15,
+    message: 'Too many friend requests. Please try again later.'
   }
 }
 


### PR DESCRIPTION
## Summary

From full architecture audit (2026-05-21):

- **Rate limit** — add `friendRequest` preset (15 req/hr); `friends/request` used generic `api` (60/min)
- **Zod validation** — `kick-player` `playerId` now validated as UUID; previously accepted any raw string
- **Sentry** — `error.tsx` now calls `Sentry.captureException(error)` so client crashes reach Sentry dashboard
- **CSS variable** — `--bd-premium: #F59E0B` added to design system; hardcoded `#F59E0B` removed from alias/ttt/c4 pages

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 848/848 passing