### PR TITLE
#664 fix: regenerate waiting game state when lobby gameType changes

### DIFF
--- a/__tests__/api/lobby-code.test.ts
+++ b/__tests__/api/lobby-code.test.ts
@@ -505,6 +505,59 @@ describe('PATCH /api/lobby/[code]', () => {
     expect(response.status).toBe(200)
     expect(mockPrisma.lobbies.update).toHaveBeenCalled()
   })
+
+  it('regenerates the waiting game state (not just the label) when gameType changes', async () => {
+    mockGetServerSession.mockResolvedValue(mockSession as any)
+    mockPrisma.users.findUnique.mockResolvedValue(mockUser as any)
+    mockPrisma.lobbies.findUnique.mockResolvedValue({
+      id: 'lobby-1',
+      code: 'ABC123',
+      creatorId: 'user-123',
+      gameType: 'tic_tac_toe',
+      maxPlayers: 4,
+      games: [
+        {
+          id: 'game-1',
+          status: 'waiting',
+          updatedAt: new Date(),
+          players: [],
+        },
+      ],
+    } as any)
+    mockPrisma.lobbies.update.mockResolvedValue({
+      id: 'lobby-1',
+      code: 'ABC123',
+      maxPlayers: 4,
+      allowSpectators: false,
+      maxSpectators: 0,
+      turnTimer: 60,
+      theme: 'default',
+      gameType: 'alias',
+    } as any)
+    mockPrisma.games.update.mockResolvedValue({} as any)
+
+    const request = new NextRequest('http://localhost:3000/api/lobby/ABC123', {
+      method: 'PATCH',
+      body: JSON.stringify({ gameType: 'alias' }),
+    })
+    const response = await PATCH(request, { params: { code: 'ABC123' } as any })
+
+    expect(response.status).toBe(200)
+    expect(mockPrisma.games.update).toHaveBeenCalledTimes(1)
+    const updateCall = mockPrisma.games.update.mock.calls[0][0]
+    expect(updateCall.where).toEqual({ id: 'game-1' })
+    expect(updateCall.data.gameType).toBe('alias')
+    // The regression this guards: previously only `gameType` was relabeled,
+    // leaving the old game's `data` shape (e.g. tic-tac-toe's board) in
+    // place, which crashed alias-page.tsx reading data.teams[...].
+    expect(updateCall.data.state).toBeDefined()
+    expect(updateCall.data.state.data).toMatchObject({
+      phase: 'team_assignment',
+      currentTeamIndex: 0,
+    })
+    expect(Array.isArray(updateCall.data.state.data.teams)).toBe(true)
+    expect(updateCall.data.state.data.board).toBeUndefined()
+  })
 })
 
 describe('POST /api/lobby/[code]/leave', () => {

--- a/app/api/lobby/[code]/route.ts
+++ b/app/api/lobby/[code]/route.ts
@@ -794,11 +794,18 @@ export async function PATCH(
       },
     })
 
-    // If game type changed, also update the waiting game record
+    // If game type changed, regenerate the waiting game's state to match the
+    // new game type — relabeling gameType alone would leave the previous
+    // game's `data` shape in place (e.g. Tic-Tac-Toe's board/currentSymbol
+    // instead of Alias's teams/currentTeamIndex), crashing the new page.
     if (typeof updates.gameType === 'string' && updates.gameType !== lobby.gameType && activeGame) {
+      const freshState = createGameEngine(updates.gameType, 'temp').getState()
       await prisma.games.update({
         where: { id: activeGame.id },
-        data: { gameType: toPersistedGameType(updates.gameType) },
+        data: {
+          gameType: toPersistedGameType(updates.gameType),
+          state: toPersistedGameStateInput(freshState),
+        },
       })
     }
 


### PR DESCRIPTION
## Summary
Fixes a production crash reported via Sentry: `TypeError: Cannot read properties of undefined (reading 'undefined')` at `alias-page.tsx:1034`.

`PATCH /api/lobby/[code]` lets a host change a waiting lobby's `gameType` (#608), but only relabeled the `Games` row's `gameType` column — it never regenerated `state`/`data` to match the new game type. Switching e.g. Tic-Tac-Toe → Alias left the old `{board, currentSymbol, ...}` shape in the DB instead of Alias's `{phase, teams, currentTeamIndex, ...}`. `alias-page.tsx`'s `data.teams[data.currentTeamIndex]` then crashed for every player in the lobby since both were undefined.

Fix: regenerate `state` via `createGameEngine(newType, 'temp').getState()` whenever `gameType` changes on a waiting game, instead of just relabeling it.

## Test plan
- [x] `npx tsc --noEmit`, `npm run ci:quick` clean
- [x] New regression test in `__tests__/api/lobby-code.test.ts` asserting the games.update call includes a freshly-generated Alias-shaped state (not the stale shape) — note: this test file carries the project's existing pre-existing `clearMocksOnScope` edge-runtime jest infra gap (confirmed present on develop before this change too, same as ~35 other suites), so it can't execute in this sandbox; logic traced manually against the route's real control flow
- [x] Live verification: created a real Tic-Tac-Toe lobby, switched it to Alias via `PATCH /api/lobby/[code]`, confirmed the persisted state now has Alias's `phase`/`teams`/`currentTeamIndex` shape with no leftover `board` field, and the Alias waiting room renders live with zero console errors