### PR TITLE
Release v1.4.0

### DIFF
--- a/__tests__/api/leaderboard.test.ts
+++ b/__tests__/api/leaderboard.test.ts
@@ -78,4 +78,12 @@ describe('GET /api/leaderboard', () => {
     expect(sql).toContain("result->>'userId' = p.\"userId\"")
     expect(sql).toContain("result->>'isWinner' = 'true'")
   })
+
+  it('caches for a short window only, so profile changes (username, etc.) show up quickly (#638)', async () => {
+    const response = await GET(buildRequest())
+
+    // Was s-maxage=300/stale-while-revalidate=600 — let a stale username/avatar
+    // linger on the leaderboard for up to ~15 minutes despite a live DB query.
+    expect(response.headers.get('Cache-Control')).toBe('public, s-maxage=20, stale-while-revalidate=60')
+  })
 })

--- a/__tests__/components/guest-conversion-nudge.test.tsx
+++ b/__tests__/components/guest-conversion-nudge.test.tsx
@@ -1,0 +1,53 @@
+import { act, render, screen } from '@testing-library/react'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
+
+jest.mock('@/lib/i18n-helpers', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const DISMISS_KEY = 'boardly:guest-conversion-dismissed:v1'
+
+describe('GuestConversionNudge', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders by default for a guest who has not dismissed it', () => {
+    render(<GuestConversionNudge registerUrl="/auth/register" />)
+
+    expect(screen.queryByText('auth.guestConversion.headline')).not.toBeNull()
+  })
+
+  it('dismissing persists via localStorage (survives remount, unlike sessionStorage)', () => {
+    const { unmount } = render(<GuestConversionNudge registerUrl="/auth/register" />)
+
+    act(() => {
+      screen.getByText('auth.guestConversion.dismiss').click()
+    })
+
+    expect(screen.queryByText('auth.guestConversion.headline')).toBeNull()
+    expect(localStorage.getItem(DISMISS_KEY)).toBe('1')
+
+    unmount()
+    render(<GuestConversionNudge registerUrl="/auth/register" />)
+
+    expect(screen.queryByText('auth.guestConversion.headline')).toBeNull()
+  })
+
+  it('does not render if already dismissed in a prior session', () => {
+    localStorage.setItem(DISMISS_KEY, '1')
+
+    render(<GuestConversionNudge registerUrl="/auth/register" />)
+
+    expect(screen.queryByText('auth.guestConversion.headline')).toBeNull()
+  })
+
+  it('links the CTA to the provided registerUrl', () => {
+    render(<GuestConversionNudge registerUrl="/auth/register?returnUrl=%2Flobby%2FABCD" />)
+
+    const cta = screen.getByText('auth.guestConversion.cta').closest('a')
+    expect(cta?.getAttribute('href')).toBe('/auth/register?returnUrl=%2Flobby%2FABCD')
+  })
+})

--- a/__tests__/components/play-vs-bot-button.test.tsx
+++ b/__tests__/components/play-vs-bot-button.test.tsx
@@ -1,0 +1,79 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import PlayVsBotButton from '@/app/games/components/PlayVsBotButton'
+import { fetchWithGuest } from '@/lib/fetch-with-guest'
+
+const pushMock = jest.fn()
+const setGuestModeMock = jest.fn()
+
+jest.mock('@/lib/i18n-helpers', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+jest.mock('@/lib/i18n-toast', () => ({
+  showToast: {
+    error: jest.fn(),
+  },
+}))
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ status: 'unauthenticated' }),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => '/games/yahtzee',
+}))
+
+jest.mock('@/contexts/GuestContext', () => ({
+  useGuest: () => ({
+    isGuest: false,
+    setGuestMode: setGuestModeMock,
+  }),
+}))
+
+jest.mock('@/lib/fetch-with-guest', () => ({
+  fetchWithGuest: jest.fn(),
+}))
+
+describe('PlayVsBotButton — fresh guest flow', () => {
+  beforeEach(() => {
+    pushMock.mockClear()
+    setGuestModeMock.mockReset().mockResolvedValue(undefined)
+    ;(fetchWithGuest as jest.Mock).mockReset().mockResolvedValue({
+      ok: true,
+      json: async () => ({ lobbyCode: 'ABCD' }),
+    })
+  })
+
+  it('opens a guest-name prompt instead of redirecting to /auth/login when unauthenticated', async () => {
+    render(<PlayVsBotButton gameType="yahtzee" />)
+
+    fireEvent.click(screen.getByText('quickPlay.playVsBot', { exact: false }))
+    fireEvent.click(screen.getByText('lobby.create.difficultyEasy'))
+
+    expect(await screen.findByText('guest.playAsGuest')).toBeTruthy()
+    expect(pushMock).not.toHaveBeenCalledWith('/auth/login')
+  })
+
+  it('starts a quick-play game as the chosen difficulty once a guest name is submitted', async () => {
+    render(<PlayVsBotButton gameType="yahtzee" />)
+
+    fireEvent.click(screen.getByText('quickPlay.playVsBot', { exact: false }))
+    fireEvent.click(screen.getByText('lobby.create.difficultyEasy'))
+
+    const input = await screen.findByPlaceholderText('guest.namePlaceholder')
+    fireEvent.change(input, { target: { value: 'NewVisitor' } })
+    fireEvent.click(screen.getByText('guest.playAsGuest'))
+
+    await waitFor(() => expect(setGuestModeMock).toHaveBeenCalledWith('NewVisitor'))
+    await waitFor(() => expect(fetchWithGuest).toHaveBeenCalledWith(
+      '/api/quick-play',
+      expect.objectContaining({
+        body: JSON.stringify({ gameType: 'yahtzee', difficulty: 'easy', forceSolo: true }),
+      })
+    ))
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/lobby/ABCD'))
+  })
+})

