### PR TITLE
#557 fix: CSRF on game state route, tighten realtime-events types, add integration tests

### DIFF
--- a/__tests__/api/game-state.test.ts
+++ b/__tests__/api/game-state.test.ts
@@ -150,6 +150,7 @@ describe('POST /api/game/[gameId]/state', () => {
   const buildRequest = (body: unknown) =>
     new NextRequest('http://localhost:3000/api/game/game-123/state', {
       method: 'POST',
+      headers: { origin: 'http://localhost:3000' },
       body: JSON.stringify(body),
     })
 
@@ -931,5 +932,98 @@ describe('POST /api/game/[gameId]/state', () => {
         triggeredAt: expect.any(Number),
       })
     )
+  })
+
+  it('returns 409 for second concurrent move when optimistic lock fails', async () => {
+    const engineState = {
+      ...persistedState,
+      currentPlayerIndex: 1,
+      updatedAt: new Date().toISOString(),
+      lastMoveAt: Date.now(),
+    }
+
+    const mockEngine = {
+      makeMove: jest.fn().mockReturnValue(true),
+      getState: jest.fn(() => engineState),
+      getCurrentPlayer: jest.fn(() => ({ id: 'player-2' })),
+      getPlayers: jest.fn(() => [
+        { id: 'player-1', score: 10 },
+        { id: 'player-2', score: 5 },
+      ]),
+      getScorecard: jest.fn(() => ({})),
+    }
+
+    mockGetRequestAuthUser.mockResolvedValue(mockAuthUser)
+    mockPrisma.games.findUnique.mockResolvedValue(dbGame as any)
+    // First request wins; second gets count:0 (another writer won the lock)
+    mockPrisma.games.updateMany
+      .mockResolvedValueOnce({ count: 1 } as any)
+      .mockResolvedValueOnce({ count: 0 } as any)
+    mockPrisma.players.update.mockResolvedValue({} as any)
+    mockRestoreGameEngine.mockReturnValue(mockEngine as any)
+
+    const [first, second] = await Promise.all([
+      POST(buildRequest({ move: { type: 'roll', data: {} } }), {
+        params: Promise.resolve({ gameId: 'game-123' }),
+      }),
+      POST(buildRequest({ move: { type: 'roll', data: {} } }), {
+        params: Promise.resolve({ gameId: 'game-123' }),
+      }),
+    ])
+
+    const statuses = [first.status, second.status].sort()
+    expect(statuses).toEqual([200, 409])
+
+    const loser = first.status === 409 ? first : second
+    expect((await loser.json()).code).toBe('STATE_CONFLICT')
+  })
+
+  it('returns 202 AUTO_ACTION_DEBOUNCED for duplicate auto-action with same debounce key', async () => {
+    const engineState = {
+      ...persistedState,
+      currentPlayerIndex: 0,
+      updatedAt: new Date().toISOString(),
+      lastMoveAt: Date.now(),
+    }
+    const mockEngine = {
+      getState: jest.fn(() => engineState),
+      getCurrentPlayer: jest.fn(() => ({ id: 'player-1' })),
+      getRollsLeft: jest.fn(() => 0),
+    }
+    mockGetRequestAuthUser.mockResolvedValue(mockAuthUser)
+    mockPrisma.games.findUnique.mockResolvedValue(dbGame as any)
+    mockRestoreGameEngine.mockReturnValue(mockEngine as any)
+
+    // Unique key per test run to avoid cross-test debounce state bleeding
+    const uniqueKey = `debounce-${Date.now()}-${Math.random()}`
+    const autoActionBody = {
+      move: { type: 'score', data: { category: 'chance' } },
+      autoActionContext: {
+        source: 'turn-timeout',
+        debounceKey: uniqueKey,
+        turnSnapshot: {
+          currentPlayerId: 'player-1',
+          currentPlayerIndex: 0,
+          lastMoveAt: null,
+          rollsLeft: 0,
+          updatedAt: engineState.updatedAt,
+        },
+      },
+    }
+
+    // First call registers the key in the module-level debounce map
+    await POST(buildRequest(autoActionBody), {
+      params: Promise.resolve({ gameId: 'game-123' }),
+    })
+
+    // Second identical call within the 2s window must be skipped
+    const second = await POST(buildRequest(autoActionBody), {
+      params: Promise.resolve({ gameId: 'game-123' }),
+    })
+    const payload = await second.json()
+
+    expect(second.status).toBe(202)
+    expect(payload.code).toBe('AUTO_ACTION_DEBOUNCED')
+    expect(payload.skipped).toBe(true)
   })
 })

