### PR TITLE
#661 feat: per-friend invite buttons + real online/offline presence

### DIFF
--- a/__tests__/components/friends-list-modal.test.tsx
+++ b/__tests__/components/friends-list-modal.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import FriendsListModal from '@/components/FriendsListModal'
+
+jest.mock('@/lib/i18n-helpers', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+jest.mock('@/lib/client-logger', () => ({
+  clientLogger: {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/i18n-toast', () => ({
+  showToast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    errorFrom: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/supabase-client', () => ({
+  getSupabaseClient: () => {
+    const channelObj = {
+      on: function () { return channelObj },
+      subscribe: function (cb?: (status: string) => void) { cb?.('SUBSCRIBED'); return channelObj },
+      presenceState: () => ({}),
+      track: jest.fn().mockResolvedValue(undefined),
+    }
+    return {
+      channel: () => channelObj,
+      removeChannel: jest.fn().mockResolvedValue(undefined),
+    }
+  },
+}))
+
+jest.mock('@/components/LoadingSpinner', () => {
+  function MockLoadingSpinner() {
+    return <div>loading-spinner</div>
+  }
+  return MockLoadingSpinner
+})
+
+const originalFetch = global.fetch
+const mockFetch = jest.fn()
+
+function mockJsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  }
+}
+
+const FRIENDS_PAYLOAD = {
+  friends: [
+    { id: 'friend-1', username: 'Alice', avatar: null, email: 'a@example.com', presence: 'offline' },
+    { id: 'friend-2', username: 'Bob', avatar: null, email: 'b@example.com', presence: 'offline' },
+  ],
+}
+
+describe('FriendsListModal', () => {
+  beforeAll(() => {
+    ;(global as typeof globalThis & { fetch: typeof mockFetch }).fetch = mockFetch as any
+  })
+
+  afterAll(() => {
+    ;(global as typeof globalThis & { fetch: typeof originalFetch }).fetch = originalFetch as any
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFetch.mockImplementation(async () => mockJsonResponse(FRIENDS_PAYLOAD))
+  })
+
+  it('onInvite mode: renders a per-friend Invite button, not a select+bulk-confirm flow', async () => {
+    const onInvite = jest.fn().mockResolvedValue({ invitedCount: 1, skippedCount: 0 })
+
+    render(
+      <FriendsListModal
+        isOpen
+        onClose={jest.fn()}
+        onInvite={onInvite}
+        lobbyCode="ABCD"
+      />
+    )
+
+    await waitFor(() => expect(screen.getAllByText('lobby.invite.inviteButton')).toHaveLength(2))
+
+    // No bulk multi-select footer (would show e.g. lobby.invite.send) in this mode
+    expect(screen.queryByText('lobby.invite.send')).toBeNull()
+    expect(screen.queryByText('common.cancel')).not.toBeNull()
+  })
+
+  it('onInvite mode: clicking Invite on one row invites only that friend and flips to Invited', async () => {
+    const onInvite = jest.fn().mockResolvedValue({ invitedCount: 1, skippedCount: 0 })
+
+    render(
+      <FriendsListModal
+        isOpen
+        onClose={jest.fn()}
+        onInvite={onInvite}
+        lobbyCode="ABCD"
+      />
+    )
+
+    const inviteButtons = await waitFor(() => screen.getAllByText('lobby.invite.inviteButton'))
+    fireEvent.click(inviteButtons[0])
+
+    await waitFor(() => expect(onInvite).toHaveBeenCalledWith(['friend-1']))
+    await waitFor(() => expect(screen.queryByText(/lobby.invite.invited/)).not.toBeNull())
+
+    // The other row's button is unaffected and still says Invite
+    expect(screen.getAllByText('lobby.invite.inviteButton')).toHaveLength(1)
+  })
+
+  it('onSelect mode: keeps the original checkbox-style multi-select + confirm button untouched', async () => {
+    const onSelect = jest.fn().mockResolvedValue(undefined)
+
+    render(
+      <FriendsListModal
+        isOpen
+        onClose={jest.fn()}
+        onSelect={onSelect}
+        confirmLabel="common.save"
+        lobbyCode="pending-lobby"
+      />
+    )
+
+    await waitFor(() => expect(screen.queryByText('Alice')).not.toBeNull())
+
+    // No per-row Invite buttons in this mode
+    expect(screen.queryByText('lobby.invite.inviteButton')).toBeNull()
+
+    fireEvent.click(screen.getByText('Alice'))
+    fireEvent.click(screen.getByText('common.save'))
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith(['friend-1']))
+  })
+})

--- a/__tests__/components/friends.test.tsx
+++ b/__tests__/components/friends.test.tsx
@@ -26,6 +26,21 @@ jest.mock('@/lib/client-logger', () => ({
   },
 }))
 