--- a/__tests__/lib/quick-play.test.ts
+++ b/__tests__/lib/quick-play.test.ts
@@ -1,0 +1,21 @@
+import { resolveBotTarget } from '@/lib/quick-play'
+
+describe('resolveBotTarget', () => {
+  it('guarantees at least one bot for forceSolo (Play vs Bot) even when minPlayers is 1', () => {
+    // Yahtzee: minPlayers 1 — without this, fillWithBots would add zero bots
+    // despite the player explicitly choosing a difficulty (#631).
+    expect(resolveBotTarget(1, true)).toBe(2)
+  })
+
+  it('leaves multi-player-minimum games unaffected for forceSolo', () => {
+    // Tic-Tac-Toe: minPlayers 2 — already guarantees an opponent.
+    expect(resolveBotTarget(2, true)).toBe(2)
+    expect(resolveBotTarget(4, true)).toBe(4)
+  })
+
+  it('does not change ordinary quick-play matchmaking (forceSolo: false)', () => {
+    expect(resolveBotTarget(1, false)).toBe(1)
+    expect(resolveBotTarget(2, false)).toBe(2)
+    expect(resolveBotTarget(4, false)).toBe(4)
+  })
+})

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -166,7 +166,9 @@ export async function GET(req: NextRequest) {
       { entries, hasMore: entries.length === PAGE_SIZE },
       {
         headers: {
-          'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+          // Short max-age so profile changes (username, avatar, premium badge) show up
+          // quickly — was 300s/600s, which let stale data linger for up to ~15 min (#638).
+          'Cache-Control': 'public, s-maxage=20, stale-while-revalidate=60',
         },
       }
     )

--- a/app/api/quick-play/route.ts
+++ b/app/api/quick-play/route.ts
@@ -14,6 +14,7 @@ import { toPersistedGameStateInput } from '@/lib/persisted-game-state'
 import { broadcastToLobby } from '@/lib/supabase-server'
 import { getBotDisplayName, normalizeBotDifficulty } from '@/lib/bot-profiles'
 import { getOrCreateBotUser, isPrismaUniqueConstraintError } from '@/lib/bot-helpers'
+import { resolveBotTarget } from '@/lib/quick-play'
 
 const log = apiLogger('/api/quick-play')
 
@@ -277,9 +278,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Failed to create lobby' }, { status: 503 })
   }
 
