### PR TITLE
#631 fix: Play vs Bot guarantees a bot opponent even when minPlayers is 1

### DIFF
--- a/__tests__/lib/quick-play.test.ts
+++ b/__tests__/lib/quick-play.test.ts
@@ -1,0 +1,21 @@
+import { resolveBotTarget } from '@/lib/quick-play'
+
+describe('resolveBotTarget', () => {
+  it('guarantees at least one bot for forceSolo (Play vs Bot) even when minPlayers is 1', () => {
+    // Yahtzee: minPlayers 1 — without this, fillWithBots would add zero bots
+    // despite the player explicitly choosing a difficulty (#631).
+    expect(resolveBotTarget(1, true)).toBe(2)
+  })
+
+  it('leaves multi-player-minimum games unaffected for forceSolo', () => {
+    // Tic-Tac-Toe: minPlayers 2 — already guarantees an opponent.
+    expect(resolveBotTarget(2, true)).toBe(2)
+    expect(resolveBotTarget(4, true)).toBe(4)
+  })
+
+  it('does not change ordinary quick-play matchmaking (forceSolo: false)', () => {
+    expect(resolveBotTarget(1, false)).toBe(1)
+    expect(resolveBotTarget(2, false)).toBe(2)
+    expect(resolveBotTarget(4, false)).toBe(4)
+  })
+})

--- a/app/api/quick-play/route.ts
+++ b/app/api/quick-play/route.ts
@@ -14,6 +14,7 @@ import { toPersistedGameStateInput } from '@/lib/persisted-game-state'
 import { broadcastToLobby } from '@/lib/supabase-server'
 import { getBotDisplayName, normalizeBotDifficulty } from '@/lib/bot-profiles'
 import { getOrCreateBotUser, isPrismaUniqueConstraintError } from '@/lib/bot-helpers'
+import { resolveBotTarget } from '@/lib/quick-play'
 
 const log = apiLogger('/api/quick-play')
 
@@ -277,9 +278,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Failed to create lobby' }, { status: 503 })
   }
 
-  // Fill with bots (1 human already in, need minPlayers - 1 bots)
+  // Fill with bots (1 human already in, need botTarget - 1 bots) — see
+  // resolveBotTarget for why this isn't always just minPlayers.
+  const botTarget = resolveBotTarget(minPlayers, forceSolo)
   try {
-    await fillWithBots(newCode, gameId, gameType, 1, minPlayers, user.id, difficulty)
+    await fillWithBots(newCode, gameId, gameType, 1, botTarget, user.id, difficulty)
   } catch (err) {
     log.error('Quick play: bot fill failed', err as Error)
     // Non-fatal — user is still in the lobby

--- a/lib/quick-play.ts
+++ b/lib/quick-play.ts
@@ -1,0 +1,12 @@
+/**
+ * How many total players a freshly-created quick-play lobby should have
+ * after bot-filling. Ordinary matchmaking (forceSolo: false) targets
+ * minPlayers as before. forceSolo (Play vs Bot) explicitly asks for a bot
+ * opponent at a chosen difficulty — for solo-capable games (minPlayers: 1,
+ * e.g. Yahtzee) minPlayers alone is already met by the human, which would
+ * leave the player with zero bots despite picking a difficulty. Guarantee
+ * at least one bot in that case.
+ */
+export function resolveBotTarget(minPlayers: number, forceSolo: boolean): number {
+  return forceSolo ? Math.max(minPlayers, 2) : minPlayers
+}


### PR DESCRIPTION
## Summary
Yahtzee has `minPlayers: 1` (fully solo-capable). Quick-play's bot-fill logic targeted `minPlayers`, so for Yahtzee the human alone already met that target and zero bots were added — even when the visitor explicitly picked a bot difficulty via Play vs Bot. They'd land in an empty 1-player lobby with no opponent.

## Fix
Extracted `resolveBotTarget(minPlayers, forceSolo)` to `lib/quick-play.ts`:
- Ordinary quick-play matchmaking (`forceSolo: false`) keeps targeting `minPlayers` as before — unaffected.
- `forceSolo` (Play vs Bot) now guarantees at least one bot (`max(minPlayers, 2)`).

## Verification
- `npx tsc --noEmit`, `npm run ci:quick`, `pnpm test`: clean, 712/712 passing
- 3 new unit tests for `resolveBotTarget`
- Verified live via Playwright on a clean anonymous session: Yahtzee → Play vs Bot → Easy → guest name → lobby now shows 2/4 players with "Dice Rookie" (AI, Easy) present, instead of 1/4 with no bot

Closes #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)