### PR TITLE
QA audit 2026-08-06: fix 13 issues (#694, #696-#708)

### DIFF
--- a/__tests__/api/stripe-checkout.test.ts
+++ b/__tests__/api/stripe-checkout.test.ts
@@ -1,0 +1,241 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+// @ts-nocheck - Route-level mocks are intentionally lightweight.
+
+import { NextRequest } from 'next/server'
+import Stripe from 'stripe'
+import { POST } from '@/app/api/stripe/checkout/route'
+import { prisma } from '@/lib/db'
+import { getServerSession } from 'next-auth'
+import { getStripe } from '@/lib/stripe'
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    users: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}))
+
+jest.mock('@/lib/next-auth', () => ({
+  authOptions: {},
+}))
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}))
+
+let mockPremiumPriceId = 'price_live_valid'
+
+jest.mock('@/lib/stripe', () => ({
+  getStripe: jest.fn(),
+  get PREMIUM_PRICE_ID() {
+    return mockPremiumPriceId
+  },
+}))
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>
+const mockGetStripe = getStripe as jest.MockedFunction<typeof getStripe>
+
+function makeRequest() {
+  return new NextRequest('http://localhost:3000/api/stripe/checkout', { method: 'POST' })
+}
+
+describe('POST /api/stripe/checkout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPremiumPriceId = 'price_live_valid'
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null as any)
+
+    const response = await POST(makeRequest())
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 502 with a clean message when Stripe rejects the configured price ID', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'user-1' } } as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      stripeCustomerId: 'cus_existing',
+      premiumUntil: null,
+    } as any)
+
+    const badPriceError = new Stripe.errors.StripeInvalidRequestError({
+      code: 'resource_missing',
+      param: 'line_items[0][price]',
+      message: "No such price: 'price_bad'",
+      type: 'invalid_request_error',
+    })
+    mockGetStripe.mockReturnValue({
+      checkout: { sessions: { create: jest.fn().mockRejectedValue(badPriceError) } },
+    } as any)
+
+    const response = await POST(makeRequest())
+    const payload = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(payload.error).toMatch(/temporarily unavailable/i)
+    // Must not leak raw Stripe error internals (price ID, param path) to the client
+    expect(JSON.stringify(payload)).not.toContain('price_bad')
+  })
+
+  it('returns 502 without calling Stripe when PREMIUM_PRICE_ID is unconfigured', async () => {
+    mockPremiumPriceId = ''
+    mockGetServerSession.mockResolvedValue({ user: { id: 'user-1' } } as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      stripeCustomerId: 'cus_existing',
+      premiumUntil: null,
+    } as any)
+    const createCheckoutSession = jest.fn()
+    mockGetStripe.mockReturnValue({
+      checkout: { sessions: { create: createCheckoutSession } },
+    } as any)
+
+    const response = await POST(makeRequest())
+    const payload = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(payload.error).toMatch(/temporarily unavailable/i)
+    expect(createCheckoutSession).not.toHaveBeenCalled()
+  })
+
+  it('recreates a stale Stripe customer and retries checkout session creation once', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'user-1' } } as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      stripeCustomerId: 'cus_stale',
+      premiumUntil: null,
+    } as any)
+    mockPrisma.users.update.mockResolvedValue({} as any)
+
+    const staleError = new Stripe.errors.StripeInvalidRequestError({
+      code: 'resource_missing',
+      param: 'customer',
+      message: "No such customer: 'cus_stale'",
+      type: 'invalid_request_error',
+    })
+    const createCustomer = jest.fn().mockResolvedValue({ id: 'cus_new' })
+    const createCheckoutSession = jest
+      .fn()
+      .mockRejectedValueOnce(staleError)
+      .mockResolvedValueOnce({ url: 'https://checkout.stripe.com/session-new' })
+
+    mockGetStripe.mockReturnValue({
+      customers: { create: createCustomer },
+      checkout: { sessions: { create: createCheckoutSession } },
+    } as any)
+
+    const response = await POST(makeRequest())
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.url).toBe('https://checkout.stripe.com/session-new')
+    expect(createCustomer).toHaveBeenCalledTimes(1)
+    expect(createCheckoutSession).toHaveBeenCalledTimes(2)
+    expect(mockPrisma.users.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { stripeCustomerId: 'cus_new' },
+    })
+  })
+
+  it('returns 502 (not an uncaught 500) if the retried checkout session creation also fails', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'user-1' } } as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      stripeCustomerId: 'cus_stale',
+      premiumUntil: null,
+    } as any)
+    mockPrisma.users.update.mockResolvedValue({} as any)
+
+    const staleError = new Stripe.errors.StripeInvalidRequestError({
+      code: 'resource_missing',
+      param: 'customer',
+      message: "No such customer: 'cus_stale'",
+      type: 'invalid_request_error',
+    })
+    const badPriceError = new Stripe.errors.StripeInvalidRequestError({
+      code: 'resource_missing',
+      param: 'line_items[0][price]',
+      message: "No such price: 'price_bad'",
+      type: 'invalid_request_error',
+    })
+    mockGetStripe.mockReturnValue({
+      customers: { create: jest.fn().mockResolvedValue({ id: 'cus_new' }) },
+      checkout: {
+        sessions: {
+          create: jest.fn().mockRejectedValueOnce(staleError).mockRejectedValueOnce(badPriceError),
+        },
+      },
+    } as any)
+
+    const response = await POST(makeRequest())
+    const payload = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(payload.error).toMatch(/temporarily unavailable/i)
+  })
+
+  it('returns a checkout URL on success', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'user-1' } } as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      stripeCustomerId: 'cus_existing',
+      premiumUntil: null,
+    } as any)
+    mockGetStripe.mockReturnValue({
+      checkout: {
+        sessions: { create: jest.fn().mockResolvedValue({ url: 'https://checkout.stripe.com/session-1' }) },
+      },
+    } as any)
+
+    const response = await POST(makeRequest())
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.url).toBe('https://checkout.stripe.com/session-1')
+  })
+
+  it('returns 502 when the billing portal call fails with a non-stale Stripe error', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: 'user-1' } } as any)
+    mockPrisma.users.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      stripeCustomerId: 'cus_existing',
+      premiumUntil: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
+    } as any)
+    const permissionError = new Stripe.errors.StripePermissionError({
+      code: 'account_invalid',
+      message: 'This account cannot currently make live charges.',
+      type: 'invalid_request_error',
+    })
+    mockGetStripe.mockReturnValue({
+      billingPortal: { sessions: { create: jest.fn().mockRejectedValue(permissionError) } },
+    } as any)
+
+    const response = await POST(makeRequest())
+    const payload = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(payload.error).toMatch(/temporarily unavailable/i)
+  })
+})