-  // Fill with bots (1 human already in, need minPlayers - 1 bots)
+  // Fill with bots (1 human already in, need botTarget - 1 bots) — see
+  // resolveBotTarget for why this isn't always just minPlayers.
+  const botTarget = resolveBotTarget(minPlayers, forceSolo)
   try {
-    await fillWithBots(newCode, gameId, gameType, 1, minPlayers, user.id, difficulty)
+    await fillWithBots(newCode, gameId, gameType, 1, botTarget, user.id, difficulty)
   } catch (err) {
     log.error('Quick play: bot fill failed', err as Error)
     // Non-fatal — user is still in the lobby

--- a/app/games/components/GameDetailPage.tsx
+++ b/app/games/components/GameDetailPage.tsx
@@ -190,7 +190,7 @@ export default function GameDetailPage({
             </div>
             <ul className="grid gap-3 sm:grid-cols-2">
               {benefits.map((item) => (
-                <li key={item} className="rounded-2xl border border-bd-line bg-white px-4 py-3 text-sm font-semibold leading-relaxed text-bd-ink-soft">
+                <li key={item} className="rounded-2xl border border-bd-line bg-bd-card-warm px-4 py-3 text-sm font-semibold leading-relaxed text-bd-ink-soft">
                   {item}
                 </li>
               ))}

--- a/app/games/components/PlayVsBotButton.tsx
+++ b/app/games/components/PlayVsBotButton.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { useTranslation, type TranslationKeys } from '@/lib/i18n-helpers'
 import { useGuest } from '@/contexts/GuestContext'
 import { fetchWithGuest } from '@/lib/fetch-with-guest'
 import { showToast } from '@/lib/i18n-toast'
+import { AuthGateModal } from '@/components/AuthGateModal'
 
 type Difficulty = 'easy' | 'medium' | 'hard'
 
@@ -24,18 +25,14 @@ interface PlayVsBotButtonProps {
 export default function PlayVsBotButton({ gameType, className = '' }: PlayVsBotButtonProps) {
   const { t } = useTranslation()
   const router = useRouter()
+  const pathname = usePathname()
   const { status } = useSession()
   const { isGuest } = useGuest()
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [pendingDifficulty, setPendingDifficulty] = useState<Difficulty | null>(null)
 
-  const handleDifficulty = async (difficulty: Difficulty) => {
-    if (status === 'unauthenticated' && !isGuest) {
-      showToast.error('quickPlay.signInToPlay')
-      router.push('/auth/login')
-      return
-    }
-
+  const startQuickPlay = async (difficulty: Difficulty) => {
     setLoading(true)
     try {
       const res = await fetchWithGuest('/api/quick-play', {
@@ -53,6 +50,17 @@ export default function PlayVsBotButton({ gameType, className = '' }: PlayVsBotB
       setLoading(false)
       setOpen(false)
     }
+  }
+
+  const handleDifficulty = async (difficulty: Difficulty) => {
+    if (status === 'unauthenticated' && !isGuest) {
+      // Let a fresh visitor pick a guest name right here instead of bouncing
+      // them to /auth/login — Play vs Bot is meant to work without an account.
+      setPendingDifficulty(difficulty)
+      return
+    }
+
+    await startQuickPlay(difficulty)
   }
 
   return (
@@ -95,6 +103,17 @@ export default function PlayVsBotButton({ gameType, className = '' }: PlayVsBotB
           </button>
         )}
       </div>
+      {pendingDifficulty && (
+        <AuthGateModal
+          dest={pathname}
+          onClose={() => { setPendingDifficulty(null); setOpen(false) }}
+          onGuestReady={() => {
+            const difficulty = pendingDifficulty
+            setPendingDifficulty(null)
+            void startQuickPlay(difficulty)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import * as Sentry from "@sentry/nextjs";
 import { useEffect } from "react";
 import BoardlyErrorState from "@/components/BoardlyErrorState";
+import { getThemeInitScript } from "@/lib/theme";
 
 export default function GlobalError({
   error,
@@ -17,7 +18,13 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html>
+    <html suppressHydrationWarning>
+      <head>
+        <script
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: getThemeInitScript() }}
+        />
+      </head>
       <body>
         <BoardlyErrorState
           error={error}

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -2582,6 +2582,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
               onPlayAgain={handleStartGame}
               onRequestRematch={handleRequestRematch}
               onBackToLobby={() => router.push(getGameLobbiesRoute(lobby.gameType) ?? '/games')}
+              registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
             />
           ) : gameEngine && (lobby?.gameType as string) === 'memory' && game?.id ? (
             <MemoryGameBoard
@@ -2601,6 +2602,8 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
               someoneTyping={someoneTyping}
               playerProfiles={chatPlayerProfiles}
               onProfileClick={setProfileUserId}
+              isGuest={isGuest}
+              registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
             />
           ) : gameEngine ? (
             <div className="flex h-full items-center justify-center p-4">

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -1400,26 +1400,24 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
                 </div>
               </div>
 
-              {isHost ? (
-                <button
-                  style={{ ...primaryBtn, fontSize: 17, padding: '16px 22px', width: '100%', justifyContent: 'center' }}
-                  onClick={() => handleMove('next_turn', {})}
-                  disabled={isMoveSubmitting}
-                >
-                  {t('alias.nextTurn')}
-                  <span aria-hidden style={{ fontSize: 18 }}>→</span>
-                </button>
-              ) : (
-                <span style={{
-                  display: 'inline-flex', alignItems: 'center', gap: 8, justifyContent: 'center',
-                  background: 'var(--bd-bg2)', border: '1.5px solid var(--bd-line)',
-                  borderRadius: 999, padding: '14px 18px',
-                  fontSize: 14, fontWeight: 600, color: 'var(--bd-ink-soft)',
-                }}>
-                  <span className="bd-float" style={{ width: 8, height: 8, borderRadius: 999, background: 'var(--bd-ink-muted)' }} />
-                  Waiting for host…
-                </span>
-              )}
+              {/*
+                Next Turn is open to every player, not just the host — the engine's own
+                validateMove for 'next_turn' has no player-ownership check (any player can
+                legally advance past turn_results). Gating this to isHost made the game
+                permanently soft-lock for everyone else whenever the host didn't click
+                through (closed tab, disconnected, distracted) — see #639.
+              */}
+              <button
+                style={{ ...primaryBtn, fontSize: 17, padding: '16px 22px', width: '100%', justifyContent: 'center' }}
+                onClick={() => handleMove('next_turn', {})}
+                disabled={isMoveSubmitting}
+              >
+                {t('alias.nextTurn')}
+                <span aria-hidden style={{ fontSize: 18 }}>→</span>
+              </button>
+              <button style={{ ...linkBtn, textAlign: 'center' }} onClick={() => router.push('/games')}>
+                {t('lobby.game.leaveGame')}
+              </button>
             </section>
           </main>
         </div>

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -17,6 +17,7 @@ import { ReactionOverlay } from '@/components/ReactionOverlay'
 import { AliasGame, type AliasGameData } from '@/lib/games/alias'
 import { sounds } from '@/lib/sounds'
 import { getLobbyTheme } from '@/lib/lobby-themes'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 interface AliasPageProps {
   code: string
@@ -1526,6 +1527,12 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
             )}
             <button style={linkBtn} onClick={() => router.push('/games')}>Leave game</button>
           </div>
+
+          {isGuest && (
+            <div style={{ width: '100%', maxWidth: 420 }}>
+              <GuestConversionNudge registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`} />
+            </div>
+          )}
         </main>
       </div>
     )

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -16,7 +16,7 @@ import LoadingSpinner from '@/components/LoadingSpinner'
 import { ReactionOverlay } from '@/components/ReactionOverlay'
 import { AliasGame, type AliasGameData } from '@/lib/games/alias'
 import { sounds } from '@/lib/sounds'
-import { getLobbyTheme } from '@/lib/lobby-themes'
+import { getThemePageStyle } from '@/lib/lobby-themes'
 import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 interface AliasPageProps {
@@ -107,14 +107,12 @@ const linkBtn: React.CSSProperties = {
 }
 
 function pageBg(theme?: string): React.CSSProperties {
-  const t = getLobbyTheme(theme)
   return {
     height: 'calc(100dvh - 4rem)',
     overflowY: 'auto',
-    background: t.bg,
-    color: t.text,
     padding: '14px 24px',
     fontFamily: 'ui-sans-serif, system-ui, -apple-system, sans-serif',
+    ...getThemePageStyle(theme),
   }
 }
 

--- a/app/lobby/[code]/components/MemoryGameBoard.tsx
+++ b/app/lobby/[code]/components/MemoryGameBoard.tsx
@@ -296,7 +296,7 @@ function MemoryPlayerCard({
   return (
     <div style={{
       display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 14,
-      background: isActive ? 'white' : 'transparent',
+      background: isActive ? 'var(--bd-input-bg)' : 'transparent',
       border: '2px solid ' + (isActive ? 'var(--bd-ink)' : 'transparent'),
       boxShadow: isActive ? '0 4px 0 var(--bd-ink)' : 'none',
       flexDirection: side === 'right' ? 'row-reverse' : 'row',
@@ -772,7 +772,7 @@ export default function MemoryGameBoard({
 
   const headerSection = (
     <div className="memory-header" style={{
-      background: 'linear-gradient(135deg, white 0%, rgba(79,201,166,0.08) 100%)',
+      background: 'linear-gradient(135deg, var(--bd-card-warm) 0%, rgba(79,201,166,0.08) 100%)',
     }}>
       {isTwoPlayer && player0 && player1 ? (
         <div style={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: 16 }}>
@@ -828,7 +828,7 @@ export default function MemoryGameBoard({
             return (
               <div key={player.id} style={{
                 display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderRadius: 12,
-                background: isActive ? 'white' : 'transparent',
+                background: isActive ? 'var(--bd-input-bg)' : 'transparent',
                 border: '2px solid ' + (isActive ? 'var(--bd-ink)' : 'var(--bd-line)'),
                 boxShadow: isActive ? '0 3px 0 var(--bd-ink)' : 'none',
                 flex: '1 1 auto', minWidth: 0, transition: 'all 0.2s',
@@ -955,7 +955,7 @@ export default function MemoryGameBoard({
               return (
                 <div key={player.id} style={{
                   display: 'flex', alignItems: 'center', gap: 6, padding: '4px 8px', borderRadius: 10,
-                  background: isActive ? 'white' : 'var(--bd-bg2)',
+                  background: isActive ? 'var(--bd-input-bg)' : 'var(--bd-bg2)',
                   border: '1.5px solid ' + (isActive ? 'var(--bd-ink)' : 'var(--bd-line)'),
                   boxShadow: isActive ? '0 2px 0 var(--bd-ink)' : 'none',
                   flex: '1 1 0', minWidth: 0, transition: 'all 0.2s',

--- a/app/lobby/[code]/components/MemoryGameBoard.tsx
+++ b/app/lobby/[code]/components/MemoryGameBoard.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from '@/components/LoadingSpinner'
 import Chat from '@/components/Chat'
 import { useGameTimer } from '../hooks/useGameTimer'
 import { sounds } from '@/lib/sounds'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 interface LobbyPlayer {
   id: string
@@ -66,6 +67,8 @@ interface MemoryGameBoardProps {
   someoneTyping?: boolean
   playerProfiles?: Map<string, { avatarUrl?: string | null; isPremium?: boolean }>
   onProfileClick?: (userId: string) => void
+  isGuest?: boolean
+  registerUrl?: string
 }
 
 const MISMATCH_RESOLVE_DELAY_MS = 1200
@@ -95,6 +98,8 @@ interface MemoryResultModalProps {
   onReturnToWaiting?: () => void
   onLeave?: () => void
   onInspect: () => void
+  isGuest?: boolean
+  registerUrl?: string
   t: (key: TranslationKeys, opts?: string | Record<string, unknown>) => string
 }
 
@@ -108,6 +113,8 @@ function MemoryResultModal({
   onReturnToWaiting,
   onLeave,
   onInspect,
+  isGuest,
+  registerUrl,
   t,
 }: MemoryResultModalProps) {
   const ghostBtn: React.CSSProperties = {
@@ -258,6 +265,11 @@ function MemoryResultModal({
           </button>
         )}
       </div>
+      {isGuest && registerUrl && (
+        <div style={{ width: '100%', maxWidth: 260 }}>
+          <GuestConversionNudge registerUrl={registerUrl} />
+        </div>
+      )}
     </div>
   )
 }
@@ -438,6 +450,8 @@ export default function MemoryGameBoard({
   someoneTyping = false,
   playerProfiles,
   onProfileClick,
+  isGuest,
+  registerUrl,
 }: MemoryGameBoardProps) {
   const { t } = useTranslation()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -883,6 +897,8 @@ export default function MemoryGameBoard({
                   onReturnToWaiting={canStartGame ? onReturnToWaiting : undefined}
                   onLeave={onLeave}
                   onInspect={() => setOverlayInspecting(true)}
+                  isGuest={isGuest}
+                  registerUrl={registerUrl}
                   t={t}
                 />
               )}
@@ -1021,6 +1037,8 @@ export default function MemoryGameBoard({
                     onReturnToWaiting={canStartGame ? onReturnToWaiting : undefined}
                     onLeave={onLeave}
                     onInspect={() => setOverlayInspecting(true)}
+                    isGuest={isGuest}
+                    registerUrl={registerUrl}
                     t={t}
                   />
                 )}

--- a/app/lobby/[code]/components/SpyGameBoard.tsx
+++ b/app/lobby/[code]/components/SpyGameBoard.tsx
@@ -66,6 +66,7 @@ interface SpyGameBoardProps {
   onRequestRematch?: () => void
   isRequestingRematch?: boolean
   onBackToLobby?: () => void
+  registerUrl?: string
 }
 
 function computeVoteLeader(votes: Record<string, string>): string {
@@ -106,6 +107,7 @@ export default function SpyGameBoard({
   onRequestRematch,
   isRequestingRematch = false,
   onBackToLobby,
+  registerUrl = '/auth/register',
 }: SpyGameBoardProps) {
   const { t } = useTranslation()
   const showActionError = React.useCallback((message: string) => {
@@ -733,6 +735,8 @@ export default function SpyGameBoard({
             onRequestRematch={onRequestRematch}
             isRequestRematchPending={isRequestingRematch}
             onBackToLobby={onBackToLobby}
+            isGuest={isGuest}
+            registerUrl={registerUrl}
           />
         )}
       </div>

--- a/app/lobby/[code]/connect-four-page.tsx
+++ b/app/lobby/[code]/connect-four-page.tsx
@@ -33,6 +33,7 @@ import { getLobbyPlayerRequirements } from '@/lib/lobby-player-requirements'
 import { ReactionOverlay } from '@/components/ReactionOverlay'
 import { useGameTimer } from './hooks/useGameTimer'
 import { useBotTurn } from './hooks/useBotTurn'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 // ─── Design sub-components ────────────────────────────────────────────────────
 
@@ -382,9 +383,10 @@ function C4StatusBanner({ isFinished, winnerName, isDraw, currentDisc, currentPl
     )
 }
 
-function C4ResultOverlay({ winnerName, isDraw, isMyWin, onPlayAgain, onReturnToLobby, onLeave, onInspect, isLoading, isHost, t }: {
+function C4ResultOverlay({ winnerName, isDraw, isMyWin, onPlayAgain, onReturnToLobby, onLeave, onInspect, isLoading, isHost, isGuest, registerUrl, t }: {
     winnerName: string | null; isDraw: boolean; isMyWin: boolean
     onPlayAgain: () => void; onReturnToLobby: () => void; onLeave: () => void; onInspect: () => void; isLoading: boolean; isHost: boolean
+    isGuest: boolean; registerUrl: string
     t: (k: TranslationKeys, opts?: Record<string, unknown>) => string
 }) {
     return (
@@ -455,6 +457,11 @@ function C4ResultOverlay({ winnerName, isDraw, isMyWin, onPlayAgain, onReturnToL
                     {t('games.connect_four.game.leave')}
                 </button>
             </div>
+            {isGuest && (
+                <div style={{ width: '100%', maxWidth: 240 }}>
+                    <GuestConversionNudge registerUrl={registerUrl} />
+                </div>
+            )}
         </div>
     )
 }
@@ -1236,6 +1243,8 @@ export default function ConnectFourLobbyPage({ code, isSpectator = false, onGame
                             onInspect={() => setOverlayInspecting(true)}
                             isLoading={isRematchSubmitting}
                             isHost={!!lobby && lobby.creatorId === currentUserId}
+                            isGuest={isGuest}
+                            registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
                             t={t}
                         />
                     )}

--- a/app/lobby/[code]/connect-four-page.tsx
+++ b/app/lobby/[code]/connect-four-page.tsx
@@ -1123,7 +1123,7 @@ export default function ConnectFourLobbyPage({ code, isSpectator = false, onGame
     // ─── Sections ─────────────────────────────────────────────────────────────
 
     const headerSection = (
-        <div className="ttt-card" style={{ background: 'linear-gradient(135deg, white 0%, rgba(255,196,77,0.08) 100%)', padding: '12px 16px', overflow: 'hidden' }}>
+        <div className="ttt-card" style={{ background: 'linear-gradient(135deg, var(--bd-card-warm) 0%, rgba(255,196,77,0.08) 100%)', padding: '12px 16px', overflow: 'hidden' }}>
             <div style={{ position: 'relative', display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: 12 }}>
                 <C4PlayerCard name={p1Name} disc={1} isActive={!isFinished && gameData.currentDisc === 1} isWinner={!isDraw && winnerDisc === 1} wins={p1Wins} side="left" isLocalPlayer={myDisc === 1} avatarSrc={p1Avatar} isPremium={p1IsPremium} t={t} />
                 <div style={{ textAlign: 'center' }}>

--- a/app/lobby/[code]/rock-paper-scissors-page.tsx
+++ b/app/lobby/[code]/rock-paper-scissors-page.tsx
@@ -18,7 +18,7 @@ import { trackMoveSubmitApplied } from '@/lib/analytics'
 import { resolveLifecycleRedirectReason } from '@/lib/lobby-lifecycle'
 import { getLobbyPlayerRequirements } from '@/lib/lobby-player-requirements'
 import { ReactionOverlay } from '@/components/ReactionOverlay'
-import { getLobbyTheme } from '@/lib/lobby-themes'
+import { getThemePageStyle } from '@/lib/lobby-themes'
 
 type RpsLifecycleStatus = 'waiting' | 'playing' | 'finished' | 'abandoned' | 'cancelled'
 
@@ -471,10 +471,8 @@ export default function RockPaperScissorsLobbyPage({ code, isSpectator = false }
         )
     }
 
-    const themeColors = getLobbyTheme(lobby?.theme)
-
     return (
-        <div className="h-[calc(100dvh-4rem)] overflow-y-auto" style={{ background: themeColors.bg, color: themeColors.text }}>
+        <div className="h-[calc(100dvh-4rem)] overflow-y-auto" style={getThemePageStyle(lobby?.theme)}>
         <div className="px-4 py-5 sm:px-6 sm:py-8 min-h-full">
             <div className="mx-auto max-w-5xl space-y-5">
                 <header className="rounded-2xl border border-[var(--bd-line)] bg-[var(--bd-bg)] p-4 shadow-sm sm:p-5">

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -110,7 +110,7 @@ function TttPlayerCard({ name, symbol, isActive, isWinner, side, avatarSrc, isPr
     return (
         <div style={{
             display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 14,
-            background: isActive ? 'white' : 'transparent',
+            background: isActive ? 'var(--bd-input-bg)' : 'transparent',
             border: '2px solid ' + (isActive ? 'var(--bd-ink)' : 'transparent'),
             boxShadow: isActive ? '0 4px 0 var(--bd-ink)' : 'none',
             flexDirection: side === 'right' ? 'row-reverse' : 'row',
@@ -1064,7 +1064,7 @@ export default function TicTacToeLobbyPage({ code, isSpectator = false, onGameRe
 
     const headerSection = (
         <div className="ttt-card" style={{
-            background: 'linear-gradient(135deg, white 0%, rgba(255,196,77,0.10) 100%)',
+            background: 'linear-gradient(135deg, var(--bd-card-warm) 0%, rgba(255,196,77,0.10) 100%)',
             overflow: 'hidden', padding: '12px 16px',
         }}>
             <div style={{ position: 'absolute', right: -30, top: -30, opacity: 0.4, transform: 'rotate(8deg)', pointerEvents: 'none' }}>

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -27,6 +27,7 @@ import { Move } from '@/lib/game-engine'
 import { trackLobbyLeaveRedirect, trackMoveSubmitApplied } from '@/lib/analytics'
 import { sounds } from '@/lib/sounds'
 import { resolveLifecycleRedirectReason } from '@/lib/lobby-lifecycle'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 import { getLobbyPlayerRequirements } from '@/lib/lobby-player-requirements'
 import { ReactionOverlay } from '@/components/ReactionOverlay'
 import { useGameTimer } from './hooks/useGameTimer'
@@ -251,9 +252,10 @@ function TttStatusBanner({ isFinished, winnerName, isDraw, currentSymbol, curren
     )
 }
 
-function TttResultModal({ winnerName, winnerSymbol, isDraw, isMyWin, onPlayAgain, onReturnToLobby, onLeave, onInspect, isLoading, isHost, t }: {
+function TttResultModal({ winnerName, winnerSymbol, isDraw, isMyWin, onPlayAgain, onReturnToLobby, onLeave, onInspect, isLoading, isHost, isGuest, registerUrl, t }: {
     winnerName: string | null; winnerSymbol: string | null; isDraw: boolean; isMyWin: boolean;
     onPlayAgain: () => void; onReturnToLobby: () => void; onLeave: () => void; onInspect: () => void; isLoading: boolean; isHost: boolean;
+    isGuest: boolean; registerUrl: string;
     t: (key: TranslationKeys, opts?: string | Record<string, unknown>) => string;
 }) {
     const accentColor = winnerSymbol === 'X' ? 'var(--bd-coral)' : 'var(--bd-lav)'
@@ -318,6 +320,11 @@ function TttResultModal({ winnerName, winnerSymbol, isDraw, isMyWin, onPlayAgain
                     {t('games.tictactoe.game.leave')}
                 </button>
             </div>
+            {isGuest && (
+                <div style={{ width: '100%', maxWidth: 260 }}>
+                    <GuestConversionNudge registerUrl={registerUrl} />
+                </div>
+            )}
         </div>
     )
 }
@@ -1182,6 +1189,8 @@ export default function TicTacToeLobbyPage({ code, isSpectator = false, onGameRe
                     onInspect={() => setOverlayInspecting(true)}
                     isLoading={isRematchSubmitting}
                     isHost={isLobbyCreator}
+                    isGuest={isGuest}
+                    registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
                     t={t}
                 />
             )}

--- a/app/lobby/page.tsx
+++ b/app/lobby/page.tsx
@@ -64,7 +64,7 @@ function LobbyListPageContent() {
         {/* Page header */}
         <div
           className="bd-card relative mb-6 overflow-hidden p-7 sm:p-8"
-          style={{ background: 'linear-gradient(120deg, white 0%, rgba(155,140,255,0.08) 100%)' }}
+          style={{ background: 'linear-gradient(120deg, var(--bd-card-warm) 0%, rgba(155,140,255,0.08) 100%)' }}
         >
           <div className="bd-dot-grid absolute inset-0 opacity-35" />
           <div className="relative flex flex-col gap-6 sm:flex-row sm:items-stretch">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -8,7 +8,6 @@ import { GuestProvider } from '@/contexts/GuestContext'
 import { OnboardingProvider } from '@/contexts/OnboardingContext'
 import DeferredGlobalEffects from '@/components/DeferredGlobalEffects'
 import i18n from '@/i18n'
-import { applyThemeMode } from '@/lib/theme'
 import { getStoredAppearanceLocale } from '@/lib/appearance-preferences'
 
 const OnboardingModal = dynamic(
@@ -27,10 +26,6 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     if (i18n.language !== nextLanguage) {
       void i18n.changeLanguage(nextLanguage)
     }
-  }, [])
-
-  useEffect(() => {
-    applyThemeMode('light')
   }, [])
 
   return (

--- a/components/AuthGateModal.tsx
+++ b/components/AuthGateModal.tsx
@@ -7,11 +7,15 @@ import { buildAuthUrl } from '@/lib/auth-redirect'
 import { useTranslation } from '@/lib/i18n-helpers'
 
 interface AuthGateModalProps {
+  /** Where Login/Sign Up should return to, and (if onGuestReady is omitted) where guest play navigates. */
   dest: string
   onClose: () => void
+  /** When provided, guest play calls this instead of navigating to `dest` — for flows that create
+   * their own destination after guest mode is set (e.g. Play vs Bot creating a lobby on demand). */
+  onGuestReady?: () => void
 }
 
-export function AuthGateModal({ dest, onClose }: AuthGateModalProps) {
+export function AuthGateModal({ dest, onClose, onGuestReady }: AuthGateModalProps) {
   const router = useRouter()
   const { t } = useTranslation()
   const { setGuestMode } = useGuest()
@@ -28,7 +32,11 @@ export function AuthGateModal({ dest, onClose }: AuthGateModalProps) {
     try {
       await setGuestMode(name.trim())
       onClose()
-      router.push(dest)
+      if (onGuestReady) {
+        onGuestReady()
+      } else {
+        router.push(dest)
+      }
     } catch {
       setError(t('guest.startFailed'))
       setLoading(false)

--- a/components/GuestConversionNudge.tsx
+++ b/components/GuestConversionNudge.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from '@/lib/i18n-helpers'
 
-const SESSION_KEY = 'boardly_guest_upgrade_dismissed'
+const DISMISS_KEY = 'boardly:guest-conversion-dismissed:v1'
 
 interface GuestConversionNudgeProps {
   registerUrl: string
@@ -15,17 +15,17 @@ export default function GuestConversionNudge({ registerUrl }: GuestConversionNud
 
   useEffect(() => {
     try {
-      if (!sessionStorage.getItem(SESSION_KEY)) {
+      if (!localStorage.getItem(DISMISS_KEY)) {
         setVisible(true)
       }
     } catch {
-      // sessionStorage unavailable (SSR or privacy mode) — don't show
+      // localStorage unavailable (SSR or privacy mode) — don't show
     }
   }, [])
 
   const dismiss = () => {
     try {
-      sessionStorage.setItem(SESSION_KEY, '1')
+      localStorage.setItem(DISMISS_KEY, '1')
     } catch {
       // ignore
     }

--- a/components/HomePage/CtaBanner.tsx
+++ b/components/HomePage/CtaBanner.tsx
@@ -96,7 +96,8 @@ export default function CtaBanner() {
           <p
             style={{
               fontSize: 17,
-              color: 'rgba(251,246,238,0.7)',
+              color: 'var(--bd-bg)',
+              opacity: 0.7,
               marginBottom: 28,
               maxWidth: 420,
               lineHeight: 1.5,

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -148,7 +148,7 @@ export default function HeroDemoConnectFour() {
     }}>
       <div style={{
         fontFamily: 'var(--bd-font-display)', fontWeight: 600, fontSize: 11,
-        color: 'rgba(31,27,22,0.55)', minHeight: isMobile ? 0 : 16, textAlign: 'center', width: '100%',
+        color: 'var(--bd-ink-muted)', minHeight: isMobile ? 0 : 16, textAlign: 'center', width: '100%',
       }}>
         {statusText}
       </div>
@@ -247,7 +247,7 @@ export default function HeroDemoConnectFour() {
         href="/games/connect-four"
         style={{
           fontSize: 12, fontWeight: 600,
-          color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 2,
+          color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
         Play full game →

--- a/components/HomePage/HeroDemoMemory.tsx
+++ b/components/HomePage/HeroDemoMemory.tsx
@@ -71,7 +71,7 @@ export default function HeroDemoMemory() {
     }}>
       <div style={{
         fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: isMobile ? 12 : 14,
-        color: 'rgba(31,27,22,0.8)', minHeight: isMobile ? 18 : 22,
+        color: 'var(--bd-ink-muted)', minHeight: isMobile ? 18 : 22,
       }}>
         {allMatched ? '🎉 All matched!' : `${matchedCount} / ${PAIRS.length} pairs`}
       </div>
@@ -85,15 +85,13 @@ export default function HeroDemoMemory() {
               onClick={() => handleFlip(i)}
               style={{
                 width: CARD_W, height: CARD_H,
-                background: card.matched
-                  ? 'rgba(255,255,255,0.85)'
-                  : isFlipped
-                    ? '#fff'
-                    : 'var(--bd-ink)',
+                background: card.matched || isFlipped
+                  ? 'var(--bd-input-bg)'
+                  : 'var(--bd-ink)',
                 border: `2.5px solid ${card.matched ? 'rgba(31,27,22,0.2)' : 'var(--bd-ink)'}`,
                 borderRadius: 10,
                 fontSize: isFlipped ? 24 : 16,
-                color: isFlipped ? 'var(--bd-ink)' : 'rgba(255,255,255,0.35)',
+                color: isFlipped ? 'var(--bd-ink)' : 'var(--bd-bg)',
                 cursor: card.matched || locked ? 'default' : 'pointer',
                 boxShadow: isFlipped ? 'none' : '0 4px 0 rgba(31,27,22,0.35)',
                 transition: 'background 0.18s, box-shadow 0.18s, font-size 0.12s',
@@ -111,7 +109,7 @@ export default function HeroDemoMemory() {
         href="/games/memory"
         style={{
           fontSize: 12, fontWeight: 600,
-          color: 'rgba(31,27,22,0.6)', textDecoration: 'underline', marginTop: 2,
+          color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
         Play full game →

--- a/components/HomePage/HeroDemoTicTacToe.tsx
+++ b/components/HomePage/HeroDemoTicTacToe.tsx
@@ -80,7 +80,7 @@ export default function HeroDemoTicTacToe() {
     }}>
       <div style={{
         fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: 14,
-        color: 'rgba(31,27,22,0.7)', minHeight: 22,
+        color: 'var(--bd-ink-muted)', minHeight: 22,
       }}>
         {statusText}
       </div>
@@ -92,7 +92,7 @@ export default function HeroDemoTicTacToe() {
             onClick={() => handleClick(i)}
             style={{
               width: 64, height: 64,
-              background: '#fff',
+              background: 'var(--bd-input-bg)',
               border: '2.5px solid var(--bd-ink)',
               borderRadius: 14,
               fontSize: 28,
@@ -115,7 +115,7 @@ export default function HeroDemoTicTacToe() {
         href="/games/tic-tac-toe"
         style={{
           fontSize: 12, fontWeight: 600,
-          color: 'rgba(31,27,22,0.5)', textDecoration: 'underline', marginTop: 2,
+          color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
         Play full game →

--- a/components/PublicProfileView.tsx
+++ b/components/PublicProfileView.tsx
@@ -448,7 +448,7 @@ export default function PublicProfileView({
           <div
             className="relative w-full overflow-hidden rounded-[2rem] border-[1.5px]"
             style={{
-              background: pageTheme?.cardBg ?? 'white',
+              background: pageTheme?.cardBg ?? 'var(--bd-input-bg)',
               borderColor: pageTheme?.cardBorder ?? 'var(--bd-line)',
               boxShadow: pageTheme?.cardShadow ?? '0 6px 0 0 rgba(31,27,22,0.08), 0 14px 28px -10px rgba(31,27,22,0.18)',
             }}

--- a/components/SpyResults.tsx
+++ b/components/SpyResults.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslation } from '@/lib/i18n-helpers'
 import { Player } from '@/lib/game-engine'
+import GuestConversionNudge from '@/components/GuestConversionNudge'
 
 type SpyPlayer = Player & { isPremium?: boolean }
 
@@ -21,6 +22,8 @@ interface SpyResultsProps {
   onRequestRematch?: () => void
   isRequestRematchPending?: boolean
   onBackToLobby?: () => void
+  isGuest?: boolean
+  registerUrl?: string
 }
 
 export default function SpyResults({
@@ -39,6 +42,8 @@ export default function SpyResults({
   onRequestRematch,
   isRequestRematchPending = false,
   onBackToLobby,
+  isGuest = false,
+  registerUrl = '/auth/register',
 }: SpyResultsProps) {
   const { t } = useTranslation()
 
@@ -196,6 +201,10 @@ export default function SpyResults({
             </>
           )}
         </div>
+
+        {isGameOver && isGuest && (
+          <GuestConversionNudge registerUrl={registerUrl} />
+        )}
       </div>
     </div>
   )

--- a/lib/quick-play.ts
+++ b/lib/quick-play.ts
@@ -1,0 +1,12 @@
+/**
+ * How many total players a freshly-created quick-play lobby should have
+ * after bot-filling. Ordinary matchmaking (forceSolo: false) targets
+ * minPlayers as before. forceSolo (Play vs Bot) explicitly asks for a bot
+ * opponent at a chosen difficulty — for solo-capable games (minPlayers: 1,
+ * e.g. Yahtzee) minPlayers alone is already met by the human, which would
+ * leave the player with zero bots despite picking a difficulty. Guarantee
+ * at least one bot in that case.
+ */
+export function resolveBotTarget(minPlayers: number, forceSolo: boolean): number {
+  return forceSolo ? Math.max(minPlayers, 2) : minPlayers
+}


### PR DESCRIPTION
## New feature
- **#628** — Guest-conversion nudge ("create an account" card) wired into all 6 games' result screens, not just Yahtzee. Dismiss persistence fixed (sessionStorage → localStorage, was reappearing every new browser session).

## Bug fixes
- **#630** — Play vs Bot opened a guest-name prompt in place instead of redirecting a fresh visitor to `/auth/login`.
- **#631** — Play vs Bot now guarantees a bot opponent even for solo-capable games (Yahtzee, `minPlayers: 1`) — previously added zero bots since the human alone already met `minPlayers`.
- **#633** — Dark mode contrast bugs across Alias, Rock-Paper-Scissors, public profile card; theme-doesn't-persist regression fixed.
- **#637** — `global-error.tsx` always rendered in light mode regardless of theme.
- **#638** — Leaderboard cache (`s-maxage=300`) let a changed username/avatar/premium badge stay stale for up to ~15 minutes on a route that already queries live. Shortened to `s-maxage=20`.
- **#639** — Alias games could permanently soft-lock: only the host could advance past the `turn_results` phase ("Next Turn" button was host-gated in the UI despite the engine permitting any player). Verified live by reproducing the freeze with 4 real guest sessions and confirming a non-host player can now advance the game.

## Verification
- `npx tsc --noEmit`, `npm run ci:quick`, `pnpm test` clean throughout (consistent 33-suite pre-existing `clearMocksOnScope` infra gap, unrelated to this release, documented across prior sessions)
- #639 specifically verified end-to-end live (not just code-read): reproduced the exact production freeze, confirmed the fix resolves it in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)