### PR TITLE
#666 fix: Alias game UI bugs — layout, mobile adaptive, hydration fixes

### DIFF
--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -1081,7 +1081,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
           />
           <main style={{
             maxWidth: 1200, width: '100%', margin: '0 auto', flex: 1, minHeight: 0,
-            display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 24, alignItems: 'flex-start',
+            display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 24, alignItems: 'stretch',
             padding: isMobile ? '0 0 16px' : undefined,
           }}>
             {/* Game content */}
@@ -1101,7 +1101,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               {/* Hero word card */}
               <div style={{
                 ...cardBase, width: '100%',
-                padding: '32px 40px 28px', minHeight: 180,
+                padding: '32px 40px 28px', minHeight: 180, flex: 1,
                 display: 'flex', flexDirection: 'column',
                 alignItems: 'center', justifyContent: 'center',
                 gap: 20, position: 'relative', overflow: 'hidden',
@@ -1218,7 +1218,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
           />
           <main style={{
             maxWidth: 1200, width: '100%', margin: '0 auto', flex: 1, minHeight: 0,
-            display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 24, alignItems: 'flex-start',
+            display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 24, alignItems: 'stretch',
             padding: isMobile ? '0 0 16px' : undefined,
           }}>
             {/* Game content */}
@@ -1236,7 +1236,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
 
               <div style={{
                 ...cardBase, width: '100%',
-                padding: '24px 32px 28px', minHeight: 220,
+                padding: '24px 32px 28px', minHeight: 220, flex: 1,
                 display: 'flex', flexDirection: 'column',
                 alignItems: 'center', justifyContent: 'center',
                 gap: 20, position: 'relative', overflow: 'hidden',
@@ -1311,7 +1311,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
         {!isSpectator && <ReactionOverlay lobbyCode={code} />}
         <div style={{ ...pageBg(lobby?.theme), display: 'flex', flexDirection: 'column' }} data-testid="alias-turn-results-screen">
           <GameContextBar code={code} title={t('alias.turnCompleteTitle')} />
-          <main style={{ maxWidth: 980, width: '100%', margin: '0 auto', flex: 1, minHeight: 0, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1.3fr 1fr', gap: 22, alignItems: 'stretch' }}>
+          <main style={{ maxWidth: 980, width: '100%', margin: '0 auto', flex: 1, minHeight: 0, overflow: 'hidden', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1.3fr 1fr', gap: 22, alignItems: 'stretch' }}>
             {/* Word list */}
             <section style={{ ...cardBase, padding: 28, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
               <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 16, flexShrink: 0 }}>
@@ -1361,7 +1361,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
             </section>
 
             {/* Right column */}
-            <section style={{ display: 'flex', flexDirection: 'column', gap: 18, alignSelf: 'start' }}>
+            <section style={{ display: 'flex', flexDirection: 'column', gap: 18, overflowY: 'auto', minHeight: 0 }}>
               <div style={{
                 ...cardBase, padding: 24,
                 background: positive ? 'var(--bd-ink)' : 'var(--bd-card-warm)',

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -1311,7 +1311,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
         {!isSpectator && <ReactionOverlay lobbyCode={code} />}
         <div style={{ ...pageBg(lobby?.theme), display: 'flex', flexDirection: 'column' }} data-testid="alias-turn-results-screen">
           <GameContextBar code={code} title={t('alias.turnCompleteTitle')} />
-          <main style={{ maxWidth: 980, width: '100%', margin: '0 auto', flex: 1, minHeight: 0, overflow: 'hidden', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1.3fr 1fr', gap: 22, alignItems: 'stretch' }}>
+          <main style={{ maxWidth: 980, width: '100%', margin: '0 auto', flex: 1, minHeight: 0, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1.3fr 1fr', gap: 22, alignItems: 'stretch' }}>
             {/* Word list */}
             <section style={{ ...cardBase, padding: 28, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
               <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 16, flexShrink: 0 }}>
@@ -1361,7 +1361,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
             </section>
 
             {/* Right column */}
-            <section style={{ display: 'flex', flexDirection: 'column', gap: 18, overflowY: 'auto', minHeight: 0 }}>
+            <section style={{ display: 'flex', flexDirection: 'column', gap: 18, alignSelf: 'start' }}>
               <div style={{
                 ...cardBase, padding: 24,
                 background: positive ? 'var(--bd-ink)' : 'var(--bd-card-warm)',

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -966,7 +966,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
     return (
       <div style={pageBg(lobby?.theme)} data-testid="alias-team-assignment">
         <GameContextBar code={code} />
-        <main style={{ maxWidth: 1100, margin: '0 auto' }}>
+        <main style={{ maxWidth: 1600, margin: '0 auto', width: '100%' }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 20 }}>
             <BdLabel>Team selection</BdLabel>
             <h1 style={{
@@ -980,23 +980,19 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
             </p>
           </div>
 
-          {isMobile ? (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div className="flex flex-col gap-4 md:flex-row md:gap-5 md:items-start">
+            <div className="flex-1 min-w-0">
               {renderTeamCard(data.teams[0], 0)}
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '4px 0' }}>
-                <span className="bd-float" style={{ fontFamily: FONT_DISPLAY, fontSize: 28, color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>vs</span>
-              </div>
-              {data.teams[1] && renderTeamCard(data.teams[1], 1)}
             </div>
-          ) : (
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr', gap: 20, alignItems: 'start' }}>
-              {renderTeamCard(data.teams[0], 0)}
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 80, gridColumn: 2, gridRow: 1 }}>
-                <span className="bd-float" style={{ fontFamily: FONT_DISPLAY, fontSize: 36, color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>vs</span>
-              </div>
-              {data.teams[1] && renderTeamCard(data.teams[1], 1)}
+            <div className="flex items-center justify-center py-1 shrink-0 md:pt-20">
+              <span className="bd-float" style={{ fontFamily: FONT_DISPLAY, fontSize: 36, color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>vs</span>
             </div>
-          )}
+            {data.teams[1] && (
+              <div className="flex-1 min-w-0">
+                {renderTeamCard(data.teams[1], 1)}
+              </div>
+            )}
+          </div>
 
           <div style={{
             display: 'flex', alignItems: 'center', justifyContent: 'space-between',

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -1313,7 +1313,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
           <GameContextBar code={code} title={t('alias.turnCompleteTitle')} />
           <main style={{ maxWidth: 980, width: '100%', margin: '0 auto', flex: 1, minHeight: 0, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1.3fr 1fr', gap: 22, alignItems: 'stretch' }}>
             {/* Word list */}
-            <section style={{ ...cardBase, padding: 28, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+            <section style={{ ...cardBase, padding: 28, display: 'flex', flexDirection: 'column', alignSelf: 'start' }}>
               <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 16, flexShrink: 0 }}>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                   <BdLabel>{describerPlayer?.name ? t('alias.describerWords', { name: describerPlayer.name }) : t('alias.wordsThisTurn')}</BdLabel>
@@ -1326,7 +1326,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
                   <ScorePill kind="skipped" count={skippedCount} />
                 </div>
               </div>
-              <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, marginRight: -4, paddingRight: 4 }}>
+              <div style={{ marginRight: -4, paddingRight: 4 }}>
                 {wordResults.length === 0 && (
                   <div style={{ padding: '40px 16px', textAlign: 'center', color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>No words played this turn.</div>
                 )}

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -965,8 +965,8 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
 
     return (
       <div style={{ ...pageBg(lobby?.theme), display: 'flex', flexDirection: 'column' }} data-testid="alias-team-assignment">
-        <GameContextBar code={code} />
         <main style={{ maxWidth: 1100, margin: '0 auto', width: '100%', flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center', paddingBottom: 24 }}>
+          <GameContextBar code={code} />
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 20 }}>
             <BdLabel>Team selection</BdLabel>
             <h1 style={{

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -964,9 +964,9 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
     }
 
     return (
-      <div style={pageBg(lobby?.theme)} data-testid="alias-team-assignment">
+      <div style={{ ...pageBg(lobby?.theme), display: 'flex', flexDirection: 'column' }} data-testid="alias-team-assignment">
         <GameContextBar code={code} />
-        <main style={{ maxWidth: 1600, margin: '0 auto', width: '100%' }}>
+        <main style={{ maxWidth: 1100, margin: '0 auto', width: '100%', flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center', paddingBottom: 24 }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 20 }}>
             <BdLabel>Team selection</BdLabel>
             <h1 style={{

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -1101,7 +1101,9 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               {/* Hero word card */}
               <div style={{
                 ...cardBase, width: '100%',
-                padding: '32px 40px 28px', minHeight: 180, flex: 1,
+                padding: isMobile ? '20px 24px' : '32px 40px 28px',
+                minHeight: isMobile ? 140 : 180,
+                flex: isMobile ? undefined : 1,
                 display: 'flex', flexDirection: 'column',
                 alignItems: 'center', justifyContent: 'center',
                 gap: 20, position: 'relative', overflow: 'hidden',
@@ -1111,7 +1113,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
                 <BdLabel>{t('alias.theSecretWord')}</BdLabel>
                 <span style={{
                   fontFamily: FONT_DISPLAY, fontWeight: 700,
-                  fontSize: 'clamp(48px, 9vw, 84px)',
+                  fontSize: isMobile ? 'clamp(36px, 10vw, 56px)' : 'clamp(48px, 9vw, 84px)',
                   lineHeight: 1.02, textAlign: 'center',
                   color: 'var(--bd-ink)', letterSpacing: '-0.02em',
                   zIndex: 1, wordBreak: 'break-word',
@@ -1122,8 +1124,8 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               </div>
 
               {/* Timer + tally */}
-              <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 28, alignItems: 'center', width: '100%' }}>
-                <CountdownRing remaining={remaining} total={turnTimerSeconds} size={140} />
+              <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: isMobile ? 16 : 28, alignItems: 'center', width: '100%' }}>
+                <CountdownRing remaining={remaining} total={turnTimerSeconds} size={isMobile ? 88 : 140} />
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                   <BdLabel>{t('alias.thisTurnSoFar')}</BdLabel>
                   <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
@@ -1148,20 +1150,22 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               </div>
 
               {/* Action buttons */}
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, width: '100%' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: isMobile ? 10 : 16, width: '100%' }}>
                 <button
                   aria-label="Guessed correctly"
                   onClick={() => handleMove('word_action', { action: 'guess' })}
                   disabled={isMoveSubmitting}
                   style={{
                     background: 'var(--bd-mint)', color: '#06322a',
-                    border: 'none', borderRadius: 18, padding: '22px 16px', fontSize: 20, fontWeight: 700,
+                    border: 'none', borderRadius: 18,
+                    padding: isMobile ? '16px 12px' : '22px 16px',
+                    fontSize: isMobile ? 17 : 20, fontWeight: 700,
                     cursor: 'pointer', boxShadow: '0 5px 0 var(--bd-mint-deep)',
                     display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 10,
                     opacity: isMoveSubmitting ? 0.5 : 1,
                   }}
                 >
-                  <span style={{ fontSize: 24, lineHeight: 1 }}>✓</span>
+                  <span style={{ fontSize: isMobile ? 20 : 24, lineHeight: 1 }}>✓</span>
                   {t('alias.guessed')}
                   <span style={{ fontSize: 11, opacity: 0.7, fontFamily: FONT_MONO }}>+1</span>
                 </button>
@@ -1171,13 +1175,15 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
                   disabled={isMoveSubmitting}
                   style={{
                     background: 'var(--bd-sun)', color: '#4a3a09',
-                    border: 'none', borderRadius: 18, padding: '22px 16px', fontSize: 20, fontWeight: 700,
+                    border: 'none', borderRadius: 18,
+                    padding: isMobile ? '16px 12px' : '22px 16px',
+                    fontSize: isMobile ? 17 : 20, fontWeight: 700,
                     cursor: 'pointer', boxShadow: '0 5px 0 var(--bd-sun-deep)',
                     display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 10,
                     opacity: isMoveSubmitting ? 0.5 : 1,
                   }}
                 >
-                  <span style={{ fontSize: 24, lineHeight: 1 }}>✗</span>
+                  <span style={{ fontSize: isMobile ? 20 : 24, lineHeight: 1 }}>✗</span>
                   {t('alias.skip')}
                   <span style={{ fontSize: 11, opacity: 0.7, fontFamily: FONT_MONO }}>−1</span>
                 </button>
@@ -1188,8 +1194,8 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               </button>
             </div>
 
-            {/* Chat panel — describer sees guesses (read-only) */}
-            <GuessChatPanel {...chatProps} canType={false} />
+            {/* Chat panel — describer sees guesses read-only; hidden on mobile to save space */}
+            {!isMobile && <GuessChatPanel {...chatProps} canType={false} />}
           </main>
         </div>
       </>
@@ -1236,7 +1242,9 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
 
               <div style={{
                 ...cardBase, width: '100%',
-                padding: '24px 32px 28px', minHeight: 220, flex: 1,
+                padding: isMobile ? '16px 20px' : '24px 32px 28px',
+                minHeight: isMobile ? 160 : 220,
+                flex: isMobile ? undefined : 1,
                 display: 'flex', flexDirection: 'column',
                 alignItems: 'center', justifyContent: 'center',
                 gap: 20, position: 'relative', overflow: 'hidden',
@@ -1262,14 +1270,15 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
 
                 <span className="bd-float" style={{
                   fontFamily: FONT_DISPLAY, fontWeight: 700,
-                  fontSize: 'clamp(100px, 16vw, 160px)', lineHeight: 1,
+                  fontSize: isMobile ? 'clamp(72px, 20vw, 100px)' : 'clamp(100px, 16vw, 160px)',
+                  lineHeight: 1,
                   color: 'var(--bd-coral)', textShadow: '0 6px 0 rgba(31,27,22,0.08)', zIndex: 1,
                 }}>?</span>
               </div>
 
               {/* Timer + tally */}
-              <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 28, alignItems: 'center', width: '100%' }}>
-                <CountdownRing remaining={remaining} total={turnTimerSeconds} size={140} />
+              <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: isMobile ? 16 : 28, alignItems: 'center', width: '100%' }}>
+                <CountdownRing remaining={remaining} total={turnTimerSeconds} size={isMobile ? 88 : 140} />
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                   <BdLabel>Live tally</BdLabel>
                   <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
@@ -1372,7 +1381,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               }}>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1 }}>
                   <BdLabel style={{ color: positive ? 'rgba(251,246,238,0.7)' : 'var(--bd-ink-muted)' }}>Turn score</BdLabel>
-                  <span style={{ fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: 56, lineHeight: 1 }}>
+                  <span style={{ fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: isMobile ? 40 : 56, lineHeight: 1 }}>
                     {scoreDelta >= 0 ? '+' : ''}{scoreDelta}
                   </span>
                 </div>
@@ -1399,7 +1408,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
                           <span style={{ fontWeight: 700, fontSize: 16 }}>{team.name}</span>
                           {isActive && <BdLabel style={{ display: 'block', fontSize: 10 }}>Just played</BdLabel>}
                         </div>
-                        <span style={{ fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: 32, fontVariantNumeric: 'tabular-nums' }}>{team.score}</span>
+                        <span style={{ fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: isMobile ? 22 : 32, fontVariantNumeric: 'tabular-nums' }}>{team.score}</span>
                       </div>
                     )
                   })}

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -560,8 +560,11 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
         if (authoritativeState) {
           applyAuthoritativeState(game.id, authoritativeState)
         }
+      } else if (res.status === 409) {
+        // STATE_CONFLICT: another player's move already advanced the phase; reconcile silently
+        await loadLobby()
       } else {
-        clientLogger.error('Alias move failed', { type })
+        clientLogger.error('Alias move failed', { type, status: res.status })
         await loadLobby()
       }
     } catch (err) {
@@ -861,6 +864,105 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
 
     const teamsValid = data.teams.every(t => t.playerIds.length >= 1)
 
+    const renderTeamCard = (team: (typeof data.teams)[0], i: number) => {
+      const accent = TEAM_ACCENTS[i] ?? 'var(--bd-lav)'
+      const accentDeep = TEAM_ACCENTS_DEEP[i] ?? '#7A6AE8'
+      const isMyTeam = myTeamId === team.id
+      return (
+        <div key={team.id} style={{
+          ...cardBase, padding: 24,
+          borderTop: `6px solid ${accent}`,
+          position: 'relative', overflow: 'hidden',
+          outline: isMyTeam ? `2px solid ${accent}` : 'none',
+          outlineOffset: 2,
+        }}>
+          <div aria-hidden style={{
+            position: 'absolute', top: -40, right: -40,
+            width: 140, height: 140, borderRadius: '50%',
+            background: accent, opacity: 0.07,
+          }} />
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 16 }}>
+            <div>
+              <BdLabel style={{ color: accentDeep }}>{`Team 0${i + 1}`}</BdLabel>
+              <div style={{ fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: 28, marginTop: 4 }}>
+                {team.name}
+              </div>
+            </div>
+            <span style={{ fontFamily: FONT_MONO, fontSize: 13, fontWeight: 600, color: 'var(--bd-ink-muted)' }}>
+              {team.playerIds.length} {team.playerIds.length === 1 ? 'player' : 'players'}
+            </span>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16, minHeight: 60 }}>
+            {team.playerIds.length === 0 && (
+              <div style={{
+                padding: '16px', border: `1.5px dashed ${accent}`, borderRadius: 12,
+                color: 'var(--bd-ink-muted)', fontSize: 13, textAlign: 'center',
+              }}>Empty — be the first</div>
+            )}
+            {team.playerIds.map(pid => {
+              const name = getPlayerName(pid)
+              const isYou = pid === currentUserId
+              const isPremiumPlayer = !!players.find(p => p.userId === pid)?.user?.isPremium
+              return (
+                <div key={pid} style={{
+                  display: 'flex', alignItems: 'center', gap: 10,
+                  padding: '8px 12px', borderRadius: 999,
+                  background: 'rgba(255,255,255,0.6)',
+                  border: isYou ? `1.5px solid ${accent}` : '1.5px solid var(--bd-line)',
+                }}>
+                  <BdAvatar name={name} color={isYou ? accent : undefined} size={32} />
+                  <span style={{ fontWeight: 600, fontSize: 14, color: isPremiumPlayer ? 'var(--bd-premium)' : undefined }}>
+                    {name}
+                    {isPremiumPlayer && <span style={{ marginLeft: 4, fontSize: 12 }} title="Premium">👑</span>}
+                  </span>
+                  {isYou && (
+                    <span style={{
+                      marginLeft: 'auto', fontSize: 10, fontFamily: FONT_MONO,
+                      color: accentDeep, background: 'rgba(255,255,255,0.8)',
+                      padding: '2px 7px', borderRadius: 999, border: `1px solid ${accent}`,
+                    }}>YOU</span>
+                  )}
+                  {players.find(p => p.userId === pid)?.userId === lobby?.creatorId && (
+                    <span style={{ marginLeft: isMyTeam ? 0 : 'auto', fontSize: 14 }}>★</span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          {myTeamId !== team.id ? (
+            <button
+              onClick={() => handleMove('assign_team', { teamId: team.id })}
+              disabled={isMoveSubmitting}
+              style={{
+                width: '100%',
+                background: accent, color: 'var(--bd-ink)',
+                border: 'none', borderRadius: 12,
+                padding: '12px 16px', fontWeight: 700, fontSize: 15,
+                cursor: 'pointer',
+                boxShadow: `0 3px 0 ${accentDeep}`,
+                opacity: isMoveSubmitting ? 0.5 : 1,
+              }}
+            >
+              Join {team.name}
+            </button>
+          ) : (
+            <div style={{
+              width: '100%', textAlign: 'center',
+              padding: '12px 16px', borderRadius: 12,
+              background: 'rgba(255,255,255,0.5)',
+              border: `1.5px solid ${accent}`,
+              fontWeight: 600, fontSize: 14,
+              color: accentDeep,
+            }}>
+              ✓ You're on this team
+            </div>
+          )}
+        </div>
+      )
+    }
+
     return (
       <div style={pageBg(lobby?.theme)} data-testid="alias-team-assignment">
         <GameContextBar code={code} />
@@ -878,115 +980,23 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
             </p>
           </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr', gap: 20, alignItems: 'start' }}>
-            {data.teams.map((team, i) => {
-              const accent = TEAM_ACCENTS[i] ?? 'var(--bd-lav)'
-              const accentDeep = TEAM_ACCENTS_DEEP[i] ?? '#7A6AE8'
-              const isMyTeam = myTeamId === team.id
-
-              return (
-                <div key={team.id} style={{
-                  ...cardBase, padding: 24,
-                  borderTop: `6px solid ${accent}`,
-                  position: 'relative', overflow: 'hidden',
-                  outline: isMyTeam ? `2px solid ${accent}` : 'none',
-                  outlineOffset: 2,
-                  gridColumn: i === 0 ? 1 : 3,
-                }}>
-                  <div aria-hidden style={{
-                    position: 'absolute', top: -40, right: -40,
-                    width: 140, height: 140, borderRadius: '50%',
-                    background: accent, opacity: 0.07,
-                  }} />
-                  <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 16 }}>
-                    <div>
-                      <BdLabel style={{ color: accentDeep }}>{`Team 0${i + 1}`}</BdLabel>
-                      <div style={{ fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: 28, marginTop: 4 }}>
-                        {team.name}
-                      </div>
-                    </div>
-                    <span style={{ fontFamily: FONT_MONO, fontSize: 13, fontWeight: 600, color: 'var(--bd-ink-muted)' }}>
-                      {team.playerIds.length} {team.playerIds.length === 1 ? 'player' : 'players'}
-                    </span>
-                  </div>
-
-                  {/* Player list */}
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16, minHeight: 60 }}>
-                    {team.playerIds.length === 0 && (
-                      <div style={{
-                        padding: '16px', border: `1.5px dashed ${accent}`, borderRadius: 12,
-                        color: 'var(--bd-ink-muted)', fontSize: 13, textAlign: 'center',
-                      }}>Empty — be the first</div>
-                    )}
-                    {team.playerIds.map(pid => {
-                      const name = getPlayerName(pid)
-                      const isYou = pid === currentUserId
-                      const isPremiumPlayer = !!players.find(p => p.userId === pid)?.user?.isPremium
-                      return (
-                        <div key={pid} style={{
-                          display: 'flex', alignItems: 'center', gap: 10,
-                          padding: '8px 12px', borderRadius: 999,
-                          background: 'rgba(255,255,255,0.6)',
-                          border: isYou ? `1.5px solid ${accent}` : '1.5px solid var(--bd-line)',
-                        }}>
-                          <BdAvatar name={name} color={isYou ? accent : undefined} size={32} />
-                          <span style={{ fontWeight: 600, fontSize: 14, color: isPremiumPlayer ? 'var(--bd-premium)' : undefined }}>
-                            {name}
-                            {isPremiumPlayer && <span style={{ marginLeft: 4, fontSize: 12 }} title="Premium">👑</span>}
-                          </span>
-                          {isYou && (
-                            <span style={{
-                              marginLeft: 'auto', fontSize: 10, fontFamily: FONT_MONO,
-                              color: accentDeep, background: 'rgba(255,255,255,0.8)',
-                              padding: '2px 7px', borderRadius: 999, border: `1px solid ${accent}`,
-                            }}>YOU</span>
-                          )}
-                          {players.find(p => p.userId === pid)?.userId === lobby?.creatorId && (
-                            <span style={{ marginLeft: isMyTeam ? 0 : 'auto', fontSize: 14 }}>★</span>
-                          )}
-                        </div>
-                      )
-                    })}
-                  </div>
-
-                  {/* Join button */}
-                  {myTeamId !== team.id ? (
-                    <button
-                      onClick={() => handleMove('assign_team', { teamId: team.id })}
-                      disabled={isMoveSubmitting}
-                      style={{
-                        width: '100%',
-                        background: accent, color: 'var(--bd-ink)',
-                        border: 'none', borderRadius: 12,
-                        padding: '12px 16px', fontWeight: 700, fontSize: 15,
-                        cursor: 'pointer',
-                        boxShadow: `0 3px 0 ${accentDeep}`,
-                        opacity: isMoveSubmitting ? 0.5 : 1,
-                      }}
-                    >
-                      Join {team.name}
-                    </button>
-                  ) : (
-                    <div style={{
-                      width: '100%', textAlign: 'center',
-                      padding: '12px 16px', borderRadius: 12,
-                      background: 'rgba(255,255,255,0.5)',
-                      border: `1.5px solid ${accent}`,
-                      fontWeight: 600, fontSize: 14,
-                      color: accentDeep,
-                    }}>
-                      ✓ You're on this team
-                    </div>
-                  )}
-                </div>
-              )
-            })}
-
-            {/* "vs" divider */}
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 80, gridColumn: 2 }}>
-              <span className="bd-float" style={{ fontFamily: FONT_DISPLAY, fontSize: 36, color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>vs</span>
+          {isMobile ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              {renderTeamCard(data.teams[0], 0)}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '4px 0' }}>
+                <span className="bd-float" style={{ fontFamily: FONT_DISPLAY, fontSize: 28, color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>vs</span>
+              </div>
+              {data.teams[1] && renderTeamCard(data.teams[1], 1)}
             </div>
-          </div>
+          ) : (
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr', gap: 20, alignItems: 'start' }}>
+              {renderTeamCard(data.teams[0], 0)}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 80, gridColumn: 2, gridRow: 1 }}>
+                <span className="bd-float" style={{ fontFamily: FONT_DISPLAY, fontSize: 36, color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>vs</span>
+              </div>
+              {data.teams[1] && renderTeamCard(data.teams[1], 1)}
+            </div>
+          )}
 
           <div style={{
             display: 'flex', alignItems: 'center', justifyContent: 'space-between',
@@ -1296,6 +1306,9 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
     const guessedCount = wordResults.filter(w => w.result === 'guessed').length
     const skippedCount = wordResults.filter(w => w.result === 'skipped').length
     const justPlayedTeamId = result.teamId
+    const nextTeamIdx = (data.currentTeamIndex + 1) % data.teams.length
+    const nextTeam = data.teams[nextTeamIdx]
+    const isNextTeamPlayer = !!nextTeam?.playerIds.includes(currentUserId ?? '')
 
     return (
       <>
@@ -1400,21 +1413,26 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
                 </div>
               </div>
 
-              {/*
-                Next Turn is open to every player, not just the host — the engine's own
-                validateMove for 'next_turn' has no player-ownership check (any player can
-                legally advance past turn_results). Gating this to isHost made the game
-                permanently soft-lock for everyone else whenever the host didn't click
-                through (closed tab, disconnected, distracted) — see #639.
-              */}
-              <button
-                style={{ ...primaryBtn, fontSize: 17, padding: '16px 22px', width: '100%', justifyContent: 'center' }}
-                onClick={() => handleMove('next_turn', {})}
-                disabled={isMoveSubmitting}
-              >
-                {t('alias.nextTurn')}
-                <span aria-hidden style={{ fontSize: 18 }}>→</span>
-              </button>
+              {/* Next Turn restricted to the team whose turn is next (#666) */}
+              {!isSpectator && (isNextTeamPlayer ? (
+                <button
+                  style={{ ...primaryBtn, fontSize: 17, padding: '16px 22px', width: '100%', justifyContent: 'center' }}
+                  onClick={() => handleMove('next_turn', {})}
+                  disabled={isMoveSubmitting}
+                >
+                  {t('alias.nextTurn')}
+                  <span aria-hidden style={{ fontSize: 18 }}>→</span>
+                </button>
+              ) : (
+                <div style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+                  background: 'var(--bd-bg2)', border: '1.5px solid var(--bd-line)',
+                  borderRadius: 14, padding: '16px 22px',
+                  fontSize: 15, fontWeight: 600, color: 'var(--bd-ink-soft)',
+                }}>
+                  ⏳ Waiting for {nextTeam?.name ?? 'next team'} to start their turn…
+                </div>
+              ))}
               <button style={{ ...linkBtn, textAlign: 'center' }} onClick={() => router.push('/games')}>
                 {t('lobby.game.leaveGame')}
               </button>

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -1079,11 +1079,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               </span>
             }
           />
-          <main style={{
-            maxWidth: 1200, width: '100%', margin: '0 auto', flex: 1, minHeight: 0,
-            display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 24, alignItems: 'stretch',
-            padding: isMobile ? '0 0 16px' : undefined,
-          }}>
+          <main style={{ maxWidth: 1200, margin: '0 auto', flex: 1, minHeight: 0 }} className="flex w-full flex-col gap-6 items-stretch md:flex-row md:gap-6 pb-4 md:pb-0">
             {/* Game content */}
             <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>
               <div style={{
@@ -1222,11 +1218,7 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               </span>
             }
           />
-          <main style={{
-            maxWidth: 1200, width: '100%', margin: '0 auto', flex: 1, minHeight: 0,
-            display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 24, alignItems: 'stretch',
-            padding: isMobile ? '0 0 16px' : undefined,
-          }}>
+          <main style={{ maxWidth: 1200, margin: '0 auto', flex: 1, minHeight: 0 }} className="flex w-full flex-col gap-6 items-stretch md:flex-row md:gap-6 pb-4 md:pb-0">
             {/* Game content */}
             <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>
               <div style={{
@@ -1320,13 +1312,13 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
         {!isSpectator && <ReactionOverlay lobbyCode={code} />}
         <div style={{ ...pageBg(lobby?.theme), display: 'flex', flexDirection: 'column' }} data-testid="alias-turn-results-screen">
           <GameContextBar code={code} title={t('alias.turnCompleteTitle')} />
-          <main style={{ maxWidth: 980, width: '100%', margin: '0 auto', flex: 1, minHeight: 0, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1.3fr 1fr', gap: 22, alignItems: 'stretch' }}>
+          <main style={{ maxWidth: 980, margin: '0 auto', flex: 1, minHeight: 0 }} className="grid w-full grid-cols-1 md:grid-cols-[1.3fr_1fr] gap-5 items-stretch">
             {/* Word list */}
-            <section style={{ ...cardBase, padding: 28, display: 'flex', flexDirection: 'column', alignSelf: 'start' }}>
-              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 16, flexShrink: 0 }}>
+            <section style={{ ...cardBase, display: 'flex', flexDirection: 'column', alignSelf: 'start' }} className="p-4 md:p-7">
+              <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 16, flexShrink: 0, flexWrap: 'wrap', gap: 8 }}>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                   <BdLabel>{describerPlayer?.name ? t('alias.describerWords', { name: describerPlayer.name }) : t('alias.wordsThisTurn')}</BdLabel>
-                  <h2 style={{ fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: 28, margin: 0 }}>
+                  <h2 style={{ fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: isMobile ? 22 : 28, margin: 0 }}>
                     {wordResults.length} {wordResults.length === 1 ? 'word' : 'words'}
                   </h2>
                 </div>

--- a/app/lobby/[code]/alias-page.tsx
+++ b/app/lobby/[code]/alias-page.tsx
@@ -253,7 +253,7 @@ const GameContextBar: React.FC<{ code: string; title?: string; right?: React.Rea
 )
 
 // Guess chat panel — shown on describer + guesser screens
-function GuessChatPanel({ guesses, guessInput, onInputChange, onSend, onKeyDown, canType, endRef, currentUserId, isMobile }: {
+function GuessChatPanel({ guesses, guessInput, onInputChange, onSend, onKeyDown, canType, endRef, currentUserId }: {
   guesses: GuessMessage[]
   guessInput: string
   onInputChange: (v: string) => void
@@ -262,15 +262,13 @@ function GuessChatPanel({ guesses, guessInput, onInputChange, onSend, onKeyDown,
   canType: boolean
   endRef: React.RefObject<HTMLDivElement | null>
   currentUserId: string | null | undefined
-  isMobile?: boolean
 }) {
   const { t } = useTranslation()
   return (
-    <div style={{
+    <div className="w-full md:w-[280px] md:max-w-[280px] h-[220px] md:h-full md:max-h-[560px]" style={{
       ...cardBase,
       display: 'flex', flexDirection: 'column',
-      width: isMobile ? '100%' : 280, minWidth: 0, maxWidth: isMobile ? '100%' : 280,
-      height: isMobile ? 220 : '100%', maxHeight: isMobile ? 220 : 560,
+      minWidth: 0,
       overflow: 'hidden', flexShrink: 0,
     }}>
       <div style={{ padding: '16px 18px 12px', borderBottom: '1px solid var(--bd-line)' }}>
@@ -800,13 +798,11 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
             </div>
           </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr auto 1fr', gap: 20, alignItems: 'stretch' }}>
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] gap-5 items-stretch">
             <TeamCard side="left" name={t('alias.team1')} accent="var(--bd-coral)" accentDeep="var(--bd-coral-deep)" list={team1} />
-            {!isMobile && (
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <span className="bd-float" style={{ fontFamily: FONT_DISPLAY, fontSize: 36, color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>vs</span>
-              </div>
-            )}
+            <div className="hidden md:flex items-center justify-center">
+              <span className="bd-float" style={{ fontFamily: FONT_DISPLAY, fontSize: 36, color: 'var(--bd-ink-muted)', fontStyle: 'italic' }}>vs</span>
+            </div>
             <TeamCard side="right" name={t('alias.team2')} accent="var(--bd-lav)" accentDeep="#7A6AE8" list={team2} />
           </div>
 
@@ -1056,7 +1052,6 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
     onKeyDown: handleGuessKeyDown,
     endRef: guessesEndRef,
     currentUserId,
-    isMobile,
   }
 
   // ── PHASE 2 — Describer turn ───────────────────────────────────────────────
@@ -1095,11 +1090,10 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               </div>
 
               {/* Hero word card */}
-              <div style={{
+              <div className="md:flex-1" style={{
                 ...cardBase, width: '100%',
                 padding: isMobile ? '20px 24px' : '32px 40px 28px',
                 minHeight: isMobile ? 140 : 180,
-                flex: isMobile ? undefined : 1,
                 display: 'flex', flexDirection: 'column',
                 alignItems: 'center', justifyContent: 'center',
                 gap: 20, position: 'relative', overflow: 'hidden',
@@ -1190,8 +1184,10 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
               </button>
             </div>
 
-            {/* Chat panel — describer sees guesses read-only; hidden on mobile to save space */}
-            {!isMobile && <GuessChatPanel {...chatProps} canType={false} />}
+            {/* Chat panel — describer sees guesses read-only; hidden on mobile via CSS */}
+            <div className="hidden md:block" style={{ width: 280, height: '100%', maxHeight: 560, flexShrink: 0 }}>
+              <GuessChatPanel {...chatProps} canType={false} />
+            </div>
           </main>
         </div>
       </>
@@ -1232,11 +1228,10 @@ export default function AliasPage({ code, isSpectator = false, onGameReset }: Al
                 }
               </div>
 
-              <div style={{
+              <div className="md:flex-1" style={{
                 ...cardBase, width: '100%',
                 padding: isMobile ? '16px 20px' : '24px 32px 28px',
                 minHeight: isMobile ? 160 : 220,
-                flex: isMobile ? undefined : 1,
                 display: 'flex', flexDirection: 'column',
                 alignItems: 'center', justifyContent: 'center',
                 gap: 20, position: 'relative', overflow: 'hidden',

--- a/app/lobby/[code]/connect-four-page.tsx
+++ b/app/lobby/[code]/connect-four-page.tsx
@@ -1269,15 +1269,16 @@ export default function ConnectFourLobbyPage({ code, isSpectator = false, onGame
             </a>
         </div>
     ) : (
-        <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 8 }}>
+        <div className="flex flex-col md:flex-row gap-2">
             <button
                 onClick={() => void handleRequestUndo()}
                 disabled={!canRequestUndo}
-                style={{ padding: '10px 14px', fontSize: 13, borderRadius: 14, fontWeight: 600, background: 'var(--bd-card-warm)', border: '1px solid var(--bd-line)', color: canRequestUndo ? 'var(--bd-ink-soft)' : 'var(--bd-ink-muted)', cursor: canRequestUndo ? 'pointer' : 'not-allowed', fontFamily: 'inherit', opacity: canRequestUndo ? 1 : 0.5, width: isMobile ? '100%' : undefined }}
+                className="w-full md:w-auto"
+                style={{ padding: '10px 14px', fontSize: 13, borderRadius: 14, fontWeight: 600, background: 'var(--bd-card-warm)', border: '1px solid var(--bd-line)', color: canRequestUndo ? 'var(--bd-ink-soft)' : 'var(--bd-ink-muted)', cursor: canRequestUndo ? 'pointer' : 'not-allowed', fontFamily: 'inherit', opacity: canRequestUndo ? 1 : 0.5 }}
             >
                 ↶ {t('games.connect_four.game.requestUndo')}
             </button>
-            <button onClick={() => setShowLeaveConfirmModal(true)} style={{ padding: '10px 14px', fontSize: 13, borderRadius: 14, fontWeight: 600, background: 'var(--bd-card-warm)', border: '1px solid var(--bd-line)', color: 'var(--bd-coral-deep)', cursor: 'pointer', fontFamily: 'inherit', width: isMobile ? '100%' : undefined }}>
+            <button onClick={() => setShowLeaveConfirmModal(true)} className="w-full md:w-auto" style={{ padding: '10px 14px', fontSize: 13, borderRadius: 14, fontWeight: 600, background: 'var(--bd-card-warm)', border: '1px solid var(--bd-line)', color: 'var(--bd-coral-deep)', cursor: 'pointer', fontFamily: 'inherit' }}>
                 {t('games.connect_four.game.leave')}
             </button>
         </div>


### PR DESCRIPTION
## Summary
- Fixed VS label showing below team cards instead of between them (waiting room + team_assignment)
- Eliminated SSR hydration layout flashes by replacing all structural `isMobile ? x : y` branches with Tailwind responsive classes (`md:` breakpoint = 768px)
- Alias describer/guesser/turn_results: optimised layout for large desktop screens (content fills height), tablet screens (no unnecessary scroll), and mobile (adaptive single-column layout)
- Moved GameContextBar inside main on team_assignment so it centres with team cards on wide screens
- Word list section on turn_results now shrinks to content height instead of expanding to fill half the card
- Connect Four game screen: undo/leave button group stacks vertically on mobile from first render (no flash)

## Screens fixed
- Alias waiting room: team grid + vs divider
- Alias team_assignment: GameContextBar position, VS placement
- Alias describer turn: word card height, chat panel visibility
- Alias guesser turn: listening card height, chat panel sizing
- Alias turn_results: grid columns, word list height, score sections
- Connect Four game: action button group direction/width

## Test plan
- [ ] Alias waiting room: mobile shows 1-column team cards (no vs), desktop shows 3-column with vs between
- [ ] Alias describer on mobile: no chat panel flash, word card correct height
- [ ] Alias guesser on mobile: chat panel sized correctly from first render
- [ ] Alias turn_results on mobile: single-column from first paint, no content clipping
- [ ] Connect Four game on mobile: Undo/Leave buttons stack vertically from first render
- [ ] `npx tsc --noEmit` clean ✅
- [ ] 44 tests passing ✅