### PR TITLE
#628 feat: wire guest-conversion nudge into all 6 games

### DIFF
--- a/__tests__/components/guest-conversion-nudge.test.tsx
+++ b/__tests__/components/guest-conversion-nudge.test.tsx
@@ -1,0 +1,53 @@
+import { act, render, screen } from '@testing-library/react'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
+
+jest.mock('@/lib/i18n-helpers', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const DISMISS_KEY = 'boardly:guest-conversion-dismissed:v1'
+
+describe('GuestConversionNudge', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders by default for a guest who has not dismissed it', () => {
+    render(<GuestConversionNudge registerUrl="/auth/register" />)
+
+    expect(screen.queryByText('auth.guestConversion.headline')).not.toBeNull()
+  })
+
+  it('dismissing persists via localStorage (survives remount, unlike sessionStorage)', () => {
+    const { unmount } = render(<GuestConversionNudge registerUrl="/auth/register" />)
+
+    act(() => {
+      screen.getByText('auth.guestConversion.dismiss').click()
+    })
+
+    expect(screen.queryByText('auth.guestConversion.headline')).toBeNull()
+    expect(localStorage.getItem(DISMISS_KEY)).toBe('1')
+
+    unmount()
+    render(<GuestConversionNudge registerUrl="/auth/register" />)
+
+    expect(screen.queryByText('auth.guestConversion.headline')).toBeNull()
+  })
+
+  it('does not render if already dismissed in a prior session', () => {
+    localStorage.setItem(DISMISS_KEY, '1')
+
+    render(<GuestConversionNudge registerUrl="/auth/register" />)
+
+    expect(screen.queryByText('auth.guestConversion.headline')).toBeNull()
+  })
+
+  it('links the CTA to the provided registerUrl', () => {
+    render(<GuestConversionNudge registerUrl="/auth/register?returnUrl=%2Flobby%2FABCD" />)
+
+    const cta = screen.getByText('auth.guestConversion.cta').closest('a')
+    expect(cta?.getAttribute('href')).toBe('/auth/register?returnUrl=%2Flobby%2FABCD')
+  })
+})

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -2582,6 +2582,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
               onPlayAgain={handleStartGame}
               onRequestRematch={handleRequestRematch}
               onBackToLobby={() => router.push(getGameLobbiesRoute(lobby.gameType) ?? '/games')}
+              registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
             />
           ) : gameEngine && (lobby?.gameType as string) === 'memory' && game?.id ? (
             <MemoryGameBoard
@@ -2601,6 +2602,8 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
               someoneTyping={someoneTyping}
               playerProfiles={chatPlayerProfiles}
               onProfileClick={setProfileUserId}
+              isGuest={isGuest}
+              registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
             />
           ) : gameEngine ? (
             <div className="flex h-full items-center justify-center p-4">

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -17,6 +17,7 @@ import { ReactionOverlay } from '@/components/ReactionOverlay'
 import { AliasGame, type AliasGameData } from '@/lib/games/alias'
 import { sounds } from '@/lib/sounds'
 import { getLobbyTheme } from '@/lib/lobby-themes'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 interface AliasPageProps {
   code: string
@@ -1526,6 +1527,12 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
             )}
             <button style={linkBtn} onClick={() => router.push('/games')}>Leave game</button>
           </div>