--- a/__tests__/app/useLobbyActions.test.tsx
+++ b/__tests__/app/useLobbyActions.test.tsx
@@ -99,7 +99,7 @@ describe('useLobbyActions', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockRestoreGameEngineClient.mockResolvedValue({} as never)
+    mockRestoreGameEngineClient.mockResolvedValue({ getCurrentPlayer: () => null } as never)
   })
 
   afterAll(() => {

--- a/__tests__/lib/i18n-language-persistence.test.ts
+++ b/__tests__/lib/i18n-language-persistence.test.ts
@@ -1,0 +1,18 @@
+import i18n from '@/i18n'
+
+describe('i18n language persistence', () => {
+  it('does not let the browser language detector auto-write to localStorage', () => {
+    // Regression test for #696: with detection.caches including 'localStorage',
+    // i18next-browser-languagedetector re-caches its htmlTag-detected value
+    // (always 'en', the SSR default) into localStorage on every fresh page
+    // load — silently clobbering whatever locale the user had actually
+    // picked via lib/appearance-preferences.ts before Providers' effect gets
+    // a chance to read it back out. Persistence must be handled exclusively
+    // by setStoredAppearanceLocale/getStoredAppearanceLocale.
+    expect(i18n.options.detection?.caches).toEqual([])
+  })
+
+  it('only detects from htmlTag, never re-derives from its own storage cache', () => {
+    expect(i18n.options.detection?.order).toEqual(['htmlTag'])
+  })
+})

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -21,6 +21,26 @@ function isStaleCustomerError(error: unknown): boolean {
   )
 }
 
+/**
+ * Any other Stripe-side config error (bad price ID, disabled product, etc.)
+ * — not something a retry fixes, but the client still needs a clean JSON
+ * error instead of an uncaught-exception 500 with no body.
+ */
+function toCheckoutErrorResponse(err: unknown, log: ReturnType<typeof apiLogger>) {
+  if (err instanceof Stripe.errors.StripeError) {
+    log.error('Stripe checkout failed', err, {
+      type: err.type,
+      code: err.code,
+      param: 'param' in err ? err.param : undefined,
+    })
+    return NextResponse.json(
+      { error: 'Checkout is temporarily unavailable. Please try again in a few minutes.' },
+      { status: 502 }
+    )
+  }
+  throw err
+}
+
 async function recreateStripeCustomer(user: { id: string; email: string | null }): Promise<string> {
   const customer = await getStripe().customers.create({
     email: user.email ?? undefined,
@@ -57,13 +77,23 @@ export async function POST(req: NextRequest) {
       })
       return NextResponse.json({ url: portal.url })
     } catch (err) {
-      if (!isStaleCustomerError(err)) throw err
-      log.warn('Stale stripeCustomerId on billing portal request, recreating', { userId: user.id })
-      return NextResponse.json(
-        { error: 'Your billing account needs to be reconnected — please start a new checkout.' },
-        { status: 409 }
-      )
+      if (isStaleCustomerError(err)) {
+        log.warn('Stale stripeCustomerId on billing portal request, recreating', { userId: user.id })
+        return NextResponse.json(
+          { error: 'Your billing account needs to be reconnected — please start a new checkout.' },
+          { status: 409 }
+        )
+      }
+      return toCheckoutErrorResponse(err, log)
     }
+  }
+
+  if (!PREMIUM_PRICE_ID) {
+    log.error('STRIPE_PREMIUM_PRICE_ID is not configured')
+    return NextResponse.json(
+      { error: 'Checkout is temporarily unavailable. Please try again in a few minutes.' },
+      { status: 502 }
+    )
   }
 
   const origin = req.headers.get('origin') ?? process.env.NEXTAUTH_URL ?? ''
@@ -88,10 +118,16 @@ export async function POST(req: NextRequest) {
   try {
     checkoutSession = await createCheckoutSession()
   } catch (err) {
-    if (!isStaleCustomerError(err)) throw err
+    if (!isStaleCustomerError(err)) {
+      return toCheckoutErrorResponse(err, log)
+    }
     log.warn('Stale stripeCustomerId on checkout, recreating customer', { userId: user.id })
     customerId = await recreateStripeCustomer(user)
-    checkoutSession = await createCheckoutSession()
+    try {
+      checkoutSession = await createCheckoutSession()
+    } catch (retryErr) {
+      return toCheckoutErrorResponse(retryErr, log)
+    }
   }
 
   log.info('Checkout session created', { userId: user.id })

--- a/app/lobby/[code]/LobbyPageClient.tsx
+++ b/app/lobby/[code]/LobbyPageClient.tsx
@@ -2530,6 +2530,7 @@ function LobbyPageContent({ onSwitchToDedicatedPage }: { onSwitchToDedicatedPage
               onProfileClick={setProfileUserId}
               isGuest={isGuest}
               registerUrl={`/auth/register?returnUrl=${encodeURIComponent(`/lobby/${code}`)}`}
+              reconcileWithServerSnapshot={reconcileWithServerSnapshot}
             />
           ) : gameEngine ? (
             <div className="flex h-full items-center justify-center p-4">

--- a/app/lobby/[code]/components/LobbyInfo.tsx
+++ b/app/lobby/[code]/components/LobbyInfo.tsx
@@ -236,8 +236,23 @@ export default function LobbyInfo({
         </div>
       </div>
 
-      {/* Settings rail — horizontal scroll on mobile */}
-      <div className="mt-3 -mx-4 overflow-x-auto sm:-mx-5">
+      {/* Settings rail — horizontal scroll on mobile. The trailing mask-image
+          fade is the overflow affordance: on touch devices the native
+          scrollbar this rail relies on for the same signal on desktop
+          doesn't render persistently, so a narrow screen has nothing on
+          screen hinting the row keeps going (e.g. the lobby theme pill can
+          sit fully off-screen with zero visual cue). Fades actual content
+          opacity rather than overlaying a solid color, so it looks correct
+          against either the standalone-card or header background this rail
+          renders inside — no scrollbar-hiding involved, the native
+          scrollbar itself is untouched. */}
+      <div
+        className="mt-3 -mx-4 overflow-x-auto sm:-mx-5"
+        style={{
+          WebkitMaskImage: 'linear-gradient(to right, black calc(100% - 28px), transparent 100%)',
+          maskImage: 'linear-gradient(to right, black calc(100% - 28px), transparent 100%)',
+        }}
+      >
         <div className="flex gap-1.5 px-4 pb-1 sm:px-5">
           {/* Players */}
           <button

--- a/app/lobby/[code]/components/LobbyInfo.tsx
+++ b/app/lobby/[code]/components/LobbyInfo.tsx
@@ -372,15 +372,24 @@ export default function LobbyInfo({
               <div className="flex flex-wrap gap-2">
                 <button
                   type="button"
-                  disabled={updatingSetting === 'allowSpectators' || lobby?.allowSpectators === true}
-                  onClick={() => void applySettingUpdate('allowSpectators', { allowSpectators: true })}
+                  disabled={isPremium && (updatingSetting === 'allowSpectators' || lobby?.allowSpectators === true)}
+                  onClick={() => {
+                    if (!isPremium) {
+                      showToast.custom('profile.premiumFeatureLocked', '👑')
+                      return
+                    }
+                    void applySettingUpdate('allowSpectators', { allowSpectators: true })
+                  }}
+                  title={isPremium ? undefined : '👑 Premium'}
                   className={`px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all ${
                     lobby?.allowSpectators
                       ? 'border-bd-ink bg-bd-ink text-bd-bg'
-                      : 'border-bd-line bg-bd-card-warm text-bd-ink hover:border-bd-ink'
+                      : !isPremium
+                        ? 'border-bd-line bg-bd-bg2 text-bd-ink-muted opacity-60'
+                        : 'border-bd-line bg-bd-card-warm text-bd-ink hover:border-bd-ink'
                   } disabled:opacity-50 disabled:cursor-not-allowed`}
                 >
-                  {t('common.enabled')}
+                  {t('common.enabled')}{!isPremium && ' 👑'}
                 </button>
                 <button
                   type="button"
@@ -465,8 +474,14 @@ export default function LobbyInfo({
                     <button
                       key={themeId}
                       type="button"
-                      disabled={updatingSetting === 'theme' || isActive || isLocked}
-                      onClick={() => !isLocked && void applySettingUpdate('theme', { theme: themeId })}
+                      disabled={updatingSetting === 'theme' || isActive}
+                      onClick={() => {
+                        if (isLocked) {
+                          showToast.custom('profile.premiumFeatureLocked', '👑')
+                          return
+                        }
+                        void applySettingUpdate('theme', { theme: themeId })
+                      }}
                       title={isLocked ? '👑 Premium' : theme.name}
                       className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all ${
                         isActive

--- a/app/lobby/[code]/components/MemoryGameBoard.tsx
+++ b/app/lobby/[code]/components/MemoryGameBoard.tsx
@@ -7,6 +7,7 @@ import type { ChatMessagePayload } from '@/types/game'
 import { useTranslation, type TranslationKeys } from '@/lib/i18n-helpers'
 import { showToast } from '@/lib/i18n-toast'
 import { fetchWithGuest } from '@/lib/fetch-with-guest'
+import { clientLogger } from '@/lib/client-logger'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import Chat from '@/components/Chat'
 import { useGameTimer } from '../hooks/useGameTimer'
@@ -70,9 +71,18 @@ interface MemoryGameBoardProps {
   isGuest?: boolean
   registerUrl?: string
   isSpectator?: boolean
+  /**
+   * Fetches a fresh authoritative snapshot from the server (bypassing
+   * realtime broadcast). Used as a watchdog fallback: Supabase Broadcast is
+   * fire-and-forget over a stateless REST POST with no delivery guarantee —
+   * if the resolve-mismatch broadcast is dropped, pendingMismatchCardIds
+   * never clears client-side and the board looks permanently frozen.
+   */
+  reconcileWithServerSnapshot?: () => Promise<void>
 }
 
 const MISMATCH_RESOLVE_DELAY_MS = 1200
+const MISMATCH_RESOLVE_WATCHDOG_MS = MISMATCH_RESOLVE_DELAY_MS + 3500
 
 function getPlayerDisplayName(player: LobbyPlayer): string {
   return player.user?.username || player.user?.name || player.name || 'Player'
@@ -454,6 +464,7 @@ export default function MemoryGameBoard({
   isGuest,
   registerUrl,
   isSpectator = false,
+  reconcileWithServerSnapshot,
 }: MemoryGameBoardProps) {
   const { t } = useTranslation()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -655,6 +666,30 @@ export default function MemoryGameBoard({
       window.clearTimeout(timer)
     }
   }, [currentPlayerId, isMyTurn, pendingMismatchCardIds])
+
+  // Watchdog: the resolve-mismatch broadcast above is fire-and-forget with no
+  // delivery guarantee. If pendingMismatchCardIds is still stuck at 2 well
+  // after the auto-resolve should have landed, the broadcast was likely
+  // dropped — force a direct snapshot refetch instead of leaving the board
+  // frozen until the player manually reloads the page.
+  useEffect(() => {
+    if (!isMyTurn || pendingMismatchCardIds.length !== 2 || !reconcileWithServerSnapshot) {
+      return
+    }
+
+    const watchdogKey = `${currentPlayerId}:${pendingMismatchCardIds.join(':')}`
+
+    const timer = window.setTimeout(() => {
+      clientLogger.warn('Memory mismatch still pending after watchdog delay — reconciling from server', {
+        watchdogKey,
+      })
+      void reconcileWithServerSnapshot()
+    }, MISMATCH_RESOLVE_WATCHDOG_MS)
+
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [currentPlayerId, isMyTurn, pendingMismatchCardIds, reconcileWithServerSnapshot])
 
   const handleCardClick = useCallback(
     (cardId: string) => {

--- a/app/lobby/[code]/components/YahtzeeGameBoard.tsx
+++ b/app/lobby/[code]/components/YahtzeeGameBoard.tsx
@@ -127,6 +127,15 @@ export default function GameBoard({
             disabled={isSpectator || !isMyTurn || isMoveInProgress || gameEngine.getRollsLeft() === 3}
             isRolling={isRolling}
             isMyTurn={isMyTurn && !isSpectator}
+            onRollDice={isSpectator ? undefined : onRollDice}
+            canRoll={
+              !isSpectator &&
+              isMyTurn &&
+              rollsLeft > 0 &&
+              heldCount < 5 &&
+              !isMoveInProgress &&
+              !isRolling
+            }
           />
         </div>
 

--- a/app/lobby/[code]/hooks/useLobbyActions.ts
+++ b/app/lobby/[code]/hooks/useLobbyActions.ts
@@ -679,7 +679,12 @@ export function useLobbyActions(props: UseLobbyActionsProps) {
       setRollHistory([])
       setCelebrationEvent(null)
 
-      const firstPlayerName = data.game.players[0]?.name || 'Player 1'
+      // The engine's actual current player (not players[0], which is API/join
+      // order and doesn't necessarily match who the engine gives the first
+      // turn to — was previously always crediting the wrong player in the
+      // "goes first" toast/chat message, e.g. always the bot even when the
+      // human host moves first).
+      const firstPlayerName = engine.getCurrentPlayer()?.name || data.game.players[0]?.name || 'Player 1'
 
       showToast.success('toast.gameStarted', undefined, { player: firstPlayerName }, { id: 'start-game' })
 

--- a/app/lobby/[code]/tic-tac-toe-page.tsx
+++ b/app/lobby/[code]/tic-tac-toe-page.tsx
@@ -105,8 +105,8 @@ function TttBoard({ board, winningLine, onCellClick, disabled, testId }: {
     )
 }
 
-function TttPlayerCard({ name, symbol, isActive, isWinner, side, avatarSrc, isPremium, t }: {
-    name: string; symbol: 'X' | 'O'; isActive: boolean; isWinner: boolean; side: 'left' | 'right'; avatarSrc?: string | null; isPremium?: boolean; t: (key: TranslationKeys) => string
+function TttPlayerCard({ name, symbol, isActive, isMe, isWinner, side, avatarSrc, isPremium, t }: {
+    name: string; symbol: 'X' | 'O'; isActive: boolean; isMe: boolean; isWinner: boolean; side: 'left' | 'right'; avatarSrc?: string | null; isPremium?: boolean; t: (key: TranslationKeys) => string
 }) {
     const bg = symbol === 'X' ? 'var(--bd-coral)' : 'var(--bd-lav)'
     return (
@@ -161,7 +161,7 @@ function TttPlayerCard({ name, symbol, isActive, isWinner, side, avatarSrc, isPr
                         justifyContent: side === 'right' ? 'flex-end' : 'flex-start',
                     }}>
                         <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--bd-mint-deep)', display: 'inline-block' }} />
-                        {t('games.tictactoe.game.theirTurn')}
+                        {isMe ? t('games.tictactoe.game.yourTurnBadge') : t('games.tictactoe.game.theirTurn')}
                     </div>
                 )}
             </div>
@@ -1059,7 +1059,7 @@ export default function TicTacToeLobbyPage({ code, isSpectator = false, onGameRe
                 <TttBgGrid />
             </div>
             <div style={{ position: 'relative', display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: 16 }}>
-                <TttPlayerCard name={xName} symbol="X" isActive={!isFinished && gameData.currentSymbol === 'X'} isWinner={!isDraw && winnerSymbol === 'X'} side="left" avatarSrc={xAvatar} isPremium={xIsPremium} t={t} />
+                <TttPlayerCard name={xName} symbol="X" isActive={!isFinished && gameData.currentSymbol === 'X'} isMe={mySymbol === 'X'} isWinner={!isDraw && winnerSymbol === 'X'} side="left" avatarSrc={xAvatar} isPremium={xIsPremium} t={t} />
                 <div style={{ textAlign: 'center' }}>
                     <div style={{ fontSize: 10, color: 'var(--bd-ink-muted)', textTransform: 'uppercase', letterSpacing: '0.1em', fontFamily: 'ui-monospace,monospace', marginBottom: 2 }}>
                         Round {roundNum}
@@ -1071,7 +1071,7 @@ export default function TicTacToeLobbyPage({ code, isSpectator = false, onGameRe
                         {drawsCount} draws{targetRounds ? ` · BO${targetRounds}` : ''}
                     </div>
                 </div>
-                <TttPlayerCard name={oName} symbol="O" isActive={!isFinished && gameData.currentSymbol === 'O'} isWinner={!isDraw && winnerSymbol === 'O'} side="right" avatarSrc={oAvatar} isPremium={oIsPremium} t={t} />
+                <TttPlayerCard name={oName} symbol="O" isActive={!isFinished && gameData.currentSymbol === 'O'} isMe={mySymbol === 'O'} isWinner={!isDraw && winnerSymbol === 'O'} side="right" avatarSrc={oAvatar} isPremium={oIsPremium} t={t} />
             </div>
         </div>
     )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,13 @@ export default function HomePage() {
         <HeroSectionRedesign
           facts={{
             availableGameCount: availableGames.length,
-            catalogGameCount: catalogGames.length,
+            // "Games in catalog" sits directly under the "N ready to play" /
+            // "M more coming soon" badges — it must equal ready + coming
+            // soon, not the raw catalog length. catalogGames also includes
+            // 'planned' games that aren't part of either badge's narrative;
+            // counting them here made the three numbers not add up (e.g.
+            // 6 + 5 = 11 shown next to a "15" stat).
+            catalogGameCount: availableGames.length + inDevelopmentGameCount,
             inDevelopmentGameCount,
             quickPlayGameCount,
           }}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2760,8 +2760,11 @@ export default function ProfilePage() {
                       <button
                         key={hex}
                         type="button"
-                        disabled={!hasUploadPack}
                         onClick={() => {
+                          if (!hasUploadPack) {
+                            showToast.custom('profile.premiumFeatureLocked', '👑')
+                            return
+                          }
                           const next = profileAccentColor === hex ? null : hex
                           setProfileAccentColor(next)
                           void handleSaveCustomization({ accentColor: next })
@@ -2772,7 +2775,7 @@ export default function ProfilePage() {
                         style={{
                           width: 32, height: 32, borderRadius: 8, background: hex, border: 'none',
                           outline: profileAccentColor === hex ? `3px solid ${hex}` : '2px solid transparent',
-                          outlineOffset: 2, cursor: hasUploadPack ? 'pointer' : 'not-allowed',
+                          outlineOffset: 2, cursor: 'pointer',
                           opacity: hasUploadPack ? 1 : 0.4,
                           transition: 'all 0.15s',
                         }}
@@ -2809,8 +2812,11 @@ export default function ProfilePage() {
                       <button
                         key={id}
                         type="button"
-                        disabled={!hasUploadPack}
                         onClick={() => {
+                          if (!hasUploadPack) {
+                            showToast.custom('profile.premiumFeatureLocked', '👑')
+                            return
+                          }
                           const next = profileFeaturedGame === id ? null : id
                           setProfileFeaturedGame(next)
                           void handleSaveCustomization({ featuredGame: next })
@@ -2820,7 +2826,7 @@ export default function ProfilePage() {
                             ? 'border-bd-ink bg-bd-ink text-bd-bg dark:border-white dark:bg-white dark:text-bd-ink'
                             : 'border-bd-line bg-white text-bd-ink hover:border-bd-ink dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:hover:border-slate-400'
                         }`}
-                        style={{ opacity: hasUploadPack ? 1 : 0.4, cursor: hasUploadPack ? 'pointer' : 'not-allowed' }}
+                        style={{ opacity: hasUploadPack ? 1 : 0.4, cursor: 'pointer' }}
                       >
                         {label}
                       </button>
@@ -2847,17 +2853,20 @@ export default function ProfilePage() {
                         <button
                           key={id}
                           type="button"
-                          disabled={!hasUploadPack}
                           aria-pressed={active}
                           aria-label={hasUploadPack ? `${name} card style${active ? ' (active)' : ''}` : `${name} — Premium required`}
                           onClick={() => {
+                            if (!hasUploadPack) {
+                              showToast.custom('profile.premiumFeatureLocked', '👑')
+                              return
+                            }
                             setPremiumCardStyle(id)
                             void handleSaveCustomization({ premiumCardStyle: id })
                           }}
                           style={{
                             background: preview,
                             opacity: hasUploadPack ? 1 : 0.4,
-                            cursor: hasUploadPack ? 'pointer' : 'not-allowed',
+                            cursor: 'pointer',
                             outline: active ? '3px solid var(--bd-ink)' : '2px solid transparent',
                             outlineOffset: 2,
                           }}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -226,7 +226,11 @@ export default function ProfilePage() {
 
   const memberSinceLabel = useMemo(() => {
     if (!profileSummary?.createdAt) {
-      return '--'
+      // null (not '--') distinguishes "profile hasn't loaded yet" from a
+      // real value so the card can show a loading skeleton instead of a
+      // static placeholder that briefly reads as broken/empty data right
+      // after registration.
+      return null
     }
 
     return new Date(profileSummary.createdAt).toLocaleDateString(i18n.language || undefined, {
@@ -1777,9 +1781,13 @@ export default function ProfilePage() {
                           <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-bd-ink-muted dark:text-slate-400">
                             {card.label}
                           </p>
-                          <p className={`mt-2 font-display text-3xl font-bold leading-none dark:text-white ${card.accent.split(' ')[1]}`}>
-                            {card.value}
-                          </p>
+                          {card.value === null ? (
+                            <div className="mt-2 h-8 w-16 animate-pulse rounded-lg bg-bd-bg2 dark:bg-slate-700" aria-hidden="true" />
+                          ) : (
+                            <p className={`mt-2 font-display text-3xl font-bold leading-none dark:text-white ${card.accent.split(' ')[1]}`}>
+                              {card.value}
+                            </p>
+                          )}
                         </>
                       )
                       const baseClass = 'group relative overflow-hidden rounded-3xl border-[1.5px] border-bd-line bg-white p-5 shadow-[0_4px_14px_rgba(31,27,22,0.07)] transition-all hover:-translate-y-0.5 dark:border-slate-700 dark:bg-slate-800'

--- a/components/DiceGroup.tsx
+++ b/components/DiceGroup.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import Dice from './Dice'
 import { useTranslation } from '@/lib/i18n-helpers'
+import { sounds } from '@/lib/sounds'
 
 interface DiceGroupProps {
   dice: number[]
@@ -11,9 +12,20 @@ interface DiceGroupProps {
   disabled?: boolean
   isRolling?: boolean
   isMyTurn?: boolean
+  /**
+   * Roll handler + whether it's currently valid to roll. The "Roll dice
+   * first" hint below is visually the most prominent, obviously-clickable
+   * element on the screen at this point in a turn — on short viewports the
+   * real Roll button can be scrolled below the fold (see the load-bearing
+   * overflow-y-auto comment in YahtzeeGameBoard.tsx), so this hint doubles
+   * as a roll trigger instead of being purely decorative text a player
+   * naturally taps and gets nothing from.
+   */
+  onRollDice?: () => void
+  canRoll?: boolean
 }
 
-const DiceGroup = React.memo(function DiceGroup({ dice, held, onToggleHold, disabled = false, isRolling = false, isMyTurn = false }: DiceGroupProps) {
+const DiceGroup = React.memo(function DiceGroup({ dice, held, onToggleHold, disabled = false, isRolling = false, isMyTurn = false, onRollDice, canRoll = false }: DiceGroupProps) {
   const { t } = useTranslation()
 
   return (
@@ -41,6 +53,18 @@ const DiceGroup = React.memo(function DiceGroup({ dice, held, onToggleHold, disa
             <span className="text-sm sm:text-base">⏳</span>
             <span className="break-words">{t('yahtzee.ui.waitTurnHint')}</span>
           </p>
+        ) : disabled && canRoll && onRollDice ? (
+          <button
+            type="button"
+            onClick={() => {
+              sounds.play('click', { force: true })
+              onRollDice()
+            }}
+            className="bd-chip px-3 py-2 text-bd-ink-soft flex items-center gap-1 sm:gap-2 justify-center w-full cursor-pointer transition-transform active:scale-[0.98]"
+          >
+            <span className="text-sm sm:text-base">🎲</span>
+            <span className="break-words">{t('yahtzee.ui.rollFirstHint')}</span>
+          </button>
         ) : disabled ? (
           <p className="bd-chip px-3 py-2 text-bd-ink-soft flex items-center gap-1 sm:gap-2 justify-center">
             <span className="text-sm sm:text-base">🎲</span>

--- a/components/Header/NotificationsMenu.tsx
+++ b/components/Header/NotificationsMenu.tsx
@@ -235,10 +235,7 @@ export function NotificationsMenu() {
     return notifications.map((item) => buildNotificationDisplayItem(item, t, i18n.language))
   }, [i18n.language, notifications, t])
 
-  const badgeLabel =
-    unreadCount > 0
-      ? t('header.notificationsUnread', { count: unreadCount })
-      : t('header.notifications')
+  const badgeLabel = t('header.notificationsUnread', { count: unreadCount })
 
   return (
     <div ref={containerRef} className="relative shrink-0">
@@ -274,7 +271,9 @@ export function NotificationsMenu() {
             <div className="flex items-start justify-between gap-3 border-b border-[var(--bd-line)] bg-[var(--bd-bg)] px-4 py-4">
               <div>
                 <p className="bd-kicker">{t('header.notifications')}</p>
-                <p className="mt-1 text-sm font-bold text-[var(--bd-ink)]">{badgeLabel}</p>
+                {unreadCount > 0 && (
+                  <p className="mt-1 text-sm font-bold text-[var(--bd-ink)]">{badgeLabel}</p>
+                )}
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 {unreadCount > 0 && (

--- a/components/HomePage/HeroDemoConnectFour.tsx
+++ b/components/HomePage/HeroDemoConnectFour.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import Link from 'next/link'
+import { useTranslation } from '@/lib/i18n-helpers'
 
 const COLS = 6
 const ROWS = 5
@@ -59,6 +60,7 @@ function botMove(board: Board): number {
 }
 
 export default function HeroDemoConnectFour() {
+  const { t } = useTranslation()
   const [board, setBoard] = useState<Board>(makeBoard)
   const [winner, setWinner] = useState<'red' | 'yellow' | 'draw' | null>(null)
   const [hoverCol, setHoverCol] = useState<number | null>(null)
@@ -134,10 +136,10 @@ export default function HeroDemoConnectFour() {
   }
 
   const statusText =
-    winner === 'red' ? '🎉 You win!'
-    : winner === 'yellow' ? 'Bot wins!'
-    : winner === 'draw' ? 'Draw!'
-    : 'Drop a piece'
+    winner === 'red' ? t('home.demo.youWin')
+    : winner === 'yellow' ? t('home.demo.botWins')
+    : winner === 'draw' ? t('home.demo.draw')
+    : t('home.demo.dropAPiece')
 
   return (
     <div style={{
@@ -250,7 +252,7 @@ export default function HeroDemoConnectFour() {
           color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
-        Play full game →
+        {t('home.demo.playFullGame')}
       </Link>
     </div>
   )

--- a/components/HomePage/HeroDemoMemory.tsx
+++ b/components/HomePage/HeroDemoMemory.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
+import { useTranslation } from '@/lib/i18n-helpers'
 
 const PAIRS = ['🎲', '🃏', '🏆', '⭐', '🎮', '🎯']
 
@@ -16,6 +17,7 @@ function makeCards(): Card[] {
 }
 
 export default function HeroDemoMemory() {
+  const { t } = useTranslation()
   const [cards, setCards] = useState<Card[]>(makeCards)
   const [flipped, setFlipped] = useState<number[]>([])
   const [locked, setLocked] = useState(false)
@@ -73,7 +75,7 @@ export default function HeroDemoMemory() {
         fontFamily: 'var(--bd-font-display)', fontWeight: 700, fontSize: isMobile ? 12 : 14,
         color: 'var(--bd-ink-muted)', minHeight: isMobile ? 18 : 22,
       }}>
-        {allMatched ? '🎉 All matched!' : `${matchedCount} / ${PAIRS.length} pairs`}
+        {allMatched ? t('home.demo.allMatched') : t('home.demo.pairsProgress', { count: matchedCount, total: PAIRS.length })}
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: `repeat(4, ${CARD_W}px)`, gridTemplateRows: `repeat(3, ${CARD_H}px)`, gap: GRID_GAP }}>
@@ -112,7 +114,7 @@ export default function HeroDemoMemory() {
           color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
-        Play full game →
+        {t('home.demo.playFullGame')}
       </Link>
     </div>
   )

--- a/components/HomePage/HeroDemoTicTacToe.tsx
+++ b/components/HomePage/HeroDemoTicTacToe.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
+import { useTranslation } from '@/lib/i18n-helpers'
 
 type Cell = 'X' | 'O' | null
 
@@ -38,6 +39,7 @@ function botMove(board: Cell[]): number {
 const EMPTY: Cell[] = Array(9).fill(null)
 
 export default function HeroDemoTicTacToe() {
+  const { t } = useTranslation()
   const [board, setBoard] = useState<Cell[]>(EMPTY)
   const [winner, setWinner] = useState<Cell | 'draw' | null>(null)
 
@@ -66,10 +68,10 @@ export default function HeroDemoTicTacToe() {
   }, [winner, reset])
 
   const statusText =
-    winner === 'X' ? '🎉 You win!'
-    : winner === 'O' ? 'Bot wins!'
-    : winner === 'draw' ? "Draw!"
-    : 'Your turn (X)'
+    winner === 'X' ? t('home.demo.youWin')
+    : winner === 'O' ? t('home.demo.botWins')
+    : winner === 'draw' ? t('home.demo.draw')
+    : t('home.demo.yourTurnX')
 
   return (
     <div style={{
@@ -118,7 +120,7 @@ export default function HeroDemoTicTacToe() {
           color: 'var(--bd-ink-muted)', textDecoration: 'underline', marginTop: 2,
         }}
       >
-        Play full game →
+        {t('home.demo.playFullGame')}
       </Link>
     </div>
   )

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -11,15 +11,18 @@ interface LanguageSwitcherProps {
   variant?: 'header' | 'panel'
 }
 
+// Each language's own self-name (endonym), not translated — a Russian
+// speaker who can't read the current locale still needs to recognize
+// "Русский" in the list, so these stay constant across all 4 locales.
 const LANGUAGE_OPTIONS: Array<{
   code: Locale
   shortLabel: string
   name: string
 }> = [
   { code: 'en', shortLabel: 'EN', name: 'English' },
-  { code: 'uk', shortLabel: 'UA', name: 'Ukrainian' },
-  { code: 'no', shortLabel: 'NO', name: 'Norwegian' },
-  { code: 'ru', shortLabel: 'RU', name: 'Russian' },
+  { code: 'uk', shortLabel: 'UA', name: 'Українська' },
+  { code: 'no', shortLabel: 'NO', name: 'Norsk' },
+  { code: 'ru', shortLabel: 'RU', name: 'Русский' },
 ]
 
 function GlobeIcon() {

--- a/contexts/OnboardingContext.tsx
+++ b/contexts/OnboardingContext.tsx
@@ -49,6 +49,12 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
   }, [pathname])
 
   const completeOnboarding = useCallback(async () => {
+    // Close immediately on click — persisting the choice is fire-and-forget
+    // background work, not something the dismiss action should block on.
+    // Previously awaited the PATCH before closing, so on any network delay
+    // the modal would silently sit there through the first click (looking
+    // like the button did nothing) until it resolved.
+    setShowModal(false)
     if (status === 'authenticated') {
       await fetch('/api/onboarding', {
         method: 'PATCH',
@@ -58,10 +64,10 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     } else {
       localStorage.setItem(GUEST_ONBOARDING_KEY, 'completed')
     }
-    setShowModal(false)
   }, [status])
 
   const skipOnboarding = useCallback(async () => {
+    setShowModal(false)
     if (status === 'authenticated') {
       await fetch('/api/onboarding', {
         method: 'PATCH',
@@ -71,7 +77,6 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     } else {
       localStorage.setItem(GUEST_ONBOARDING_KEY, 'skipped')
     }
-    setShowModal(false)
   }, [status])
 
   return (

--- a/i18n.ts
+++ b/i18n.ts
@@ -64,9 +64,18 @@ i18n
       // Order of detection methods
       // Keep first client render aligned with SSR output (htmlTag from server),
       // then switch to persisted language after hydration in Providers.
+      //
+      // caches is deliberately empty: with caches: ['localStorage'], this
+      // detector writes its htmlTag-detected value ('en', the SSR default)
+      // back into the 'i18nextLng' key on every fresh page load, clobbering
+      // whatever locale the user had actually picked before Providers' effect
+      // gets a chance to read it back out — silently reverting the language on
+      // every hard navigation/reload. Persistence is handled explicitly by
+      // lib/appearance-preferences.ts (setStoredAppearanceLocale /
+      // getStoredAppearanceLocale) instead, so the detector shouldn't also be
+      // writing to storage.
       order: ['htmlTag'],
-      caches: ['localStorage'],
-      lookupLocalStorage: 'i18nextLng',
+      caches: [],
     },
     react: {
       useSuspense: false, // Disable suspense to avoid hydration issues

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1370,6 +1370,7 @@ const en = {
     sending: 'Sending...',
     memberSince: 'Member Since',
     premiumAccount: 'Premium Account',
+    premiumFeatureLocked: 'Upgrade to Premium to unlock this',
     comingSoon: 'Coming soon',
     verificationBanner: {
       title: 'Email not verified',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -638,6 +638,7 @@ const en = {
         victoryBadge: 'VICTORY',
         drawBadge: 'DRAW',
         theirTurn: 'Their turn',
+        yourTurnBadge: 'Your turn',
         catsGameFull: "Cat's game — board is full.",
         playerTurn: "{{player}}'s turn",
         moveNum: '· move {{num}}',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -402,6 +402,16 @@ const en = {
         description: 'Everyone sees the same board, scores, and turns in their browser. No download needed.',
       },
     },
+    demo: {
+      youWin: '🎉 You win!',
+      botWins: 'Bot wins!',
+      draw: 'Draw!',
+      yourTurnX: 'Your turn (X)',
+      dropAPiece: 'Drop a piece',
+      allMatched: '🎉 All matched!',
+      pairsProgress: '{{count}} / {{total}} pairs',
+      playFullGame: 'Play full game →',
+    },
   },
   games: {
     title: 'Available Games',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -1370,6 +1370,7 @@ const no = {
     sending: 'Sender...',
     memberSince: 'Medlem siden',
     premiumAccount: 'Premium-konto',
+    premiumFeatureLocked: 'Oppgrader til Premium for å låse opp dette',
     comingSoon: 'Kommer snart',
     verificationBanner: {
       title: 'E-post ikke bekreftet',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -638,6 +638,7 @@ const no = {
         victoryBadge: 'SEIER',
         drawBadge: 'UAVGJORT',
         theirTurn: 'Deres tur',
+        yourTurnBadge: 'Din tur',
         catsGameFull: 'Uavgjort — brettet er fullt.',
         playerTurn: '{{player}}s tur',
         moveNum: '· trekk {{num}}',

--- a/locales/no.ts
+++ b/locales/no.ts
@@ -401,7 +401,17 @@ const no = {
         title: 'Begynn å spille',
         description: 'Alle ser samme brett, poeng og trekk i nettleseren sin. Ingen nedlasting nødvendig.',
       },
-    }
+    },
+    demo: {
+      youWin: '🎉 Du vinner!',
+      botWins: 'Bot vinner!',
+      draw: 'Uavgjort!',
+      yourTurnX: 'Din tur (X)',
+      dropAPiece: 'Slipp en brikke',
+      allMatched: '🎉 Alle par funnet!',
+      pairsProgress: '{{count}} / {{total}} par',
+      playFullGame: 'Spill hele spillet →',
+    },
   },
   games: {
     title: 'Tilgjengelige spill',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -638,6 +638,7 @@ const ru = {
         victoryBadge: 'ПОБЕДА',
         drawBadge: 'НИЧЬЯ',
         theirTurn: 'Их ход',
+        yourTurnBadge: 'Ваш ход',
         catsGameFull: 'Ничья — доска заполнена.',
         playerTurn: 'Ход {{player}}',
         moveNum: '· ход {{num}}',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -401,7 +401,17 @@ const ru = {
         title: 'Начинайте играть',
         description: 'Все видят одну доску, счёт и ходы в своём браузере. Загрузка не нужна.',
       },
-    }
+    },
+    demo: {
+      youWin: '🎉 Вы выиграли!',
+      botWins: 'Бот выиграл!',
+      draw: 'Ничья!',
+      yourTurnX: 'Ваш ход (X)',
+      dropAPiece: 'Сделайте ход',
+      allMatched: '🎉 Все пары найдены!',
+      pairsProgress: '{{count}} / {{total}} пар',
+      playFullGame: 'Играть полностью →',
+    },
   },
   games: {
     title: 'Доступные игры',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -1370,6 +1370,7 @@ const ru = {
     sending: 'Отправка...',
     memberSince: 'Участник с',
     premiumAccount: 'Премиум аккаунт',
+    premiumFeatureLocked: 'Чтобы открыть это, оформите Премиум',
     comingSoon: 'Скоро',
     verificationBanner: {
       title: 'Почта не подтверждена',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -1372,6 +1372,7 @@ const uk: Translation = {
     sending: 'Надсилання...',
     memberSince: 'Учасник з',
     premiumAccount: 'Преміум акаунт',
+    premiumFeatureLocked: 'Оформіть Преміум, щоб відкрити це',
     comingSoon: 'Незабаром',
     verificationBanner: {
       title: 'Пошту не підтверджено',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -640,6 +640,7 @@ const uk: Translation = {
         victoryBadge: 'ПЕРЕМОГА',
         drawBadge: 'НІЧИЯ',
         theirTurn: 'Їхній хід',
+        yourTurnBadge: 'Ваш хід',
         catsGameFull: 'Нічия — дошка заповнена.',
         playerTurn: 'Хід {{player}}',
         moveNum: '· хід {{num}}',

--- a/locales/uk.ts
+++ b/locales/uk.ts
@@ -404,6 +404,16 @@ const uk: Translation = {
         description: 'Всі бачать одну дошку, рахунок і ходи у своєму браузері. Завантаження не потрібне.',
       },
     },
+    demo: {
+      youWin: '🎉 Ви перемогли!',
+      botWins: 'Бот переміг!',
+      draw: 'Нічия!',
+      yourTurnX: 'Ваш хід (X)',
+      dropAPiece: 'Зробіть хід',
+      allMatched: '🎉 Усі пари знайдено!',
+      pairsProgress: '{{count}} / {{total}} пар',
+      playFullGame: 'Грати повну гру →',
+    },
   },
   games: {
     title: 'Доступні ігри',


### PR DESCRIPTION
## Summary
Fixes all 15 GitHub issues filed from the 2026-08-06 black-box QA audit of boardly.online, except the underlying Stripe live-account activation (deferred separately — see #694 comment).

- #694 — Stripe checkout: clean 502 + user-facing error instead of an uncaught 500 (root cause is a Stripe live-account business-verification gap, tracked separately, not fixable in code)
- #696 — language selection no longer resets on hard reload (i18next-browser-languagedetector was clobbering the saved locale)
- #697 — Memory game: watchdog fallback when the mismatch-resolve realtime broadcast is dropped
- #698 — upgrade-to-premium toast instead of a silent no-op on premium-gated controls
- #699 — "goes first" toast/chat message now credits the actual first mover, not players[0]
- #700 — Tic-Tac-Toe turn badge no longer says "Their turn" on your own turn
- #701 — Profile "Member Since" shows a loading skeleton instead of a static `--`
- #702 — Yahtzee's "Roll dice first" hint is now clickable (real button was below the fold on short viewports)
- #703 — mobile lobby settings chip row gets a trailing fade as a scroll affordance
- #704 — homepage interactive demo widgets (TTT/C4/Memory) fully translated
- #705 — language dropdown shows each language's native self-name
- #706 — onboarding modal closes immediately on click instead of waiting on a network request
- #707 — notifications dropdown no longer shows a duplicate "Notifications" label
- #708 — landing page "Games in catalog" stat now matches the badges above it

## Test plan
- [x] `npm run ci:quick` — 0 errors
- [x] Full jest suite — 761/761 passing (35 pre-existing edge-runtime-environment suite failures unrelated, tracked in #693)
- [x] Live browser verification for #694, #696, #698, #699, #700, #702, #703, #704, #705, #706
- [ ] #701, #707 verified via type-check/code-review only (guest-session rate limit blocked further live testing this session)
- [ ] #697 (Memory watchdog) verified via code path only — the dropped-broadcast race isn't reliably forceable live