+jest.mock('@/lib/supabase-client', () => ({
+  getSupabaseClient: () => {
+    const channelObj = {
+      on: function () { return channelObj },
+      subscribe: function (cb?: (status: string) => void) { cb?.('SUBSCRIBED'); return channelObj },
+      presenceState: () => ({}),
+      track: jest.fn().mockResolvedValue(undefined),
+    }
+    return {
+      channel: () => channelObj,
+      removeChannel: jest.fn().mockResolvedValue(undefined),
+    }
+  },
+}))
+
 jest.mock('@/lib/i18n-toast', () => ({
   showToast: {
     success: jest.fn(),

--- a/__tests__/hooks/useFriendPresence.test.ts
+++ b/__tests__/hooks/useFriendPresence.test.ts
@@ -1,0 +1,129 @@
+import React from 'react'
+import { act, renderHook } from '@testing-library/react'
+import {
+  useOnlinePresence,
+  useAnnouncePresence,
+  __resetSharedChannelForTests,
+} from '@/hooks/useFriendPresence'
+
+/**
+ * Mimics the real @supabase/realtime-js client closely enough to catch the
+ * bug this module exists to prevent: `RealtimeClient.channel(topic)` returns
+ * the *same already-joined* channel object on a second call with the same
+ * topic, and calling `.on('presence', ...)` on an already-joined channel
+ * throws ("cannot add `presence` callbacks ... after `subscribe()`.").
+ */
+function createFakeSupabaseClient() {
+  const channelsByTopic = new Map<string, any>()
+
+  function channel(topic: string) {
+    const existing = channelsByTopic.get(topic)
+    if (existing) return existing
+
+    let joined = false
+    const listeners: Array<() => void> = []
+    const chan = {
+      on(type: string, _filter: unknown, cb: () => void) {
+        if (joined && type === 'presence') {
+          throw new Error(`cannot add \`presence\` callbacks for ${topic} after \`subscribe()\`.`)
+        }
+        listeners.push(cb)
+        return chan
+      },
+      subscribe(cb?: (status: string) => void) {
+        joined = true
+        cb?.('SUBSCRIBED')
+        return chan
+      },
+      track: jest.fn().mockResolvedValue(undefined),
+      presenceState: () => ({}),
+      _fireSync() {
+        listeners.forEach((l) => l())
+      },
+    }
+    channelsByTopic.set(topic, chan)
+    return chan
+  }
+
+  return {
+    channel,
+    removeChannel: jest.fn(async (chan: any) => {
+      for (const [topic, value] of channelsByTopic.entries()) {
+        if (value === chan) channelsByTopic.delete(topic)
+      }
+    }),
+  }
+}
+
+let fakeClient: ReturnType<typeof createFakeSupabaseClient>
+
+jest.mock('@/lib/supabase-client', () => ({
+  getSupabaseClient: () => fakeClient,
+}))
+
+describe('useFriendPresence shared channel', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    fakeClient = createFakeSupabaseClient()
+    __resetSharedChannelForTests()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('survives React Strict Mode double-invoking effects without throwing', () => {
+    expect(() => {
+      renderHook(() => useOnlinePresence(), { wrapper: React.StrictMode })
+    }).not.toThrow()
+  })
+
+  it('only creates one underlying channel for multiple simultaneous consumers', () => {
+    renderHook(() => useOnlinePresence())
+    renderHook(() => useOnlinePresence())
+    renderHook(() => useAnnouncePresence('user-1', true))
+
+    expect(fakeClient.channel('online-users')).toBeTruthy()
+    // Confirms the dedup-by-topic fake behaves like the real client: a 2nd
+    // call to .channel() for the same topic returns the SAME object.
+    const a = fakeClient.channel('x')
+    const b = fakeClient.channel('x')
+    expect(a).toBe(b)
+  })
+
+  it('announces presence via track() once the channel is subscribed', async () => {
+    renderHook(() => useAnnouncePresence('user-1', true))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const chan = fakeClient.channel('online-users')
+    expect(chan.track).toHaveBeenCalledWith({ userId: 'user-1' })
+  })
+
+  it('does not announce when disabled (showOnlineStatus off)', async () => {
+    renderHook(() => useAnnouncePresence('user-1', false))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const chan = fakeClient.channel('online-users')
+    expect(chan.track).not.toHaveBeenCalled()
+  })
+
+  it('removes the channel only after the last consumer unmounts (deferred teardown)', () => {
+    const hookA = renderHook(() => useOnlinePresence())
+    const hookB = renderHook(() => useOnlinePresence())
+
+    hookA.unmount()
+    // Teardown is deferred by a tick — channel must still exist while B is mounted.
+    act(() => {
+      jest.advanceTimersByTime(0)
+    })
+    expect(fakeClient.removeChannel).not.toHaveBeenCalled()
+
+    hookB.unmount()
+    act(() => {
+      jest.advanceTimersByTime(0)
+    })
+    expect(fakeClient.removeChannel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/lobby/[code]/components/WaitingRoomActions.tsx
+++ b/app/lobby/[code]/components/WaitingRoomActions.tsx
@@ -29,6 +29,7 @@ export default function WaitingRoomActions({
   onStartGame,
   onAddBot,
   onBotDifficultyChange,
+  onInviteFriends,
 }: WaitingRoomActionsProps) {
   const { t } = useTranslation()
   const [showSettings, setShowSettings] = useState(false)
@@ -90,7 +91,7 @@ export default function WaitingRoomActions({
     <div className="flex-shrink-0 space-y-3 border-t border-bd-line bg-bd-card-warm px-4 py-4 pb-[max(1rem,calc(1rem+env(safe-area-inset-bottom)))] sm:px-6">
       {/* Lobby full badge OR settings toggle */}
       {canAddMorePlayers ? (
-        canConfigureBots && (
+        (canConfigureBots || onInviteFriends) && (
           <button
             onClick={() => {
               sounds.play('click')
@@ -121,6 +122,22 @@ export default function WaitingRoomActions({
       {/* Collapsible settings panel */}
       {showSettings && canAddMorePlayers && (
         <div className="rounded-xl border border-bd-line bg-bd-bg2/60 px-3 py-3 space-y-3">
+          {/* Invite Friends */}
+          {onInviteFriends && (
+            <button
+              onClick={() => {
+                sounds.play('click')
+                onInviteFriends()
+              }}
+              className="bd-btn bd-btn-soft w-full justify-center px-3 py-2.5 text-sm"
+            >
+              <span className="inline-flex items-center justify-center gap-1.5">
+                <span>👥</span>
+                <span>{t('lobby.invite.title')}</span>
+              </span>
+            </button>
+          )}
+
           {/* Add Bot */}
           {supportsBots && (
             <button

--- a/components/Friends.tsx
+++ b/components/Friends.tsx
@@ -8,6 +8,12 @@ import { clientLogger } from '@/lib/client-logger'
 import { showToast } from '@/lib/i18n-toast'
 import LoadingSpinner from './LoadingSpinner'
 import { buildPublicProfilePath, extractPublicProfileId } from '@/lib/public-profile'
+import {
+  useOnlinePresence,
+  mergeFriendPresence,
+  sortFriendsByPresence,
+  type FriendPresence,
+} from '@/hooks/useFriendPresence'
 
 interface Friend {
   id: string
@@ -18,7 +24,7 @@ interface Friend {
   friendshipId: string
   friendsSince: string
   isPremium?: boolean
-  presence?: 'offline' | 'online' | 'in_lobby' | 'in_game'
+  presence?: FriendPresence
   statistics?: {
     totalGames: number
     totalWins: number
@@ -203,6 +209,7 @@ export default function Friends() {
   const { t } = useTranslation()
   const { data: session, status } = useSession()
   const router = useRouter()
+  const onlineUserIds = useOnlinePresence()
   const [activeTab, setActiveTab] = useState<TabType>('friends')
   const [friends, setFriends] = useState<Friend[]>([])
   const [receivedRequests, setReceivedRequests] = useState<FriendRequest[]>([])
@@ -548,16 +555,8 @@ export default function Friends() {
     })
   }
 
-  const resolvePresence = (friend: Friend): 'offline' | 'online' | 'in_lobby' | 'in_game' => {
-    return friend.presence || 'offline'
-  }
-
-  const presencePriority: Record<'offline' | 'online' | 'in_lobby' | 'in_game', number> = {
-    in_game: 0,
-    in_lobby: 1,
-    online: 2,
-    offline: 3,
-  }
+  const resolvePresence = (friend: Friend): FriendPresence =>
+    mergeFriendPresence(friend.presence, onlineUserIds.has(friend.id))
 
   const openFriendPublicProfile = useCallback(
     (friend: Friend) => {
@@ -758,26 +757,17 @@ export default function Friends() {
             })
           ) : (
             <div className="grid gap-4">
-              {[...friends]
-                .sort((a, b) => {
-                  const aPresence = resolvePresence(a)
-                  const bPresence = resolvePresence(b)
-                  const priorityDiff = presencePriority[aPresence] - presencePriority[bPresence]
-                  if (priorityDiff !== 0) return priorityDiff
-                  const aName = a.username ?? ''
-                  const bName = b.username ?? ''
-                  return aName.localeCompare(bName)
-                })
+              {sortFriendsByPresence(friends, resolvePresence, (friend) => friend.username ?? '')
                 .map((friend) => {
                   const presence = resolvePresence(friend)
                   const isOnline = presence !== 'offline'
                   const presenceBadge =
                     presence === 'in_game'
-                      ? { label: 'In game', className: 'bg-bd-lav/20 text-bd-lav-deep dark:bg-bd-lav/15 dark:text-bd-lav' }
+                      ? { label: t('profile.friends.presence.inGame'), className: 'bg-bd-lav/20 text-bd-lav-deep dark:bg-bd-lav/15 dark:text-bd-lav' }
                       : presence === 'in_lobby'
-                        ? { label: 'In lobby', className: 'bg-bd-sun/25 text-bd-ink-soft dark:bg-bd-sun/15 dark:text-bd-sun' }
+                        ? { label: t('profile.friends.presence.inLobby'), className: 'bg-bd-sun/25 text-bd-ink-soft dark:bg-bd-sun/15 dark:text-bd-sun' }
                         : presence === 'online'
-                          ? { label: 'Online', className: 'bg-bd-mint/20 text-bd-mint-deep dark:bg-bd-mint/15 dark:text-bd-mint' }
+                          ? { label: t('profile.friends.presence.online'), className: 'bg-bd-mint/20 text-bd-mint-deep dark:bg-bd-mint/15 dark:text-bd-mint' }
                           : null
                   const presenceStripClassName =
                     presence === 'in_game'

--- a/components/FriendsListModal.tsx
+++ b/components/FriendsListModal.tsx
@@ -4,9 +4,13 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from '@/lib/i18n-helpers'
 import { clientLogger } from '@/lib/client-logger'
 import { showToast } from '@/lib/i18n-toast'
+import {
+  useOnlinePresence,
+  mergeFriendPresence,
+  sortFriendsByPresence,
+  type FriendPresence,
+} from '@/hooks/useFriendPresence'
 import LoadingSpinner from './LoadingSpinner'
-
-type FriendPresence = 'offline' | 'online' | 'in_lobby' | 'in_game'
 
 interface Friend {
   id: string
@@ -41,11 +45,21 @@ export default function FriendsListModal({
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState(false)
   const [inviting, setInviting] = useState(false)
+  const [invitingFriendId, setInvitingFriendId] = useState<string | null>(null)
+  const [invitedFriendIds, setInvitedFriendIds] = useState<Set<string>>(new Set())
+  const onlineUserIds = useOnlinePresence()
+
+  // Only one of onInvite/onSelect is ever passed by callers; onSelect (the
+  // create-lobby party pre-select flow, no lobby exists yet) keeps the
+  // original select-many + confirm-button behavior untouched. onInvite (an
+  // already-existing lobby) gets a dedicated Invite button per friend.
+  const mode: 'select-multi' | 'invite-single' = onSelect ? 'select-multi' : 'invite-single'
 
   useEffect(() => {
     if (!isOpen) return
     loadFriends()
     setSelectedFriends(new Set(initialSelectedFriendIds))
+    setInvitedFriendIds(new Set())
     // initialSelectedFriendIds intentionally omitted: default [] creates a new reference
     // on every render and would cause an infinite loop. We only need this on open.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -80,14 +94,8 @@ export default function FriendsListModal({
     setSelectedFriends(newSelected)
   }
 
-  const resolvePresence = (friend: Friend): FriendPresence => friend.presence || 'offline'
-
-  const presencePriority: Record<FriendPresence, number> = {
-    in_game: 0,
-    in_lobby: 1,
-    online: 2,
-    offline: 3,
-  }
+  const resolvePresence = (friend: Friend): FriendPresence =>
+    mergeFriendPresence(friend.presence, onlineUserIds.has(friend.id))
 
   const handleInvite = async () => {
     if (selectedFriends.size === 0) {
@@ -136,7 +144,43 @@ export default function FriendsListModal({
     }
   }
 
+  const handleInviteSingle = async (friend: Friend) => {
+    if (!onInvite || invitingFriendId || invitedFriendIds.has(friend.id)) return
+
+    setInvitingFriendId(friend.id)
+    try {
+      const result = await onInvite([friend.id])
+      if (result.invitedCount > 0) {
+        setInvitedFriendIds((prev) => new Set(prev).add(friend.id))
+        showToast.success('lobby.invite.sentToFriend', undefined, { name: friend.username || 'Unknown' })
+      } else {
+        showToast.info('toast.inviteSkippedUsers', undefined, { count: 1 })
+      }
+    } catch (error) {
+      clientLogger.error('Error inviting friend:', error)
+      const translationKey =
+        typeof (error as { translationKey?: unknown })?.translationKey === 'string'
+          ? ((error as { translationKey?: string }).translationKey as string)
+          : null
+
+      if (translationKey) {
+        showToast.error(translationKey)
+      } else {
+        showToast.errorFrom(error, 'lobby.invite.failed')
+      }
+    } finally {
+      setInvitingFriendId(null)
+    }
+  }
+
   if (!isOpen) return null
+
+  const presenceLabel = (presence: FriendPresence): string | null => {
+    if (presence === 'in_game') return t('profile.friends.presence.inGame')
+    if (presence === 'in_lobby') return t('profile.friends.presence.inLobby')
+    if (presence === 'online') return t('profile.friends.presence.online')
+    return null
+  }
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
@@ -182,30 +226,49 @@ export default function FriendsListModal({
             </p>
 
             <div className="space-y-2 mb-6">
-              {[...friends]
-                .sort((a, b) => {
-                  const priorityDiff =
-                    presencePriority[resolvePresence(a)] - presencePriority[resolvePresence(b)]
-                  if (priorityDiff !== 0) return priorityDiff
+              {sortFriendsByPresence(
+                friends,
+                resolvePresence,
+                (friend) => friend.username ?? ''
+              ).map((friend) => {
+                const presence = resolvePresence(friend)
+                const isOnline = presence !== 'offline'
+                const label = presenceLabel(presence)
+                const isSelected = selectedFriends.has(friend.id)
 
-                  const aName = a.username ?? ''
-                  const bName = b.username ?? ''
-                  return aName.localeCompare(bName)
-                })
-                .map((friend) => {
-                  const presence = resolvePresence(friend)
-                  const isOnline = presence !== 'offline'
-                  const presenceLabel =
-                    presence === 'in_game'
-                      ? 'In game'
-                      : presence === 'in_lobby'
-                        ? 'In lobby'
-                        : presence === 'online'
-                          ? 'Online'
-                          : null
+                const avatarBlock = (
+                  <div className="relative">
+                    <div
+                      className="w-10 h-10 rounded-full flex items-center justify-center font-bold text-white"
+                      style={{ background: 'var(--bd-ink)' }}
+                    >
+                      {friend.username?.[0]?.toUpperCase() || '?'}
+                    </div>
+                    {isOnline && (
+                      <div
+                        className="absolute bottom-0 right-0 w-3 h-3 rounded-full"
+                        style={{ background: '#22C55E', border: '2px solid var(--bd-card-warm)' }}
+                      />
+                    )}
+                  </div>
+                )
 
-                  const isSelected = selectedFriends.has(friend.id)
+                const nameBlock = (
+                  <div className="flex-1 text-left">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium" style={{ color: 'var(--bd-ink)' }}>
+                        {friend.username || 'Unknown'}
+                      </span>
+                      {label && (
+                        <span className="text-xs font-medium" style={{ color: '#22C55E' }}>
+                          {label}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )
 
+                if (mode === 'select-multi') {
                   return (
                     <button
                       key={friend.id}
@@ -216,57 +279,71 @@ export default function FriendsListModal({
                         background: isSelected ? '#FFC44D18' : 'var(--bd-bg)',
                       }}
                     >
-                      <div className="relative">
-                        <div
-                          className="w-10 h-10 rounded-full flex items-center justify-center font-bold text-white"
-                          style={{ background: 'var(--bd-ink)' }}
-                        >
-                          {friend.username?.[0]?.toUpperCase() || '?'}
-                        </div>
-                        {isOnline && (
-                          <div
-                            className="absolute bottom-0 right-0 w-3 h-3 rounded-full"
-                            style={{ background: '#22C55E', border: '2px solid var(--bd-card-warm)' }}
-                          />
-                        )}
-                      </div>
-                      <div className="flex-1 text-left">
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium" style={{ color: 'var(--bd-ink)' }}>
-                            {friend.username || 'Unknown'}
-                          </span>
-                          {presenceLabel && (
-                            <span className="text-xs font-medium" style={{ color: '#22C55E' }}>
-                              {presenceLabel}
-                            </span>
-                          )}
-                        </div>
-                      </div>
+                      {avatarBlock}
+                      {nameBlock}
                       {isSelected && (
                         <span style={{ color: 'var(--bd-ink)' }}>✓</span>
                       )}
                     </button>
                   )
-                })}
+                }
+
+                const isInvited = invitedFriendIds.has(friend.id)
+                const isInvitingThisRow = invitingFriendId === friend.id
+
+                return (
+                  <div
+                    key={friend.id}
+                    className="w-full flex items-center gap-3 p-3 rounded-xl"
+                    style={{ border: '1.5px solid var(--bd-line)', background: 'var(--bd-bg)' }}
+                  >
+                    {avatarBlock}
+                    {nameBlock}
+                    <button
+                      type="button"
+                      onClick={() => handleInviteSingle(friend)}
+                      disabled={isInvited || isInvitingThisRow || invitingFriendId !== null}
+                      className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-bold transition-opacity disabled:cursor-not-allowed"
+                      style={{
+                        background: isInvited ? 'var(--bd-bg2)' : 'var(--bd-sun)',
+                        color: isInvited ? 'var(--bd-ink-muted)' : 'var(--bd-ink)',
+                        opacity: isInvitingThisRow ? 0.65 : 1,
+                      }}
+                    >
+                      {isInvited
+                        ? `✓ ${t('lobby.invite.invited')}`
+                        : isInvitingThisRow
+                          ? '…'
+                          : t('lobby.invite.inviteButton')}
+                    </button>
+                  </div>
+                )
+              })}
             </div>
 
-            <div className="flex gap-2">
-              <button
-                onClick={handleInvite}
-                disabled={inviting || selectedFriends.size === 0}
-                className="flex-1 btn btn-primary disabled:opacity-50"
-              >
-                {inviting
-                  ? t('common.loading')
-                  : confirmLabel || (onSelect ? t('common.save') : t('lobby.invite.send', { count: selectedFriends.size }))}
-              </button>
-              <button
-                onClick={onClose}
-                className="flex-1 btn btn-secondary"
-              >
+            {mode === 'select-multi' ? (
+              <div className="flex gap-2">
+                <button
+                  onClick={handleInvite}
+                  disabled={inviting || selectedFriends.size === 0}
+                  className="flex-1 btn btn-primary disabled:opacity-50"
+                >
+                  {inviting
+                    ? t('common.loading')
+                    : confirmLabel || t('common.save')}
+                </button>
+                <button
+                  onClick={onClose}
+                  className="flex-1 btn btn-secondary"
+                >
+                  {t('common.cancel')}
+                </button>
+              </div>
+            ) : (
+              <button onClick={onClose} className="w-full btn btn-secondary">
                 {t('common.cancel')}
               </button>
-            </div>
+            )}
           </>
         )}
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,6 +18,10 @@ const NotificationsMenu = dynamic(
   () => import('./Header/NotificationsMenu').then((mod) => mod.NotificationsMenu),
   { loading: () => null }
 )
+const PresenceTracker = dynamic(
+  () => import('./Header/PresenceTracker').then((mod) => mod.PresenceTracker),
+  { loading: () => null }
+)
 const AudioSettingsButton = dynamic(
   () => import('./Header/AudioSettingsButton').then((mod) => mod.AudioSettingsButton),
   { loading: () => null }
@@ -121,6 +125,7 @@ export default function Header() {
             </div>
 
             {effectiveIsAuthenticated && <NotificationsMenu />}
+            {effectiveIsAuthenticated && <PresenceTracker />}
 
             {!isAuthUiReady ? (
               <div className="w-8 h-8 border-4 border-white border-t-transparent rounded-full animate-spin"></div>

--- a/components/Header/PresenceTracker.tsx
+++ b/components/Header/PresenceTracker.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useAnnouncePresence } from '@/hooks/useFriendPresence'
+
+/**
+ * Renders nothing — side-effect-only component that announces this user's
+ * presence on the global online-users Supabase Presence channel for as long
+ * as it's mounted (i.e. for as long as the user has any Boardly tab open).
+ * Respects the "Show online status" account preference: when disabled, it
+ * never announces (but doesn't block other consumers from reading presence).
+ */
+export function PresenceTracker() {
+  const { data: session } = useSession()
+  const userId = session?.user?.id
+  const [showOnlineStatus, setShowOnlineStatus] = useState(true)
+
+  useEffect(() => {
+    if (!userId) return
+    let cancelled = false
+    fetch('/api/user/account-preferences', { cache: 'no-store' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && typeof data?.preferences?.showOnlineStatus === 'boolean') {
+          setShowOnlineStatus(data.preferences.showOnlineStatus)
+        }
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [userId])
+
+  useAnnouncePresence(userId, showOnlineStatus)
+
+  return null
+}

--- a/hooks/useFriendPresence.ts
+++ b/hooks/useFriendPresence.ts
@@ -1,0 +1,162 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { RealtimeChannel } from '@supabase/supabase-js'
+import { getSupabaseClient } from '@/lib/supabase-client'
+
+export type FriendPresence = 'offline' | 'online' | 'in_lobby' | 'in_game'
+
+/** Global Supabase Presence channel every authenticated client tracks itself on. */
+export const ONLINE_USERS_CHANNEL = 'online-users'
+
+export const PRESENCE_PRIORITY: Record<FriendPresence, number> = {
+  in_game: 0,
+  in_lobby: 1,
+  online: 2,
+  offline: 3,
+}
+
+/**
+ * Module-level, ref-counted shared channel for ONLINE_USERS_CHANNEL.
+ *
+ * Supabase's realtime client dedupes `channel(topic)` calls by topic name —
+ * a second call with the same topic returns the *same already-joined*
+ * channel object rather than a new one. Calling `.on('presence', ...)` on an
+ * already-joined channel throws ("cannot add `presence` callbacks ... after
+ * `subscribe()`"). Multiple independent consumers on one page (the global
+ * PresenceTracker plus any number of useOnlinePresence() readers, and React
+ * Strict Mode's dev-only double-invoke of effects) would each otherwise try
+ * to create+subscribe their own channel for this same topic. Sharing one
+ * subscribe() call via ref-counting avoids that entirely.
+ */
+let sharedChannel: RealtimeChannel | null = null
+let subscribedPromise: Promise<void> | null = null
+let refCount = 0
+let teardownTimer: ReturnType<typeof setTimeout> | null = null
+const syncListeners = new Set<() => void>()
+
+function acquireChannel(): { channel: RealtimeChannel; ready: Promise<void> } {
+  if (teardownTimer !== null) {
+    clearTimeout(teardownTimer)
+    teardownTimer = null
+  }
+  refCount += 1
+
+  if (!sharedChannel) {
+    const supabase = getSupabaseClient()
+    const channel = supabase.channel(ONLINE_USERS_CHANNEL, {
+      config: { presence: { key: 'reader' } },
+    })
+    channel.on('presence', { event: 'sync' }, () => {
+      syncListeners.forEach((listener) => listener())
+    })
+    subscribedPromise = new Promise<void>((resolve) => {
+      channel.subscribe((status) => {
+        if (status === 'SUBSCRIBED') resolve()
+      })
+    })
+    sharedChannel = channel
+  }
+
+  return { channel: sharedChannel, ready: subscribedPromise! }
+}
+
+function releaseChannel() {
+  refCount = Math.max(0, refCount - 1)
+  if (refCount > 0) return
+
+  // Defer teardown by a tick: React Strict Mode's dev-only double-invoke
+  // (mount -> cleanup -> mount) would otherwise tear down and immediately
+  // need a fresh channel, racing Supabase's async removeChannel and hitting
+  // the same already-joined-channel issue this module exists to avoid.
+  teardownTimer = setTimeout(() => {
+    teardownTimer = null
+    if (refCount > 0) return
+    const channel = sharedChannel
+    sharedChannel = null
+    subscribedPromise = null
+    if (channel) {
+      const supabase = getSupabaseClient()
+      void supabase.removeChannel(channel)
+    }
+  }, 0)
+}
+
+/**
+ * Subscribes to the global presence channel and returns the live set of
+ * currently-online userIds. Read-only (never calls `.track()`) — use
+ * `useAnnouncePresence` to announce the current user's own presence.
+ */
+export function useOnlinePresence(): Set<string> {
+  const [onlineIds, setOnlineIds] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    const { channel } = acquireChannel()
+    const sync = () => setOnlineIds(new Set(Object.keys(channel.presenceState())))
+    syncListeners.add(sync)
+    sync()
+    return () => {
+      syncListeners.delete(sync)
+      releaseChannel()
+    }
+  }, [])
+
+  return onlineIds
+}
+
+/**
+ * Announces the current user's presence on the global channel for as long
+ * as the calling component is mounted and `enabled` is true. No-ops when
+ * `userId` is unset or `enabled` is false (e.g. "Show online status" off).
+ */
+export function useAnnouncePresence(userId: string | undefined, enabled: boolean): void {
+  useEffect(() => {
+    if (!userId || !enabled) return
+
+    const { channel, ready } = acquireChannel()
+    let active = true
+    void ready.then(() => {
+      if (active) void channel.track({ userId })
+    })
+
+    return () => {
+      active = false
+      releaseChannel()
+    }
+  }, [userId, enabled])
+}
+
+/** Combine server-derived presence (in_game/in_lobby/offline) with the live online-channel signal. */
+export function mergeFriendPresence(
+  serverPresence: FriendPresence | undefined,
+  isOnlineLive: boolean
+): FriendPresence {
+  if (serverPresence === 'in_game' || serverPresence === 'in_lobby') {
+    return serverPresence
+  }
+  return isOnlineLive ? 'online' : 'offline'
+}
+
+export function sortFriendsByPresence<T>(
+  friends: T[],
+  resolvePresence: (friend: T) => FriendPresence,
+  resolveName: (friend: T) => string
+): T[] {
+  return [...friends].sort((a, b) => {
+    const diff = PRESENCE_PRIORITY[resolvePresence(a)] - PRESENCE_PRIORITY[resolvePresence(b)]
+    if (diff !== 0) return diff
+    return resolveName(a).localeCompare(resolveName(b))
+  })
+}
+
+/** Test-only: resets the module-level shared channel state between test cases. */
+export function __resetSharedChannelForTests(): void {
+  if (teardownTimer !== null) {
+    clearTimeout(teardownTimer)
+    teardownTimer = null
+  }
+  sharedChannel = null
+  subscribedPromise = null
+  refCount = 0
+  syncListeners.clear()
+}

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -104,6 +104,9 @@ const en = {
       sent_other: 'Invited {{count}} friends!',
       linkCopied: 'Lobby link copied! Send it to {{count}} friend',
       linkCopied_other: 'Lobby link copied! Send it to {{count}} friends',
+      inviteButton: 'Invite',
+      invited: 'Invited',
+      sentToFriend: 'Invite sent to {{name}}!',
     },
     filters: {
       title: 'Filters',
@@ -1791,6 +1794,11 @@ const en = {
       emailVerificationRequired: 'Email Verification Required',
       emailVerificationRequiredDesc: 'Please verify your email to access your friend code and connect with friends.',
       verifyEmail: 'Verify Email',
+      presence: {
+        inGame: 'In game',
+        inLobby: 'In lobby',
+        online: 'Online',
+      },
       errors: {
         loadFailed: 'Failed to load friends',
         usernameRequired: 'Username is required',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -103,7 +103,10 @@ const no = {
       sent: 'Inviterte {{count}} venn!',
       sent_other: 'Inviterte {{count}} venner!',
       linkCopied: 'Lobbylenke kopiert! Send den til {{count}} venn',
-      linkCopied_other: 'Lobbylenke kopiert! Send den til {{count}} venner'
+      linkCopied_other: 'Lobbylenke kopiert! Send den til {{count}} venner',
+      inviteButton: 'Inviter',
+      invited: 'Invitert',
+      sentToFriend: 'Invitasjon sendt til {{name}}!',
     },
     filters: {
       title: 'Filtre',
@@ -1780,6 +1783,11 @@ const no = {
       emailVerificationRequired: 'E-postbekreftelse kreves',
       emailVerificationRequiredDesc: 'Vennligst bekreft e-posten din for å få tilgang til vennekoden og koble til venner.',
       verifyEmail: 'Bekreft e-post',
+      presence: {
+        inGame: 'I spill',
+        inLobby: 'I lobby',
+        online: 'Pålogget',
+      },
       errors: {
         loadFailed: 'Kunne ikke laste venner',
         usernameRequired: 'Brukernavn er påkrevd',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -103,7 +103,10 @@ const ru = {
       sent: 'Приглашён {{count}} друг!',
       sent_other: 'Приглашено {{count}} друзей!',
       linkCopied: 'Ссылка на лобби скопирована! Отправьте её {{count}} другу',
-      linkCopied_other: 'Ссылка на лобби скопирована! Отправьте её {{count}} друзьям'
+      linkCopied_other: 'Ссылка на лобби скопирована! Отправьте её {{count}} друзьям',
+      inviteButton: 'Пригласить',
+      invited: 'Приглашён',
+      sentToFriend: 'Приглашение отправлено {{name}}!',
     },
     filters: {
       title: 'Фильтры',
@@ -1780,6 +1783,11 @@ const ru = {
       emailVerificationRequired: 'Требуется подтверждение эл. почты',
       emailVerificationRequiredDesc: 'Пожалуйста, подтвердите эл. почту, чтобы получить доступ к коду друга и подключаться к друзьям.',
       verifyEmail: 'Подтвердить эл. почту',
+      presence: {
+        inGame: 'В игре',
+        inLobby: 'В лобби',
+        online: 'Онлайн',
+      },
       errors: {
         loadFailed: 'Не удалось загрузить друзей',
         usernameRequired: 'Требуется имя пользователя',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -113,6 +113,9 @@ const uk: Translation = {
       sent_other: 'Запрошено {{count}} друзів!',
       linkCopied: 'Посилання на лобі скопійовано! Надішліть його {{count}} другу',
       linkCopied_other: 'Посилання на лобі скопійовано! Надішліть його {{count}} друзям',
+      inviteButton: 'Запросити',
+      invited: 'Запрошено',
+      sentToFriend: 'Запрошення надіслано {{name}}!',
     },
     stats: {
       total: 'Всього лобі',
@@ -1793,6 +1796,11 @@ const uk: Translation = {
       emailVerificationRequired: 'Потрібна верифікація електронної пошти',
       emailVerificationRequiredDesc: 'Будь ласка, підтвердіть вашу електронну пошту, щоб отримати доступ до коду друга та зв\'язатися з друзями.',
       verifyEmail: 'Підтвердити пошту',
+      presence: {
+        inGame: 'У грі',
+        inLobby: 'У лобі',
+        online: 'Онлайн',
+      },
       errors: {
         loadFailed: 'Не вдалося завантажити друзів',
         usernameRequired: 'Ім\'я користувача обов\'язкове',


### PR DESCRIPTION
## Summary
- New global Supabase Presence channel (`online-users`) every signed-in client announces itself on (`hooks/useFriendPresence.ts` + `components/Header/PresenceTracker.tsx`), ref-counted/shared across consumers on one page to avoid Supabase's channel-dedup-by-topic throwing when multiple components subscribe to the same topic (found and fixed live via a React Strict Mode double-invoke crash, covered by a regression test).
- `Friends.tsx` and `FriendsListModal.tsx` now merge that live signal with the existing server-derived `in_lobby`/`in_game` presence, replacing duplicated sort/label logic; fixed previously hardcoded (untranslated) presence labels.
- `FriendsListModal`'s `onInvite` mode (existing lobby) now shows a dedicated Invite button per friend with per-row pending/invited state, instead of checkboxes + a single "Save"/"Invite N friends" button. The `onSelect` mode (create-lobby party pre-select) is untouched.
- Restored the actually-wired "Invite Friends" entry point in the waiting room (`WaitingRoomActions` accepted the prop but never rendered a button for it — found while testing).

## Test plan
- [x] `npx tsc --noEmit`, `npm run ci:quick` clean
- [x] New tests: `useFriendPresence` (shared-channel ref counting, Strict Mode double-invoke, deferred teardown), `FriendsListModal` (per-row invite UX, `onSelect` mode untouched), `Friends.tsx` presence mock
- [x] Locale parity passes (en/ru/no/uk)
- [x] Live verification with two real friended accounts via Playwright + injected NextAuth session cookies: presence syncs within seconds of either side opening any page, a real invite sent from the waiting room flips the row to "Invited" (`POST /api/lobby/[code]/invite` → 200), zero console errors
- [x] 726/726 real tests passing (pre-existing unrelated `clearMocksOnScope` edge-runtime infra gap in 35 suites, confirmed present on develop before this change)