+
+          {isGuest && (
+            <div style={{ width: '100%', maxWidth: 420 }}>
+              <GuestConversionNudge registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`} />
+            </div>
+          )}
         </main>
       </div>
     )

--- a/app/lobby/[code]/components/MemoryGameBoard.tsx
+++ b/app/lobby/[code]/components/MemoryGameBoard.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from '@/components/LoadingSpinner'
 import Chat from '@/components/Chat'
 import { useGameTimer } from '../hooks/useGameTimer'
 import { sounds } from '@/lib/sounds'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 interface LobbyPlayer {
   id: string
@@ -66,6 +67,8 @@ interface MemoryGameBoardProps {
   someoneTyping?: boolean
   playerProfiles?: Map<string, { avatarUrl?: string | null; isPremium?: boolean }>
   onProfileClick?: (userId: string) => void
+  isGuest?: boolean
+  registerUrl?: string
 }
 
 const MISMATCH_RESOLVE_DELAY_MS = 1200
@@ -95,6 +98,8 @@ interface MemoryResultModalProps {
   onReturnToWaiting?: () => void
   onLeave?: () => void
   onInspect: () => void
+  isGuest?: boolean
+  registerUrl?: string
   t: (key: TranslationKeys, opts?: string | Record<string, unknown>) => string
 }
 
@@ -108,6 +113,8 @@ function MemoryResultModal({
   onReturnToWaiting,
   onLeave,
   onInspect,
+  isGuest,
+  registerUrl,
   t,
 }: MemoryResultModalProps) {
   const ghostBtn: React.CSSProperties = {
@@ -258,6 +265,11 @@ function MemoryResultModal({
           </button>
         )}
       </div>
+      {isGuest && registerUrl && (
+        <div style={{ width: '100%', maxWidth: 260 }}>
+          <GuestConversionNudge registerUrl={registerUrl} />
+        </div>
+      )}
     </div>
   )
 }
@@ -438,6 +450,8 @@ export default function MemoryGameBoard({
   someoneTyping = false,
   playerProfiles,
   onProfileClick,
+  isGuest,
+  registerUrl,
 }: MemoryGameBoardProps) {
   const { t } = useTranslation()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -883,6 +897,8 @@ export default function MemoryGameBoard({
                   onReturnToWaiting={canStartGame ? onReturnToWaiting : undefined}
                   onLeave={onLeave}
                   onInspect={() => setOverlayInspecting(true)}
+                  isGuest={isGuest}
+                  registerUrl={registerUrl}
                   t={t}
                 />
               )}
@@ -1021,6 +1037,8 @@ export default function MemoryGameBoard({
                     onReturnToWaiting={canStartGame ? onReturnToWaiting : undefined}
                     onLeave={onLeave}
                     onInspect={() => setOverlayInspecting(true)}
+                    isGuest={isGuest}
+                    registerUrl={registerUrl}
                     t={t}
                   />
                 )}

--- a/app/lobby/[code]/components/SpyGameBoard.tsx
+++ b/app/lobby/[code]/components/SpyGameBoard.tsx
@@ -66,6 +66,7 @@ interface SpyGameBoardProps {
   onRequestRematch?: () => void
   isRequestingRematch?: boolean
   onBackToLobby?: () => void
+  registerUrl?: string
 }
 
 function computeVoteLeader(votes: Record<string, string>): string {
@@ -106,6 +107,7 @@ export default function SpyGameBoard({
   onRequestRematch,
   isRequestingRematch = false,
   onBackToLobby,
+  registerUrl = '/auth/register',
 }: SpyGameBoardProps) {
   const { t } = useTranslation()
   const showActionError = React.useCallback((message: string) => {
@@ -733,6 +735,8 @@ export default function SpyGameBoard({
             onRequestRematch={onRequestRematch}
             isRequestRematchPending={isRequestingRematch}
             onBackToLobby={onBackToLobby}
+            isGuest={isGuest}
+            registerUrl={registerUrl}
           />
         )}
       </div>

--- a/app/lobby/[code]/connect-four-page.tsx
+++ b/app/lobby/[code]/connect-four-page.tsx
@@ -33,6 +33,7 @@ import { getLobbyPlayerRequirements } from '@/lib/lobby-player-requirements'
 import { ReactionOverlay } from '@/components/ReactionOverlay'
 import { useGameTimer } from './hooks/useGameTimer'
 import { useBotTurn } from './hooks/useBotTurn'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 // ─── Design sub-components ────────────────────────────────────────────────────
 
@@ -382,9 +383,10 @@ function C4StatusBanner({ isFinished, winnerName, isDraw, currentDisc, currentPl
     )
 }
 
-function C4ResultOverlay({ winnerName, isDraw, isMyWin, onPlayAgain, onReturnToLobby, onLeave, onInspect, isLoading, isHost, t }: {
+function C4ResultOverlay({ winnerName, isDraw, isMyWin, onPlayAgain, onReturnToLobby, onLeave, onInspect, isLoading, isHost, isGuest, registerUrl, t }: {
     winnerName: string | null; isDraw: boolean; isMyWin: boolean
     onPlayAgain: () => void; onReturnToLobby: () => void; onLeave: () => void; onInspect: () => void; isLoading: boolean; isHost: boolean
+    isGuest: boolean; registerUrl: string
     t: (k: TranslationKeys, opts?: Record<string, unknown>) => string
 }) {
     return (
@@ -455,6 +457,11 @@ function C4ResultOverlay({ winnerName, isDraw, isMyWin, onPlayAgain, onReturnToL
                     {t('games.connect_four.game.leave')}
                 </button>
             </div>
+            {isGuest && (
+                <div style={{ width: '100%', maxWidth: 240 }}>
+                    <GuestConversionNudge registerUrl={registerUrl} />
+                </div>
+            )}
         </div>
     )
 }
@@ -1236,6 +1243,8 @@ export default function ConnectFourLobbyPage({ code, isSpectator = false, onGame
                             onInspect={() => setOverlayInspecting(true)}
                             isLoading={isRematchSubmitting}
                             isHost={!!lobby && lobby.creatorId === currentUserId}
+                            isGuest={isGuest}
+                            registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
                             t={t}
                         />
                     )}

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -27,6 +27,7 @@ import { Move } from '@/lib/game-engine'
 import { trackLobbyLeaveRedirect, trackMoveSubmitApplied } from '@/lib/analytics'
 import { sounds } from '@/lib/sounds'
 import { resolveLifecycleRedirectReason } from '@/lib/lobby-lifecycle'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 import { getLobbyPlayerRequirements } from '@/lib/lobby-player-requirements'
 import { ReactionOverlay } from '@/components/ReactionOverlay'
 import { useGameTimer } from './hooks/useGameTimer'
@@ -251,9 +252,10 @@ function TttStatusBanner({ isFinished, winnerName, isDraw, currentSymbol, curren
     )
 }
 
-function TttResultModal({ winnerName, winnerSymbol, isDraw, isMyWin, onPlayAgain, onReturnToLobby, onLeave, onInspect, isLoading, isHost, t }: {
+function TttResultModal({ winnerName, winnerSymbol, isDraw, isMyWin, onPlayAgain, onReturnToLobby, onLeave, onInspect, isLoading, isHost, isGuest, registerUrl, t }: {
     winnerName: string | null; winnerSymbol: string | null; isDraw: boolean; isMyWin: boolean;
     onPlayAgain: () => void; onReturnToLobby: () => void; onLeave: () => void; onInspect: () => void; isLoading: boolean; isHost: boolean;
+    isGuest: boolean; registerUrl: string;
     t: (key: TranslationKeys, opts?: string | Record<string, unknown>) => string;
 }) {
     const accentColor = winnerSymbol === 'X' ? 'var(--bd-coral)' : 'var(--bd-lav)'
@@ -318,6 +320,11 @@ function TttResultModal({ winnerName, winnerSymbol, isDraw, isMyWin, onPlayAgain
                     {t('games.tictactoe.game.leave')}
                 </button>
             </div>
+            {isGuest && (
+                <div style={{ width: '100%', maxWidth: 260 }}>
+                    <GuestConversionNudge registerUrl={registerUrl} />
+                </div>
+            )}
         </div>
     )
 }
@@ -1182,6 +1189,8 @@ export default function TicTacToeLobbyPage({ code, isSpectator = false, onGameRe
                     onInspect={() => setOverlayInspecting(true)}
                     isLoading={isRematchSubmitting}
                     isHost={isLobbyCreator}
+                    isGuest={isGuest}
+                    registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
                     t={t}
                 />
             )}

--- a/components/GuestConversionNudge.tsx
+++ b/components/GuestConversionNudge.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from '@/lib/i18n-helpers'
 
-const SESSION_KEY = 'boardly_guest_upgrade_dismissed'
+const DISMISS_KEY = 'boardly:guest-conversion-dismissed:v1'
 
 interface GuestConversionNudgeProps {
   registerUrl: string
@@ -15,17 +15,17 @@ export default function GuestConversionNudge({ registerUrl }: GuestConversionNud
 
   useEffect(() => {
     try {
-      if (!sessionStorage.getItem(SESSION_KEY)) {
+      if (!localStorage.getItem(DISMISS_KEY)) {
         setVisible(true)
       }
     } catch {
-      // sessionStorage unavailable (SSR or privacy mode) — don't show
+      // localStorage unavailable (SSR or privacy mode) — don't show
     }
   }, [])
 
   const dismiss = () => {
     try {
-      sessionStorage.setItem(SESSION_KEY, '1')
+      localStorage.setItem(DISMISS_KEY, '1')
     } catch {
       // ignore
     }

--- a/components/SpyResults.tsx
+++ b/components/SpyResults.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslation } from '@/lib/i18n-helpers'
 import { Player } from '@/lib/game-engine'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 type SpyPlayer = Player & { isPremium?: boolean }
 
@@ -21,6 +22,8 @@ interface SpyResultsProps {
   onRequestRematch?: () => void
   isRequestRematchPending?: boolean
   onBackToLobby?: () => void
+  isGuest?: boolean
+  registerUrl?: string
 }
 
 export default function SpyResults({
@@ -39,6 +42,8 @@ export default function SpyResults({
   onRequestRematch,
   isRequestRematchPending = false,
   onBackToLobby,
+  isGuest = false,
+  registerUrl = '/auth/register',
 }: SpyResultsProps) {
   const { t } = useTranslation()
 
@@ -196,6 +201,10 @@ export default function SpyResults({
             </>
           )}
         </div>
+
+        {isGameOver && isGuest && (
+          <GuestConversionNudge registerUrl={registerUrl} />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
\`GuestConversionNudge\` (the "create an account" card shown to guests, with locale copy in all 4 languages) already existed but was wired into exactly one of the six games' result screens — Yahtzee, which per the 2026-06-20 churn analysis is the *least*-played game by guests (W25: Memory 23, TTT 13, C4 5, Alias 4, Spy 3, Yahtzee 3). The five games carrying nearly all guest traffic showed nothing after a finished game.

## Changes
- Wired the nudge into Tic-Tac-Toe, Connect Four, Memory, Guess the Spy, and Alias result screens, matching the existing Yahtzee pattern
- Fixed dismiss persistence: `sessionStorage` → versioned `localStorage` key (`boardly:guest-conversion-dismissed:v1`), matching `InstallPrompt.tsx`. Previously the nudge reappeared every new browser session/tab instead of staying dismissed once a guest opted out.
- 4 new tests for `GuestConversionNudge`

## Verification
- `npx tsc --noEmit`, `npm run ci:quick`, `pnpm test`: clean, 707/707 passing (33 suites still fail to *run* due to the pre-existing unrelated `clearMocksOnScope` jest-runtime infra issue, confirmed present on develop before this work)
- Verified live via Playwright as a guest: played a Tic-Tac-Toe game vs bot to completion, confirmed the nudge renders with the correct `registerUrl` (`/auth/register?returnUrl=%2Flobby%2F6073`) and that dismissing it persists via `localStorage`. Connect Four's board has a headless-Playwright click-interception quirk unrelated to this change (couldn't drive a full game through automation); relying on the identical mechanical pattern + clean typecheck/lint for that one.
- No backend/registration changes — `app/api/user/upgrade-guest/route.ts` + `GuestContext`'s auth-transition effect already migrate a guest's data to the new account automatically on sign-up.

Closes #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)