### PR TITLE
#633 fix: dark mode contrast bugs + theme-doesn't-persist regression

### DIFF
--- a/app/games/components/GameDetailPage.tsx
+++ b/app/games/components/GameDetailPage.tsx
@@ -190,7 +190,7 @@ export default function GameDetailPage({
             </div>
             <ul className="grid gap-3 sm:grid-cols-2">
               {benefits.map((item) => (
-                <li key={item} className="rounded-2xl border border-bd-line bg-white px-4 py-3 text-sm font-semibold leading-relaxed text-bd-ink-soft">
+                <li key={item} className="rounded-2xl border border-bd-line bg-bd-card-warm px-4 py-3 text-sm font-semibold leading-relaxed text-bd-ink-soft">
                   {item}
                 </li>
               ))}

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -16,7 +16,7 @@ import LoadingSpinner from '@/components/LoadingSpinner'
 import { ReactionOverlay } from '@/components/ReactionOverlay'
 import { AliasGame, type AliasGameData } from '@/lib/games/alias'
 import { sounds } from '@/lib/sounds'
-import { getLobbyTheme } from '@/lib/lobby-themes'
+import { getThemePageStyle } from '@/lib/lobby-themes'
 import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 interface AliasPageProps {
@@ -107,14 +107,12 @@ const linkBtn: React.CSSProperties = {
 }
 
 function pageBg(theme?: string): React.CSSProperties {
-  const t = getLobbyTheme(theme)
   return {
     height: 'calc(100dvh - 4rem)',
     overflowY: 'auto',
-    background: t.bg,
-    color: t.text,
     padding: '14px 24px',
     fontFamily: 'ui-sans-serif, system-ui, -apple-system, sans-serif',
+    ...getThemePageStyle(theme),
   }
 }
 

--- a/app/lobby/[code]/components/MemoryGameBoard.tsx
+++ b/app/lobby/[code]/components/MemoryGameBoard.tsx
@@ -296,7 +296,7 @@ function MemoryPlayerCard({
   return (
     <div style={{
       display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 14,
-      background: isActive ? 'white' : 'transparent',
+      background: isActive ? 'var(--bd-input-bg)' : 'transparent',
       border: '2px solid ' + (isActive ? 'var(--bd-ink)' : 'transparent'),
       boxShadow: isActive ? '0 4px 0 var(--bd-ink)' : 'none',
       flexDirection: side === 'right' ? 'row-reverse' : 'row',
@@ -772,7 +772,7 @@ export default function MemoryGameBoard({
 
   const headerSection = (
     <div className="memory-header" style={{
-      background: 'linear-gradient(135deg, white 0%, rgba(79,201,166,0.08) 100%)',
+      background: 'linear-gradient(135deg, var(--bd-card-warm) 0%, rgba(79,201,166,0.08) 100%)',
     }}>
       {isTwoPlayer && player0 && player1 ? (
         <div style={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: 16 }}>
@@ -828,7 +828,7 @@ export default function MemoryGameBoard({
             return (
               <div key={player.id} style={{
                 display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderRadius: 12,
-                background: isActive ? 'white' : 'transparent',
+                background: isActive ? 'var(--bd-input-bg)' : 'transparent',
                 border: '2px solid ' + (isActive ? 'var(--bd-ink)' : 'var(--bd-line)'),
                 boxShadow: isActive ? '0 3px 0 var(--bd-ink)' : 'none',
                 flex: '1 1 auto', minWidth: 0, transition: 'all 0.2s',
@@ -955,7 +955,7 @@ export default function MemoryGameBoard({
               return (
                 <div key={player.id} style={{
                   display: 'flex', alignItems: 'center', gap: 6, padding: '4px 8px', borderRadius: 10,
-                  background: isActive ? 'white' : 'var(--bd-bg2)',
+                  background: isActive ? 'var(--bd-input-bg)' : 'var(--bd-bg2)',
                   border: '1.5px solid ' + (isActive ? 'var(--bd-ink)' : 'var(--bd-line)'),
                   boxShadow: isActive ? '0 2px 0 var(--bd-ink)' : 'none',
                   flex: '1 1 0', minWidth: 0, transition: 'all 0.2s',

--- a/app/lobby/[code]/connect-four-page.tsx
+++ b/app/lobby/[code]/connect-four-page.tsx
@@ -1123,7 +1123,7 @@ export default function ConnectFourLobbyPage({ code, isSpectator = false, onGame
     // ─── Sections ─────────────────────────────────────────────────────────────
 
     const headerSection = (
-        <div className="ttt-card" style={{ background: 'linear-gradient(135deg, white 0%, rgba(255,196,77,0.08) 100%)', padding: '12px 16px', overflow: 'hidden' }}>
+        <div className="ttt-card" style={{ background: 'linear-gradient(135deg, var(--bd-card-warm) 0%, rgba(255,196,77,0.08) 100%)', padding: '12px 16px', overflow: 'hidden' }}>
             <div style={{ position: 'relative', display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: 12 }}>
                 <C4PlayerCard name={p1Name} disc={1} isActive={!isFinished && gameData.currentDisc === 1} isWinner={!isDraw && winnerDisc === 1} wins={p1Wins} side="left" isLocalPlayer={myDisc === 1} avatarSrc={p1Avatar} isPremium={p1IsPremium} t={t} />
                 <div style={{ textAlign: 'center' }}>

--- a/app/lobby/[code]/rock-paper-scissors-page.tsx
+++ b/app/lobby/[code]/rock-paper-scissors-page.tsx
@@ -18,7 +18,7 @@ import { trackMoveSubmitApplied } from '@/lib/analytics'
 import { resolveLifecycleRedirectReason } from '@/lib/lobby-lifecycle'
 import { getLobbyPlayerRequirements } from '@/lib/lobby-player-requirements'
 import { ReactionOverlay } from '@/components/ReactionOverlay'
-import { getLobbyTheme } from '@/lib/lobby-themes'
+import { getThemePageStyle } from '@/lib/lobby-themes'
 
 type RpsLifecycleStatus = 'waiting' | 'playing' | 'finished' | 'abandoned' | 'cancelled'
 
@@ -471,10 +471,8 @@ export default function RockPaperScissorsLobbyPage({ code, isSpectator = false }
         )
     }
 
-    const themeColors = getLobbyTheme(lobby?.theme)
-
     return (
-        <div className="h-[calc(100dvh-4rem)] overflow-y-auto" style={{ background: themeColors.bg, color: themeColors.text }}>
+        <div className="h-[calc(100dvh-4rem)] overflow-y-auto" style={getThemePageStyle(lobby?.theme)}>
         <div className="px-4 py-5 sm:px-6 sm:py-8 min-h-full">
             <div className="mx-auto max-w-5xl space-y-5">
                 <header className="rounded-2xl border border-[var(--bd-line)] bg-[var(--bd-bg)] p-4 shadow-sm sm:p-5">

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -110,7 +110,7 @@ function TttPlayerCard({ name, symbol, isActive, isWinner, side, avatarSrc, isPr
     return (
         <div style={{
             display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 14,
-            background: isActive ? 'white' : 'transparent',
+            background: isActive ? 'var(--bd-input-bg)' : 'transparent',
             border: '2px solid ' + (isActive ? 'var(--bd-ink)' : 'transparent'),
             boxShadow: isActive ? '0 4px 0 var(--bd-ink)' : 'none',
             flexDirection: side === 'right' ? 'row-reverse' : 'row',
@@ -1064,7 +1064,7 @@ export default function TicTacToeLobbyPage({ code, isSpectator = false, onGameRe
 
     const headerSection = (
         <div className="ttt-card" style={{
-            background: 'linear-gradient(135deg, white 0%, rgba(255,196,77,0.10) 100%)',
+            background: 'linear-gradient(135deg, var(--bd-card-warm) 0%, rgba(255,196,77,0.10) 100%)',
             overflow: 'hidden', padding: '12px 16px',
         }}>
             <div style={{ position: 'absolute', right: -30, top: -30, opacity: 0.4, transform: 'rotate(8deg)', pointerEvents: 'none' }}>

--- a/app/lobby/page.tsx
+++ b/app/lobby/page.tsx
@@ -64,7 +64,7 @@ function LobbyListPageContent() {
         {/* Page header */}
         <div
           className="bd-card relative mb-6 overflow-hidden p-7 sm:p-8"
-          style={{ background: 'linear-gradient(120deg, white 0%, rgba(155,140,255,0.08) 100%)' }}
+          style={{ background: 'linear-gradient(120deg, var(--bd-card-warm) 0%, rgba(155,140,255,0.08) 100%)' }}
         >
           <div className="bd-dot-grid absolute inset-0 opacity-35" />
           <div className="relative flex flex-col gap-6 sm:flex-row sm:items-stretch">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -8,7 +8,6 @@ import { GuestProvider } from '@/contexts/GuestContext'
 import { OnboardingProvider } from '@/contexts/OnboardingContext'
 import DeferredGlobalEffects from '@/components/DeferredGlobalEffects'
 import i18n from '@/i18n'
-import { applyThemeMode } from '@/lib/theme'
 import { getStoredAppearanceLocale } from '@/lib/appearance-preferences'
 
 const OnboardingModal = dynamic(
@@ -27,10 +26,6 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     if (i18n.language !== nextLanguage) {
       void i18n.changeLanguage(nextLanguage)
     }
-  }, [])
-
-  useEffect(() => {
-    applyThemeMode('light')
   }, [])
 
   return (

--- a/components/HomePage/CtaBanner.tsx
+++ b/components/HomePage/CtaBanner.tsx
@@ -96,7 +96,8 @@ export default function CtaBanner() {
           <p
             style={{
               fontSize: 17,
-              color: 'rgba(251,246,238,0.7)',
+              color: 'var(--bd-bg)',
+              opacity: 0.7,
               marginBottom: 28,
               maxWidth: 420,
               lineHeight: 1.5,

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -148,7 +148,7 @@ export default function HeroDemoConnectFour() {
     }}>
       <div style={{
         fontFamily: 'var(--bd-font-display)', fontWeight: 600, fontSize: 11,
-        color: 'rgba(31,27,22,0.55)', minHeight: isMobile ? 0 : 16, textAlign: 'center', width: '100%',
+        color: 'var(--bd-ink-muted)', minHeight: isMobile ? 0 : 16, textAlign: 'center', width: '100%',
       }}>
         {statusText}
       </div>
@@ -247,7 +247,7 @@ export default function HeroDemoConnectFour() {
         href="/games/connect-four"
         style={{
           fontSize: 12, fontWeight: 600,
-          color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 2,
+          color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
         Play full game →

--- a/components/HomePage/HeroDemoMemory.tsx
+++ b/components/HomePage/HeroDemoMemory.tsx
@@ -71,7 +71,7 @@ export default function HeroDemoMemory() {
     }}>
       <div style={{
         fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: isMobile ? 12 : 14,
-        color: 'rgba(31,27,22,0.8)', minHeight: isMobile ? 18 : 22,
+        color: 'var(--bd-ink-muted)', minHeight: isMobile ? 18 : 22,
       }}>
         {allMatched ? '🎉 All matched!' : `${matchedCount} / ${PAIRS.length} pairs`}
       </div>
@@ -85,15 +85,13 @@ export default function HeroDemoMemory() {
               onClick={() => handleFlip(i)}
               style={{
                 width: CARD_W, height: CARD_H,
-                background: card.matched
-                  ? 'rgba(255,255,255,0.85)'
-                  : isFlipped
-                    ? '#fff'
-                    : 'var(--bd-ink)',
+                background: card.matched || isFlipped
+                  ? 'var(--bd-input-bg)'
+                  : 'var(--bd-ink)',
                 border: `2.5px solid ${card.matched ? 'rgba(31,27,22,0.2)' : 'var(--bd-ink)'}`,
                 borderRadius: 10,
                 fontSize: isFlipped ? 24 : 16,
-                color: isFlipped ? 'var(--bd-ink)' : 'rgba(255,255,255,0.35)',
+                color: isFlipped ? 'var(--bd-ink)' : 'var(--bd-bg)',
                 cursor: card.matched || locked ? 'default' : 'pointer',
                 boxShadow: isFlipped ? 'none' : '0 4px 0 rgba(31,27,22,0.35)',
                 transition: 'background 0.18s, box-shadow 0.18s, font-size 0.12s',
@@ -111,7 +109,7 @@ export default function HeroDemoMemory() {
         href="/games/memory"
         style={{
           fontSize: 12, fontWeight: 600,
-          color: 'rgba(31,27,22,0.6)', textDecoration: 'underline', marginTop: 2,
+          color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
         Play full game →

--- a/components/HomePage/HeroDemoTicTacToe.tsx
+++ b/components/HomePage/HeroDemoTicTacToe.tsx
@@ -80,7 +80,7 @@ export default function HeroDemoTicTacToe() {
     }}>
       <div style={{
         fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 14,
-        color: 'rgba(31,27,22,0.7)', minHeight: 22,
+        color: 'var(--bd-ink-muted)', minHeight: 22,
       }}>
         {statusText}
       </div>
@@ -92,7 +92,7 @@ export default function HeroDemoTicTacToe() {
             onClick={() => handleClick(i)}
             style={{
               width: 64, height: 64,
-              background: '#fff',
+              background: 'var(--bd-input-bg)',
               border: '2.5px solid var(--bd-ink)',
               borderRadius: 14,
               fontSize: 28,
@@ -115,7 +115,7 @@ export default function HeroDemoTicTacToe() {
         href="/games/tic-tac-toe"
         style={{
           fontSize: 12, fontWeight: 600,
-          color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 2,
+          color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
         Play full game →

--- a/components/PublicProfileView.tsx
+++ b/components/PublicProfileView.tsx
@@ -448,7 +448,7 @@ export default function PublicProfileView({
           <div
             className="relative w-full overflow-hidden rounded-[2rem] border-[1.5px]"
             style={{
-              background: pageTheme?.cardBg ?? 'white',
+              background: pageTheme?.cardBg ?? 'var(--bd-input-bg)',
               borderColor: pageTheme?.cardBorder ?? 'var(--bd-line)',
               boxShadow: pageTheme?.cardShadow ?? '0 6px 0 0 rgba(31,27,22,0.08), 0 14px 28px -10px rgba(31,27,22,0.18)',
             }}


### PR DESCRIPTION
## Summary
- Critical: `providers.tsx` forced light theme on every mount, overriding stored dark/system preference
- White-gradient headers + active-card backgrounds ignoring `html.dark` in Memory/TTT/C4/lobby-list
- Homepage hero demo boards (TTT/C4/Memory) had hardcoded white/ink-rgba combos
- `CtaBanner.tsx` body text invisible on its own inverted band in dark mode
- Shared `GameDetailPage.tsx` "why play" cards — affects all 8 game detail pages
- `PublicProfileView.tsx` profile card hardcoded to white (affects non-premium users + the real `/u/[id]` page)
- Alias entirely ignored `html.dark` (own local `pageBg()` helper bypassing the theme system) — all 4 Alias screens
- Rock-Paper-Scissors had the identical bug, fixed by the same pattern (not live-verified, RPS creation currently disabled)

## Test plan
- [x] `tsc --noEmit` clean, `pnpm test` 709/709 real tests passing throughout
- [x] Verified live in a real browser (light + dark + persistence-after-reload): home, games catalog, game detail page, guides, leaderboard, privacy, login, register, lobby create, profile (all 6 tabs), notifications dropdown, public profile view
- [x] Verified actual gameplay live for Connect Four, Memory, Tic-Tac-Toe, Guess the Spy, and Alias (filled missing players via the lobby's own `join-guest` API where bots aren't supported)
- [x] Checked for unwanted page-level scroll across lobby create/waiting room/in-game boards at multiple viewport sizes (1440×900 down to 660px tall, plus mobile 390×844) — none found
- [ ] RPS fix not live-verified (lobby creation disabled site-wide); applied by direct code analogy to the proven Alias fix

Closes #633