--- a/__tests__/hooks/useBotTurn.test.ts
+++ b/__tests__/hooks/useBotTurn.test.ts
@@ -1,0 +1,115 @@
+import { act, renderHook } from '@testing-library/react'
+import { useBotTurn } from '@/app/lobby/[code]/hooks/useBotTurn'
+
+jest.mock('@/lib/client-logger', () => ({
+  clientLogger: {
+    log: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/i18n-toast', () => ({
+  showToast: { error: jest.fn() },
+}))
+
+jest.mock('@/lib/fetch-with-guest', () => ({
+  fetchWithGuest: jest.fn(),
+}))
+
+import { fetchWithGuest } from '@/lib/fetch-with-guest'
+
+const mockFetchWithGuest = fetchWithGuest as jest.MockedFunction<typeof fetchWithGuest>
+
+const WATCHDOG_MS = 14_000
+const RETRY_DELAY_MS = 2_000
+
+describe('useBotTurn watchdog', () => {
+  const advanceAndFlush = async (ms: number) => {
+    await act(async () => {
+      jest.advanceTimersByTime(ms)
+      await Promise.resolve()
+    })
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const botGame = {
+    id: 'game-123',
+    players: [
+      { userId: 'player-1', user: { bot: null } },
+      { userId: 'bot-1', user: { bot: { id: 'bot-1' } } },
+    ],
+  }
+
+  const makeBotEngine = (botPlayerId = 'bot-1', playerIndex = 1) => ({
+    getState: jest.fn(() => ({ status: 'playing', currentPlayerIndex: playerIndex })),
+    getCurrentPlayer: jest.fn(() => ({ id: botPlayerId })),
+  })
+
+  it('fires watchdog after 14s when fetch never resolves, calls reconcile and schedules retry', async () => {
+    // fetch never resolves — simulates a hung bot-turn request
+    mockFetchWithGuest.mockReturnValue(new Promise(() => {}))
+    const reconcileWithServerSnapshot = jest.fn().mockResolvedValue(undefined)
+    const gameEngine = makeBotEngine() as any
+
+    renderHook(() =>
+      useBotTurn({
+        game: botGame,
+        gameEngine,
+        code: 'ABCD12',
+        isGameStarted: true,
+        reconcileWithServerSnapshot,
+      })
+    )
+
+    // fetchWithGuest should be called once immediately for the bot turn
+    await advanceAndFlush(0)
+    expect(mockFetchWithGuest).toHaveBeenCalledTimes(1)
+
+    // Before watchdog fires, reconcile should not have been called
+    expect(reconcileWithServerSnapshot).not.toHaveBeenCalled()
+
+    // Advance past watchdog threshold
+    await advanceAndFlush(WATCHDOG_MS + 100)
+    expect(reconcileWithServerSnapshot).toHaveBeenCalledTimes(1)
+
+    // Retry should be scheduled — advance past retry delay and expect a second fetch attempt
+    await advanceAndFlush(RETRY_DELAY_MS + 100)
+    expect(mockFetchWithGuest).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not fire watchdog if fetch resolves before 14s', async () => {
+    mockFetchWithGuest.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as any)
+    const reconcileWithServerSnapshot = jest.fn().mockResolvedValue(undefined)
+    const gameEngine = makeBotEngine() as any
+
+    renderHook(() =>
+      useBotTurn({
+        game: botGame,
+        gameEngine,
+        code: 'ABCD12',
+        isGameStarted: true,
+        reconcileWithServerSnapshot,
+      })
+    )
+
+    await advanceAndFlush(0)
+    await act(async () => { await Promise.resolve() })
+
+    // Advance past watchdog — should not trigger since fetch already resolved
+    await advanceAndFlush(WATCHDOG_MS + 100)
+    expect(reconcileWithServerSnapshot).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/game/[gameId]/state/route.ts
+++ b/app/api/game/[gameId]/state/route.ts
@@ -8,6 +8,7 @@ import { advanceTurnPastDisconnectedPlayers, type TurnState } from '@/lib/discon
 import { broadcastToLobby } from '@/lib/supabase-server'
 import { appendGameReplaySnapshot } from '@/lib/game-replay'
 import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
+import { verifyCsrfToken } from '@/lib/csrf'
 import { parseAndValidateGameState, toPersistedGameStateInput } from '@/lib/persisted-game-state'
 import { TicTacToeGame } from '@/lib/games/tic-tac-toe-game'
 import { sanitizeSpyStateForBroadcast } from '@/lib/games/spy-game'
@@ -204,6 +205,10 @@ export async function POST(
     const rateLimitResult = await limiter(request)
     if (rateLimitResult) {
       return rateLimitResult
+    }
+
+    if (!verifyCsrfToken(request)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 
     const { gameId } = await params

--- a/types/realtime-events.ts
+++ b/types/realtime-events.ts
@@ -209,7 +209,7 @@ export interface GameUpdatePayload extends BaseEventPayload {
   /** Action that triggered the update */
   action: 'state-change' | 'turn-changed' | 'player-left' | 'game-abandoned' | 'chat-message'
   /** Game-specific data */
-  payload: unknown
+  payload: Record<string, unknown>
 }
 
 export interface GameActionPayload {
@@ -218,7 +218,7 @@ export interface GameActionPayload {
   /** Action type (validated on server) */
   action: 'state-change' | 'player-left' | 'player-joined' | 'chat-message' | 'game-abandoned'
   /** Action-specific data */
-  payload: unknown
+  payload: Record<string, unknown>
 }
 
 export interface GameAbandonedPayload extends BaseEventPayload {
@@ -279,7 +279,7 @@ export interface BotActionPayload extends BaseEventPayload {
   /** Type of action (roll, score, etc.) */
   actionType: string
   /** Action details */
-  action: unknown
+  action: Record<string, unknown>
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add `verifyCsrfToken` to `POST /api/game/[gameId]/state` (CSRF protection from architecture audit)
- Tighten `GameUpdatePayload.payload`, `GameActionPayload.payload`, `BotActionPayload.action`: `unknown` → `Record<string, unknown>`
- Add `origin` header to `buildRequest` test helper so CSRF passes in edge runtime test env
- 4 new integration tests: concurrent moves → 409 STATE_CONFLICT, duplicate auto-action debounce → 202, useBotTurn watchdog fires after 14s on hung fetch (+ no-fire on success)

## Test plan
- [ ] 852/852 tests passing (`pnpm test`)
- [ ] `npx tsc --noEmit` clean