### PR TITLE
Mobile responsiveness fixes: #683, #687, #688

### DIFF
--- a/__tests__/integration/guest-flow.test.ts
+++ b/__tests__/integration/guest-flow.test.ts
@@ -114,7 +114,8 @@ describe('Guest user flow integration', () => {
       username: guestName,
       email: `guest-${guestId}@boardly.guest`,
       isGuest: true,
-      lastActiveAt: new Date(Date.now() - 60_000),
+      // Beyond the 5-minute activity throttle (#683) so the write isn't skipped.
+      lastActiveAt: new Date(Date.now() - 10 * 60_000),
     })
     ;(prisma.users.update as jest.Mock).mockResolvedValue({
       id: guestId,

--- a/__tests__/lib/guest-helpers.test.ts
+++ b/__tests__/lib/guest-helpers.test.ts
@@ -100,6 +100,48 @@ describe('Guest Helpers', () => {
             expect(prisma.users.create).not.toHaveBeenCalled()
         })
 
+        it('should skip the write when recently active and username unchanged', async () => {
+            const guestId = 'guest_throttled'
+            const guestName = 'Same Name'
+            const existingUser = {
+                id: guestId,
+                username: guestName,
+                email: `guest-${guestId}@boardly.guest`,
+                isGuest: true,
+                lastActiveAt: new Date(Date.now() - 60000), // 1 minute ago
+            }
+
+                ; (prisma.users.findFirst as jest.Mock).mockResolvedValue(existingUser)
+
+            const user = await getOrCreateGuestUser(guestId, guestName)
+
+            expect(prisma.users.update).not.toHaveBeenCalled()
+            expect(user).toEqual(existingUser)
+        })
+
+        it('should fall back to the existing record if the activity write times out', async () => {
+            const guestId = 'guest_slow_write'
+            const guestName = 'Test Guest'
+            const existingUser = {
+                id: guestId,
+                username: 'Old Name',
+                email: `guest-${guestId}@boardly.guest`,
+                isGuest: true,
+                lastActiveAt: new Date(Date.now() - 3600000), // 1 hour ago
+            }
+
+                ; (prisma.users.findFirst as jest.Mock)
+                    .mockResolvedValueOnce(existingUser) // lookup by guestId
+                    .mockResolvedValueOnce(null) // username uniqueness check — available
+                ; (prisma.users.update as jest.Mock).mockRejectedValue(new Error('Database operation timed out after 12000ms (Users.update)'))
+
+            const user = await getOrCreateGuestUser(guestId, guestName)
+
+            expect(prisma.users.update).toHaveBeenCalled()
+            expect(user.id).toBe(guestId)
+            expect(user.username).toBe(guestName)
+        })
+
         it('should handle errors gracefully', async () => {
             const guestId = 'guest_error'
             const guestName = 'Error Guest'

--- a/app/globals.css
+++ b/app/globals.css
@@ -1664,6 +1664,21 @@ input[type="range"].slider-thumb::-moz-range-track {
     width: min(calc(100vw - 52px), calc(var(--ttt-h) - 325px));
     height: auto;
   }
+  /* Connect Four's board is 7 cols x 6 rows, not square like TTT's 3x3 — sizing
+     cells from 100vw alone (its original formula) ignores vertical space
+     entirely, so the board's real height (6 rows tall) can run past the
+     bottom of the screen and get clipped by .ttt-board-card's overflow:hidden
+     on shorter phone viewports (confirmed live on a real iPhone, #688).
+     Overhead = .ttt-board-wrap's 325px budget above (identical header/status/
+     tabs/actions shell) + this board's own 28px drop-arrow row + the grid's
+     own 46px of internal padding(16)/row-gaps(30) that .ttt-board-wrap doesn't
+     need to account for separately (its square sizing wraps the whole card).
+     Not live-verified against a real device this session (tooling outage) —
+     erred toward a larger overhead (safety buffer ~20px) so a slightly-smaller
+     board is the failure mode, not a re-cropped one. */
+  .ttt-board-card {
+    --c4-cell: min(calc((100vw - 104px) / 7), calc((var(--ttt-h) - 420px) / 6));
+  }
 }
 
 .ttt-mobile-content {

--- a/app/lobby/[code]/connect-four-page.tsx
+++ b/app/lobby/[code]/connect-four-page.tsx
@@ -171,8 +171,8 @@ function C4Board({ board, winningLine, hoverCol, onColHover, onColClick, disable
                                 disabled={disabled || colFull}
                                 aria-label={`column ${c + 1}`}
                                 style={{
-                                    width: 'clamp(34px, calc((100vw - 104px) / 7), 52px)',
-                                    height: 'clamp(34px, calc((100vw - 104px) / 7), 52px)',
+                                    width: 'clamp(30px, var(--c4-cell, calc((100vw - 104px) / 7)), 52px)',
+                                    height: 'clamp(30px, var(--c4-cell, calc((100vw - 104px) / 7)), 52px)',
                                     borderRadius: '50%',
                                     padding: 3,
                                     background: isHoveredCol && !cell ? hoverTint : 'rgba(255,255,255,0.10)',

--- a/components/Scorecard.tsx
+++ b/components/Scorecard.tsx
@@ -367,9 +367,9 @@ const Scorecard = React.memo(function Scorecard({
       )}
 
       {/* Two-column body — each column scrolls independently on small viewports */}
-      <div className="flex-1 min-h-0 grid grid-cols-1 sm:grid-cols-2 overflow-y-auto sm:overflow-hidden divide-y sm:divide-y-0 sm:divide-x" style={{ borderColor: 'var(--bd-line)' }}>
+      <div className="flex-1 min-h-0 grid grid-cols-1 sm:grid-cols-2 overflow-hidden divide-y sm:divide-y-0 sm:divide-x" style={{ borderColor: 'var(--bd-line)' }}>
         {/* ── Upper section ── */}
-        <div className="flex flex-col min-h-0 px-3 pt-3 pb-2 sm:overflow-y-auto">
+        <div className="flex flex-col min-h-0 overflow-y-auto px-3 pt-3 pb-2">
           {/* Section header */}
           <div className="mb-2 flex flex-shrink-0 items-center justify-between gap-2">
             <div className="flex items-center gap-2">
@@ -431,7 +431,7 @@ const Scorecard = React.memo(function Scorecard({
         </div>
 
         {/* ── Lower section ── */}
-        <div className="flex flex-col min-h-0 px-3 pt-3 pb-2 sm:overflow-y-auto">
+        <div className="flex flex-col min-h-0 overflow-y-auto px-3 pt-3 pb-2">
           {/* Section header */}
           <div className="mb-2 flex flex-shrink-0 items-center justify-between gap-2">
             <div className="flex items-center gap-2">

--- a/lib/guest-helpers.ts
+++ b/lib/guest-helpers.ts
@@ -3,6 +3,12 @@ import { apiLogger } from '@/lib/logger'
 
 const log = apiLogger('/lib/guest-helpers')
 
+// Matches the authenticated-user activity throttle in lib/next-auth.ts — guests hit this
+// path on nearly every API call (getRequestAuthUser -> getOrCreateGuestUser), so writing
+// lastActiveAt unconditionally on every request made it the hottest, unthrottled write in
+// the app and a recurring source of Users.update timeouts under DB contention (#683).
+const GUEST_ACTIVITY_THROTTLE_MS = 5 * 60 * 1000
+
 /**
  * Get or create a guest user based on guest ID
  * Guest users are temporary and marked with isGuest = true
@@ -18,13 +24,21 @@ export async function getOrCreateGuestUser(guestId: string, guestName: string) {
         })
 
         if (existingGuest) {
+            const usernameChanged = existingGuest.username !== guestName
+            const lastActiveAgeMs = Date.now() - existingGuest.lastActiveAt.getTime()
+
+            // Nothing to persist and we touched this row recently — skip the write.
+            if (!usernameChanged && lastActiveAgeMs < GUEST_ACTIVITY_THROTTLE_MS) {
+                return existingGuest
+            }
+
             // Update last active timestamp and username only if it changed
             const updateData: { lastActiveAt: Date; username?: string } = {
                 lastActiveAt: new Date(),
             }
 
             // Only update username if it has changed
-            if (existingGuest.username !== guestName) {
+            if (usernameChanged) {
                 // Check if the new username is already taken
                 const usernameExists = await prisma.users.findFirst({
                     where: {
@@ -46,16 +60,26 @@ export async function getOrCreateGuestUser(guestId: string, guestName: string) {
                 }
             }
 
-            const updatedGuest = await prisma.users.update({
-                where: { id: existingGuest.id },
-                data: updateData,
-            })
-            log.info('Found existing guest user', {
-                guestId,
-                guestName: updatedGuest.username,
-                usernameUpdated: updateData.username !== undefined
-            })
-            return updatedGuest
+            try {
+                const updatedGuest = await prisma.users.update({
+                    where: { id: existingGuest.id },
+                    data: updateData,
+                })
+                log.info('Found existing guest user', {
+                    guestId,
+                    guestName: updatedGuest.username,
+                    usernameUpdated: updateData.username !== undefined
+                })
+                return updatedGuest
+            } catch (updateError) {
+                // This is a housekeeping write (activity timestamp / display name) piggybacking
+                // on whatever request the guest happened to make — it shouldn't be able to take
+                // down that request (e.g. Quick Play matchmaking) just because it hit the DB
+                // timeout under load. Fall back to the pre-write record; the next request will
+                // retry the write.
+                log.error('Failed to update guest activity, continuing with existing record', updateError as Error, { guestId })
+                return { ...existingGuest, ...updateData }
+            }
         }
 
         // For new guest users, ensure username is unique

--- a/lib/next-auth.ts
+++ b/lib/next-auth.ts
@@ -365,11 +365,18 @@ export const authOptions: NextAuthOptions = {
       const fiveMinutes = 5 * 60 * 1000
 
       if (token.id && now - lastUpdate > fiveMinutes) {
-        // Update lastActiveAt in background (non-blocking)
-        prisma.users.update({
-          where: { id: token.id as string },
-          data: { lastActiveAt: new Date() }
-        }).catch(() => { }) // Silently fail to avoid blocking auth
+        // Awaited (not fire-and-forget): Vercel serverless functions can kill pending
+        // promises once the response is sent (see #509), which would silently orphan
+        // this write and its DB connection under load. Failures are swallowed here
+        // deliberately — a stale lastActiveAt shouldn't block auth.
+        try {
+          await prisma.users.update({
+            where: { id: token.id as string },
+            data: { lastActiveAt: new Date() }
+          })
+        } catch {
+          // Silently fail to avoid blocking auth
+        }
 
         token.lastActiveUpdate = now
       }


### PR DESCRIPTION
## Summary
Direct develop→main PR at user's request (not a release/vX.Y.Z branch this time) — skipping the usual full CI-wait/review cycle by explicit choice; user will verify live on production themselves after merge, especially #688 which hasn't been checked against a real device.

- **#683**: `getOrCreateGuestUser()` had an unthrottled, uncaught `Users.update` on every guest quick-play request — root cause of a recurring 12s DB timeout. Throttled to 5min + made resilient. Also fixed a related fire-and-forget update in `next-auth.ts`.
- **#687**: Yahtzee scorecard Upper/Lower Section text overlapping on mobile (<640px) — missing `overflow-y-auto` let content spill into the sibling section.
- **#688**: Connect Four board didn't fit real mobile viewport height (bottom row clipped) — board was sized purely from `100vw`, blind to vertical space. **Not live-verified on a real device** — please check on your phone before/after merging.

## Test plan
- [x] `tsc --noEmit` clean
- [x] 755/755 real tests passing (pre-existing 35-suite jest-runtime infra gap unrelated)
- [ ] Verify #688 fix on a real phone (Connect Four board fits without cropping)