### PR TITLE
#630 fix: Play vs Bot opens guest-name prompt instead of redirecting to login

### DIFF
--- a/__tests__/components/play-vs-bot-button.test.tsx
+++ b/__tests__/components/play-vs-bot-button.test.tsx
@@ -1,0 +1,79 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import PlayVsBotButton from '@/app/games/components/PlayVsBotButton'
+import { fetchWithGuest } from '@/lib/fetch-with-guest'
+
+const pushMock = jest.fn()
+const setGuestModeMock = jest.fn()
+
+jest.mock('@/lib/i18n-helpers', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+jest.mock('@/lib/i18n-toast', () => ({
+  showToast: {
+    error: jest.fn(),
+  },
+}))
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ status: 'unauthenticated' }),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => '/games/yahtzee',
+}))
+
+jest.mock('@/contexts/GuestContext', () => ({
+  useGuest: () => ({
+    isGuest: false,
+    setGuestMode: setGuestModeMock,
+  }),
+}))
+
+jest.mock('@/lib/fetch-with-guest', () => ({
+  fetchWithGuest: jest.fn(),
+}))
+
+describe('PlayVsBotButton — fresh guest flow', () => {
+  beforeEach(() => {
+    pushMock.mockClear()
+    setGuestModeMock.mockReset().mockResolvedValue(undefined)
+    ;(fetchWithGuest as jest.Mock).mockReset().mockResolvedValue({
+      ok: true,
+      json: async () => ({ lobbyCode: 'ABCD' }),
+    })
+  })
+
+  it('opens a guest-name prompt instead of redirecting to /auth/login when unauthenticated', async () => {
+    render(<PlayVsBotButton gameType="yahtzee" />)
+
+    fireEvent.click(screen.getByText('quickPlay.playVsBot', { exact: false }))
+    fireEvent.click(screen.getByText('lobby.create.difficultyEasy'))
+
+    expect(await screen.findByText('guest.playAsGuest')).toBeTruthy()
+    expect(pushMock).not.toHaveBeenCalledWith('/auth/login')
+  })
+
+  it('starts a quick-play game as the chosen difficulty once a guest name is submitted', async () => {
+    render(<PlayVsBotButton gameType="yahtzee" />)
+
+    fireEvent.click(screen.getByText('quickPlay.playVsBot', { exact: false }))
+    fireEvent.click(screen.getByText('lobby.create.difficultyEasy'))
+
+    const input = await screen.findByPlaceholderText('guest.namePlaceholder')
+    fireEvent.change(input, { target: { value: 'NewVisitor' } })
+    fireEvent.click(screen.getByText('guest.playAsGuest'))
+
+    await waitFor(() => expect(setGuestModeMock).toHaveBeenCalledWith('NewVisitor'))
+    await waitFor(() => expect(fetchWithGuest).toHaveBeenCalledWith(
+      '/api/quick-play',
+      expect.objectContaining({
+        body: JSON.stringify({ gameType: 'yahtzee', difficulty: 'easy', forceSolo: true }),
+      })
+    ))
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/lobby/ABCD'))
+  })
+})

--- a/app/games/components/PlayVsBotButton.tsx
+++ b/app/games/components/PlayVsBotButton.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { useTranslation, type TranslationKeys } from '@/lib/i18n-helpers'
 import { useGuest } from '@/contexts/GuestContext'
 import { fetchWithGuest } from '@/lib/fetch-with-guest'
 import { showToast } from '@/lib/i18n-toast'
+import { AuthGateModal } from '@/components/AuthGateModal'
 
 type Difficulty = 'easy' | 'medium' | 'hard'
 
@@ -24,18 +25,14 @@ interface PlayVsBotButtonProps {
 export default function PlayVsBotButton({ gameType, className = '' }: PlayVsBotButtonProps) {
   const { t } = useTranslation()
   const router = useRouter()
+  const pathname = usePathname()
   const { status } = useSession()
   const { isGuest } = useGuest()
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [pendingDifficulty, setPendingDifficulty] = useState<Difficulty | null>(null)
 
-  const handleDifficulty = async (difficulty: Difficulty) => {
-    if (status === 'unauthenticated' && !isGuest) {
-      showToast.error('quickPlay.signInToPlay')
-      router.push('/auth/login')
-      return
-    }
-
+  const startQuickPlay = async (difficulty: Difficulty) => {
     setLoading(true)
     try {
       const res = await fetchWithGuest('/api/quick-play', {
@@ -53,6 +50,17 @@ export default function PlayVsBotButton({ gameType, className = '' }: PlayVsBotB
       setLoading(false)
       setOpen(false)
     }
+  }
+
+  const handleDifficulty = async (difficulty: Difficulty) => {
+    if (status === 'unauthenticated' && !isGuest) {
+      // Let a fresh visitor pick a guest name right here instead of bouncing
+      // them to /auth/login — Play vs Bot is meant to work without an account.
+      setPendingDifficulty(difficulty)
+      return
+    }
+
+    await startQuickPlay(difficulty)
   }
 
   return (
@@ -95,6 +103,17 @@ export default function PlayVsBotButton({ gameType, className = '' }: PlayVsBotB
           </button>
         )}
       </div>
+      {pendingDifficulty && (
+        <AuthGateModal
+          dest={pathname}
+          onClose={() => { setPendingDifficulty(null); setOpen(false) }}
+          onGuestReady={() => {
+            const difficulty = pendingDifficulty
+            setPendingDifficulty(null)
+            void startQuickPlay(difficulty)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/components/AuthGateModal.tsx
+++ b/components/AuthGateModal.tsx
@@ -7,11 +7,15 @@ import { buildAuthUrl } from '@/lib/auth-redirect'
 import { useTranslation } from '@/lib/i18n-helpers'
 
 interface AuthGateModalProps {
+  /** Where Login/Sign Up should return to, and (if onGuestReady is omitted) where guest play navigates. */
   dest: string
   onClose: () => void
+  /** When provided, guest play calls this instead of navigating to `dest` — for flows that create
+   * their own destination after guest mode is set (e.g. Play vs Bot creating a lobby on demand). */
+  onGuestReady?: () => void
 }
 
-export function AuthGateModal({ dest, onClose }: AuthGateModalProps) {
+export function AuthGateModal({ dest, onClose, onGuestReady }: AuthGateModalProps) {
   const router = useRouter()
   const { t } = useTranslation()
   const { setGuestMode } = useGuest()
@@ -28,7 +32,11 @@ export function AuthGateModal({ dest, onClose }: AuthGateModalProps) {
     try {
       await setGuestMode(name.trim())
       onClose()
-      router.push(dest)
+      if (onGuestReady) {
+        onGuestReady()
+      } else {
+        router.push(dest)
+      }
     } catch {
       setError(t('guest.startFailed'))
       setLoading(false)


### PR DESCRIPTION
## Summary
A fresh visitor (no session, no guest identity) clicking Play vs Bot got bounced to `/auth/login`, contradicting the page copy right next to the button ("Free to play as a guest") and the `AuthGateModal` pattern already used elsewhere for exactly this situation.

## Changes
- `AuthGateModal`: added optional `onGuestReady` callback — used instead of navigating to a fixed `dest` when the caller needs to create its own destination after guest mode is set. Existing `dest`-based usage on `GameLobbiesPage` is unaffected.
- `PlayVsBotButton`: extracted `startQuickPlay()` from `handleDifficulty()` so the guest-name modal's `onGuestReady` can proceed directly with the quick-play request once a name is set, without re-checking (and tripping on) a stale `isGuest` closure value.

## Verification
- `npx tsc --noEmit`, `npm run ci:quick`, `pnpm test`: clean, 709/709 passing
- Verified live via Playwright on a clean anonymous session: Play vs Bot → Medium on Yahtzee now opens the guest-name prompt in place; submitting a name creates the lobby and navigates to it
- 2 new tests covering the unauthenticated flow

## Found while verifying (separate issue filed, not fixed here)
#631 — Yahtzee's `minPlayers: 1` means quick-play's bot-fill logic adds zero bots even when a difficulty was explicitly chosen, so the guest lands in an empty solo lobby. Pre-existing, unrelated to this fix, needs its own product decision.

Closes #630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)