### PR TITLE
Fix all 12 findings from the develop audit (#713-#724)

### DIFF
--- a/__tests__/lib/broadcast-sanitize.test.ts
+++ b/__tests__/lib/broadcast-sanitize.test.ts
@@ -1,5 +1,7 @@
 import { sanitizeStateForBroadcast } from '@/lib/broadcast-sanitize'
 
+type StateLike = { status?: string; data?: unknown }
+
 describe('sanitizeStateForBroadcast dispatcher', () => {
   it('routes sketch_and_guess to the sketch sanitizer and strips the live prompt', () => {
     const state = {
@@ -18,9 +20,158 @@ describe('sanitizeStateForBroadcast dispatcher', () => {
     expect((forDrawer.data as { rounds: Array<{ prompt: string }> }).rounds[0].prompt).toBe('castle')
   })
 
-  it('passes state through unchanged for a game type with no registered sanitizer', () => {
-    const state = { status: 'playing', data: { secret: 'visible-on-purpose' } }
-    const result = sanitizeStateForBroadcast('tic_tac_toe', state, null)
-    expect(result).toBe(state)
+  it('passes state through unchanged for a game that declares no hidden state', () => {
+    const state = { status: 'playing', data: { board: ['x', 'o'] } }
+    expect(sanitizeStateForBroadcast('tic_tac_toe', state, null)).toBe(state)
+  })
+
+  it('passes state through unchanged for an unknown game type', () => {
+    const state = { status: 'playing', data: { anything: true } }
+    expect(sanitizeStateForBroadcast('not_a_real_game', state, null)).toBe(state)
+  })
+})
+
+describe('memory sanitization (#715)', () => {
+  const buildState = (): StateLike => ({
+    status: 'playing',
+    data: {
+      cards: [
+        { id: 'a', value: '🍎', isFlipped: true, isMatched: false },
+        { id: 'b', value: '🍊', isFlipped: false, isMatched: true },
+        { id: 'c', value: '🍋', isFlipped: false, isMatched: false },
+        { id: 'd', value: '🍌', isFlipped: false, isMatched: false },
+      ],
+      moveHistory: [{ playerId: 'p1', card1Value: '🍇', card2Value: '🍓', isMatch: false }],
+    },
+  })
+
+  const cardsOf = (state: StateLike) => (state.data as { cards: Array<{ id: string; value: string }> }).cards
+
+  it('redacts the value of every face-down, unmatched card', () => {
+    const result = sanitizeStateForBroadcast('memory', buildState(), null)
+    const cards = cardsOf(result)
+
+    expect(cards.find((c) => c.id === 'c')?.value).toBe('')
+    expect(cards.find((c) => c.id === 'd')?.value).toBe('')
+  })
+
+  it('keeps values the table can already see (flipped or matched)', () => {
+    const result = sanitizeStateForBroadcast('memory', buildState(), null)
+    const cards = cardsOf(result)
+
+    expect(cards.find((c) => c.id === 'a')?.value).toBe('🍎')
+    expect(cards.find((c) => c.id === 'b')?.value).toBe('🍊')
+  })
+
+  it('redacts for the player whose turn it is too — there is no viewer exception', () => {
+    const forActivePlayer = sanitizeStateForBroadcast('memory', buildState(), 'p1')
+    expect(cardsOf(forActivePlayer).find((c) => c.id === 'c')?.value).toBe('')
+  })
+
+  it('does not mutate the source state', () => {
+    const state = buildState()
+    sanitizeStateForBroadcast('memory', state, null)
+    expect(cardsOf(state).find((c) => c.id === 'c')?.value).toBe('🍋')
+  })
+
+  it('leaves already-public move history intact', () => {
+    const result = sanitizeStateForBroadcast('memory', buildState(), null)
+    const history = (result.data as { moveHistory: Array<{ card1Value: string }> }).moveHistory
+    expect(history[0].card1Value).toBe('🍇')
+  })
+})
+
+describe('alias sanitization (#716)', () => {
+  const buildState = (phase = 'turn_active'): StateLike => ({
+    status: 'playing',
+    data: {
+      phase,
+      currentTeamIndex: 0,
+      currentCardIndex: 0,
+      currentCard: ['bridge', 'kettle', 'anchor'],
+      currentCardResults: [{ word: 'ladder', result: 'guessed' }],
+      teams: [
+        { id: 'team-1', playerIds: ['describer', 'teammate'], describerIndex: 0 },
+        { id: 'team-2', playerIds: ['opponent'], describerIndex: 0 },
+      ],
+    },
+  })
+
+  const cardOf = (state: StateLike) => (state.data as { currentCard: string[] | null }).currentCard
+
+  it('hides the word card from a guesser on the describing team', () => {
+    expect(cardOf(sanitizeStateForBroadcast('alias', buildState(), 'teammate'))).toBeNull()
+  })
+
+  it('hides the word card from the opposing team', () => {
+    expect(cardOf(sanitizeStateForBroadcast('alias', buildState(), 'opponent'))).toBeNull()
+  })
+
+  it('hides the word card on a shared broadcast with no viewer', () => {
+    expect(cardOf(sanitizeStateForBroadcast('alias', buildState(), null))).toBeNull()
+  })
+
+  it('still shows the word card to the describer', () => {
+    expect(cardOf(sanitizeStateForBroadcast('alias', buildState(), 'describer'))).toEqual([
+      'bridge',
+      'kettle',
+      'anchor',
+    ])
+  })
+
+  it('leaves state alone outside an active turn', () => {
+    const state = buildState('turn_results')
+    expect(sanitizeStateForBroadcast('alias', state, 'opponent')).toBe(state)
+  })
+
+  it('keeps already-resolved words visible', () => {
+    const result = sanitizeStateForBroadcast('alias', buildState(), 'opponent')
+    const results = (result.data as { currentCardResults: Array<{ word: string }> }).currentCardResults
+    expect(results[0].word).toBe('ladder')
+  })
+})
+
+describe('fake_artist sanitization (#716)', () => {
+  const buildState = (phase = 'drawing', status = 'playing'): StateLike => ({
+    status,
+    data: {
+      phase,
+      fakeArtistId: 'impostor',
+      promptFingerprint: 'lighthouse',
+      playerOrder: ['impostor', 'honest'],
+      roundResults: [{ round: 1, fakeArtistId: 'honest' }],
+    },
+  })
+
+  const fakeIdOf = (state: StateLike) => (state.data as { fakeArtistId: string }).fakeArtistId
+
+  it('hides the impostor from an honest player', () => {
+    const result = sanitizeStateForBroadcast('fake_artist', buildState(), 'honest')
+    expect(fakeIdOf(result)).toBe('')
+    expect((result.data as { promptFingerprint: string }).promptFingerprint).toBe('')
+  })
+
+  it('hides the impostor on a shared broadcast with no viewer', () => {
+    expect(fakeIdOf(sanitizeStateForBroadcast('fake_artist', buildState(), null))).toBe('')
+  })
+
+  it('still tells the fake artist who they are', () => {
+    expect(fakeIdOf(sanitizeStateForBroadcast('fake_artist', buildState(), 'impostor'))).toBe('impostor')
+  })
+
+  it('reveals the impostor to everyone at the reveal phase', () => {
+    const state = buildState('reveal')
+    expect(sanitizeStateForBroadcast('fake_artist', state, 'honest')).toBe(state)
+  })
+
+  it('reveals the impostor once the game is finished', () => {
+    const state = buildState('voting', 'finished')
+    expect(sanitizeStateForBroadcast('fake_artist', state, 'honest')).toBe(state)
+  })
+
+  it('keeps already-revealed past rounds intact', () => {
+    const result = sanitizeStateForBroadcast('fake_artist', buildState(), 'honest')
+    const rounds = (result.data as { roundResults: Array<{ fakeArtistId: string }> }).roundResults
+    expect(rounds[0].fakeArtistId).toBe('honest')
   })
 })

--- a/__tests__/lib/csrf.test.ts
+++ b/__tests__/lib/csrf.test.ts
@@ -1,0 +1,24 @@
+import { isSignatureAuthenticatedWebhook } from '@/lib/csrf'
+
+// Note: verifyCsrfToken and the proxy middleware itself take a NextRequest, which
+// cannot be constructed under jsdom (whatwg-fetch's Request conflicts with it) and
+// the node/edge test environments are currently broken by the jest 30 mismatch
+// tracked in #693. So this covers the exemption predicate as a pure function; the
+// middleware wiring is verified by reading proxy.ts.
+describe('isSignatureAuthenticatedWebhook', () => {
+  it('exempts the Stripe webhook, which arrives with no Origin or Referer (#713)', () => {
+    expect(isSignatureAuthenticatedWebhook('/api/stripe/webhook')).toBe(true)
+  })
+
+  it('does not exempt ordinary API routes', () => {
+    expect(isSignatureAuthenticatedWebhook('/api/lobby')).toBe(false)
+    expect(isSignatureAuthenticatedWebhook('/api/stripe/checkout')).toBe(false)
+    expect(isSignatureAuthenticatedWebhook('/api/game/abc/state')).toBe(false)
+  })
+
+  it('matches exactly, so a lookalike path is not exempt', () => {
+    expect(isSignatureAuthenticatedWebhook('/api/stripe/webhook-spoof')).toBe(false)
+    expect(isSignatureAuthenticatedWebhook('/api/stripe/webhook/')).toBe(false)
+    expect(isSignatureAuthenticatedWebhook('/api/stripe/webhook/extra')).toBe(false)
+  })
+})

--- a/__tests__/lib/lobby-password.test.ts
+++ b/__tests__/lib/lobby-password.test.ts
@@ -10,8 +10,12 @@ describe('lib/lobby-password', () => {
     await expect(hashLobbyPassword(undefined)).resolves.toBeNull()
   })
 
-  it('supports legacy plain-text password verification', async () => {
-    await expect(verifyLobbyPassword('legacy-secret', 'legacy-secret')).resolves.toBe(true)
+  it('rejects a stored password that is not a bcrypt hash (#721)', async () => {
+    // The legacy plain-text comparison is gone: an unhashed stored value now
+    // fails to match anything, so those rows can't keep working un-migrated.
+    // Verified against production before removing it — the 64 remaining
+    // plain-text rows all belonged to inactive lobbies.
+    await expect(verifyLobbyPassword('legacy-secret', 'legacy-secret')).resolves.toBe(false)
     await expect(verifyLobbyPassword('legacy-secret', 'wrong')).resolves.toBe(false)
   })
 

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,7 @@
 import NextAuth from 'next-auth'
+import { NextResponse, type NextRequest } from 'next/server'
 import { authOptions } from '@/lib/next-auth'
+import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -7,4 +9,52 @@ export const revalidate = 0
 
 const handler = NextAuth(authOptions)
 
-export { handler as GET, handler as POST }
+// Password sign-in actually happens here, not in /api/auth/login — the client
+// calls signIn('credentials'), which POSTs to this catch-all. Without this the
+// password check in authOptions.authorize() was completely unthrottled (#714).
+//
+// Scoped to the credentials callback on purpose: this route also serves session,
+// csrf and OAuth endpoints that the app polls routinely, and throttling those
+// would break normal usage.
+const CREDENTIALS_CALLBACK_PATH = '/api/auth/callback/credentials'
+const credentialsLimiter = rateLimit(rateLimitPresets.credentialsLogin)
+
+/**
+ * next-auth's browser client parses `data.url` out of every credentials response
+ * and calls `new URL()` on it, so a bare `{ error }` body makes signIn() throw a
+ * URL parse error instead of resolving with a result the form can handle. Reshape
+ * the limiter's 429 into the redirect envelope the client expects, keeping the
+ * status and Retry-After intact for non-browser callers.
+ */
+function toClientReadableRateLimitResponse(
+  rateLimitResponse: NextResponse,
+  request: NextRequest
+): NextResponse {
+  const errorUrl = new URL('/auth/login', request.nextUrl.origin)
+  errorUrl.searchParams.set('error', 'RateLimited')
+
+  const response = NextResponse.json(
+    { url: errorUrl.toString() },
+    { status: rateLimitResponse.status }
+  )
+
+  const retryAfter = rateLimitResponse.headers.get('Retry-After')
+  if (retryAfter) {
+    response.headers.set('Retry-After', retryAfter)
+  }
+
+  return response
+}
+
+async function postHandler(request: NextRequest, context: unknown) {
+  if (new URL(request.url).pathname === CREDENTIALS_CALLBACK_PATH) {
+    const rateLimitResult = await credentialsLimiter(request)
+    if (rateLimitResult) {
+      return toClientReadableRateLimitResponse(rateLimitResult, request)
+    }
+  }
+
+  return handler(request, context)
+}
+
+export { handler as GET, postHandler as POST }

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -6,6 +6,12 @@ import { withErrorHandler, AuthenticationError, assertExists } from '@/lib/error
 import { apiLogger } from '@/lib/logger'
 import { loginSchema } from '@/lib/validation/auth'
 
+// NOTE: the web app does NOT use this route — it signs in via
+// signIn('credentials'), which NextAuth handles in app/api/auth/[...nextauth].
+// This endpoint verifies a password but issues no session, so it is a second,
+// independent copy of the credential check. Kept for now because it is public
+// API surface that an external client could rely on; if nothing consumes it,
+// delete it rather than keeping two password paths in sync. See #714.
 const limiter = rateLimit(rateLimitPresets.auth)
 const log = apiLogger('/api/auth/login')
 

--- a/app/api/game/[gameId]/state/route.ts
+++ b/app/api/game/[gameId]/state/route.ts
@@ -14,18 +14,9 @@ import { sanitizeStateForBroadcast } from '@/lib/broadcast-sanitize'
 import { getGameMetadata } from '@/lib/game-catalog'
 import { maybeAutoTransitionCompletedSeries } from '@/lib/lobby-series-transition'
 import { buildTerminalFieldsAndPlayerUpdates } from '@/lib/game-persistence'
+import { gameStateRequestSchema, type AutoActionContextRequest } from '@/lib/validation/game-state'
 
-interface AutoActionContext {
-  source: 'turn-timeout'
-  debounceKey: string
-  turnSnapshot: {
-    currentPlayerId: string
-    currentPlayerIndex: number
-    lastMoveAt: number | null
-    rollsLeft: number
-    updatedAt: string | number | null
-  }
-}
+type AutoActionContext = AutoActionContextRequest
 
 interface BotAutoResponse {
   type: 'undo' | 'draw'
@@ -233,19 +224,19 @@ export async function POST(
     }
 
     const requestBody = await request.json()
-    const move = requestBody?.move
-    const autoActionContext = requestBody?.autoActionContext as AutoActionContext | undefined
-    const isAutoAction = autoActionContext?.source === 'turn-timeout'
-
-    if (!move || !move.type) {
-      return NextResponse.json({ error: 'Invalid move data' }, { status: 400 })
+    const parsedBody = gameStateRequestSchema.safeParse(requestBody)
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        { error: 'Invalid move data', issues: parsedBody.error.issues },
+        { status: 400 }
+      )
     }
 
-    if (isAutoAction) {
-      if (!autoActionContext?.debounceKey || !autoActionContext.turnSnapshot) {
-        return NextResponse.json({ error: 'Invalid auto action context' }, { status: 400 })
-      }
+    const move = parsedBody.data.move
+    const autoActionContext = parsedBody.data.autoActionContext
+    const isAutoAction = autoActionContext?.source === 'turn-timeout'
 
+    if (isAutoAction) {
       const debounceKey = `${gameId}:${autoActionContext.debounceKey}:${move.type}`
       if (shouldDebounceAutoAction(debounceKey)) {
         return NextResponse.json(

--- a/app/api/stripe/cancel/route.ts
+++ b/app/api/stripe/cancel/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getRequestAuthUser } from '@/lib/request-auth'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/next-auth'
 import { prisma } from '@/lib/db'
 import { getStripe } from '@/lib/stripe'
 import { apiLogger } from '@/lib/logger'
+import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
 
 const log = apiLogger('/api/stripe/cancel')
+const limiter = rateLimit(rateLimitPresets.api)
 
 export async function POST(req: NextRequest) {
-  const user = await getRequestAuthUser(req)
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const rateLimitResult = await limiter(req)
+  if (rateLimitResult) return rateLimitResult
+
+  // Subscription management requires a real account — getRequestAuthUser would
+  // also accept a guest JWT, and a guest can never own a subscription (#718).
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const user = { id: session.user.id }
 
   const dbUser = await prisma.users.findUnique({
     where: { id: user.id },

--- a/app/api/stripe/reactivate/route.ts
+++ b/app/api/stripe/reactivate/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getRequestAuthUser } from '@/lib/request-auth'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/next-auth'
 import { prisma } from '@/lib/db'
 import { getStripe } from '@/lib/stripe'
 import { apiLogger } from '@/lib/logger'
+import { rateLimit, rateLimitPresets } from '@/lib/rate-limit'
 
 const log = apiLogger('/api/stripe/reactivate')
+const limiter = rateLimit(rateLimitPresets.api)
 
 export async function POST(req: NextRequest) {
-  const user = await getRequestAuthUser(req)
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const rateLimitResult = await limiter(req)
+  if (rateLimitResult) return rateLimitResult
+
+  // Subscription management requires a real account — getRequestAuthUser would
+  // also accept a guest JWT, and a guest can never own a subscription (#718).
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const user = { id: session.user.id }
 
   const dbUser = await prisma.users.findUnique({
     where: { id: user.id },

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -12,7 +12,10 @@ async function updateSubscriptionState(
   until: Date | null,
   cancelAtPeriodEnd: boolean
 ) {
-  await prisma.users.updateMany({
+  // stripeCustomerId is unique, so this touches at most one row. A zero-row
+  // result means we received a subscription for a customer we don't recognise —
+  // previously that returned 200 and the entitlement was silently dropped.
+  const result = await prisma.users.updateMany({
     where: { stripeCustomerId: customerId },
     data: {
       premiumUntil: until,
@@ -20,6 +23,76 @@ async function updateSubscriptionState(
       premiumCancelAtPeriod: cancelAtPeriodEnd,
     },
   })
+
+  if (result.count === 0) {
+    log.error('Stripe subscription event matched no user', undefined, {
+      customerId,
+      subscriptionId,
+    })
+  }
+
+  return result.count
+}
+
+function resolveSubscriptionEnd(subscription: Stripe.Subscription): Date | null {
+  const isActive = subscription.status === 'active' || subscription.status === 'trialing'
+  const periodEnd = subscription.items.data[0]?.current_period_end
+  return isActive && periodEnd ? new Date(periodEnd * 1000) : null
+}
+
+async function handleEvent(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case 'customer.subscription.created':
+    case 'customer.subscription.updated': {
+      const sub = event.data.object as Stripe.Subscription
+      await updateSubscriptionState(
+        sub.customer as string,
+        sub.id,
+        resolveSubscriptionEnd(sub),
+        sub.cancel_at_period_end
+      )
+      log.info(`Subscription ${event.type}`, {
+        customerId: sub.customer,
+        status: sub.status,
+        cancelAtPeriodEnd: sub.cancel_at_period_end,
+      })
+      break
+    }
+
+    case 'customer.subscription.deleted': {
+      const sub = event.data.object as Stripe.Subscription
+      await updateSubscriptionState(sub.customer as string, null, null, false)
+      log.info('Subscription deleted', { customerId: sub.customer })
+      break
+    }
+
+    // Entitlement previously depended entirely on a customer.subscription.*
+    // event arriving. If one was missed, a paid checkout never granted Premium
+    // and nothing reconciled it. Grant on the checkout itself as well; the
+    // subscription events remain the source of truth for renewals and cancels.
+    case 'checkout.session.completed': {
+      const session = event.data.object as Stripe.Checkout.Session
+      if (session.mode !== 'subscription' || !session.subscription || !session.customer) {
+        break
+      }
+
+      const subscriptionId =
+        typeof session.subscription === 'string' ? session.subscription : session.subscription.id
+      const customerId = typeof session.customer === 'string' ? session.customer : session.customer.id
+
+      // Re-read the subscription so the period end comes from Stripe rather than
+      // being inferred from the checkout session.
+      const subscription = await getStripe().subscriptions.retrieve(subscriptionId)
+      await updateSubscriptionState(
+        customerId,
+        subscriptionId,
+        resolveSubscriptionEnd(subscription),
+        subscription.cancel_at_period_end
+      )
+      log.info('Checkout session completed', { customerId, subscriptionId })
+      break
+    }
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -28,34 +101,41 @@ export async function POST(req: NextRequest) {
 
   if (!sig) return NextResponse.json({ error: 'Missing signature' }, { status: 400 })
 
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    // Fail loudly rather than letting constructEvent throw an opaque parse error.
+    log.error('STRIPE_WEBHOOK_SECRET is not configured; cannot verify webhook')
+    return NextResponse.json({ error: 'Webhook not configured' }, { status: 500 })
+  }
+
   let event: Stripe.Event
   try {
-    event = getStripe().webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET!)
+    event = getStripe().webhooks.constructEvent(body, sig, webhookSecret)
   } catch (err) {
     log.error('Webhook signature verification failed', err as Error)
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
   }
 
+  // Claim the event id before doing any work. The primary key makes this atomic:
+  // a concurrent or retried delivery of the same event loses the race and exits.
   try {
-    switch (event.type) {
-      case 'customer.subscription.created':
-      case 'customer.subscription.updated': {
-        const sub = event.data.object as Stripe.Subscription
-        const isActive = sub.status === 'active' || sub.status === 'trialing'
-        const periodEnd = sub.items.data[0]?.current_period_end
-        const until = isActive && periodEnd ? new Date(periodEnd * 1000) : null
-        await updateSubscriptionState(sub.customer as string, sub.id, until, sub.cancel_at_period_end)
-        log.info(`Subscription ${event.type}`, { customerId: sub.customer, status: sub.status, cancelAtPeriodEnd: sub.cancel_at_period_end })
-        break
-      }
-      case 'customer.subscription.deleted': {
-        const sub = event.data.object as Stripe.Subscription
-        await updateSubscriptionState(sub.customer as string, null, null, false)
-        log.info('Subscription deleted', { customerId: sub.customer })
-        break
-      }
-    }
+    await prisma.stripeWebhookEvents.create({
+      data: { id: event.id, type: event.type },
+    })
+  } catch {
+    log.info('Ignoring duplicate Stripe event', { eventId: event.id, type: event.type })
+    return NextResponse.json({ received: true, duplicate: true })
+  }
+
+  try {
+    await handleEvent(event)
   } catch (err) {
+    // Release the claim so Stripe's retry can reprocess this event, rather than
+    // having the ledger record a delivery that never took effect.
+    await prisma.stripeWebhookEvents
+      .delete({ where: { id: event.id } })
+      .catch(() => undefined)
+
     log.error('Webhook handler error', err as Error)
     return NextResponse.json({ error: 'Handler error' }, { status: 500 })
   }

--- a/app/api/user/check-username/route.ts
+++ b/app/api/user/check-username/route.ts
@@ -76,63 +76,63 @@ async function checkUsernameHandler(req: NextRequest) {
 
 export const GET = withErrorHandler(checkUsernameHandler)
 
+const MAX_USERNAME_LENGTH = 20
+const MAX_SUGGESTIONS = 3
+
+/**
+ * Builds the candidate pool in the same priority order the old implementation
+ * used: `name1..name99`, then `name_1..name_99`, then one random 4-digit suffix.
+ */
+function buildSuggestionCandidates(baseUsername: string): string[] {
+  const candidates: string[] = []
+
+  for (let i = 1; i <= 99; i++) {
+    candidates.push(`${baseUsername}${i}`)
+  }
+  for (let i = 1; i <= 99; i++) {
+    candidates.push(`${baseUsername}_${i}`)
+  }
+
+  const randomNum = Math.floor(Math.random() * 9000) + 1000 // 1000-9999
+  candidates.push(`${baseUsername}${randomNum}`.substring(0, MAX_USERNAME_LENGTH))
+
+  return candidates.filter((candidate) => candidate.length <= MAX_USERNAME_LENGTH)
+}
+
+/**
+ * Previously this ran one `findFirst` per candidate inside a loop — up to ~199
+ * sequential, non-indexable (`mode: 'insensitive'`) queries for a single request
+ * to a public, unauthenticated endpoint (#720). The rate limiter bounds requests,
+ * not the work each one costs, so a handful of probes could pin the database.
+ *
+ * Resolve the whole candidate set in one round trip instead and pick locally.
+ */
 async function generateUsernameSuggestions(baseUsername: string): Promise<string[]> {
+  const candidates = buildSuggestionCandidates(baseUsername)
+  if (candidates.length === 0) return []
+
+  // Every candidate starts with the base name, so one prefix query returns a
+  // superset of the taken ones. Preferred over an `in` list because Prisma's
+  // `mode: 'insensitive'` is only reliably applied to prefix/equality filters.
+  // Bounded so a very common prefix can't return an unbounded result set; if it
+  // truncates, the worst case is suggesting a name that turns out to be taken.
+  const taken = await prisma.users.findMany({
+    where: { username: { startsWith: baseUsername, mode: 'insensitive' } },
+    select: { username: true },
+    take: 1000,
+  })
+
+  const takenLower = new Set(
+    taken
+      .map((user) => user.username?.toLowerCase())
+      .filter((username): username is string => Boolean(username))
+  )
+
   const suggestions: string[] = []
-  const maxSuggestions = 3
-
-  // Try with numbers
-  for (let i = 1; i <= 99 && suggestions.length < maxSuggestions; i++) {
-    const suggestion = `${baseUsername}${i}`
-    if (suggestion.length <= 20) {
-      const exists = await prisma.users.findFirst({
-        where: {
-          username: {
-            equals: suggestion,
-            mode: 'insensitive',
-          },
-        },
-      })
-      if (!exists) {
-        suggestions.push(suggestion)
-      }
-    }
-  }
-
-  // Try with underscore and numbers
-  if (suggestions.length < maxSuggestions) {
-    for (let i = 1; i <= 99 && suggestions.length < maxSuggestions; i++) {
-      const suggestion = `${baseUsername}_${i}`
-      if (suggestion.length <= 20) {
-        const exists = await prisma.users.findFirst({
-          where: {
-            username: {
-              equals: suggestion,
-              mode: 'insensitive',
-            },
-          },
-        })
-        if (!exists) {
-          suggestions.push(suggestion)
-        }
-      }
-    }
-  }
-
-  // Try with random numbers at the end
-  if (suggestions.length < maxSuggestions) {
-    const randomNum = Math.floor(Math.random() * 9000) + 1000 // 1000-9999
-    const suggestion = `${baseUsername}${randomNum}`.substring(0, 20)
-    const exists = await prisma.users.findFirst({
-      where: {
-        username: {
-          equals: suggestion,
-          mode: 'insensitive',
-        },
-      },
-    })
-    if (!exists) {
-      suggestions.push(suggestion)
-    }
+  for (const candidate of candidates) {
+    if (takenLower.has(candidate.toLowerCase())) continue
+    suggestions.push(candidate)
+    if (suggestions.length >= MAX_SUGGESTIONS) break
   }
 
   return suggestions

--- a/app/lobby/[code]/components/MemoryGameBoard.tsx
+++ b/app/lobby/[code]/components/MemoryGameBoard.tsx
@@ -764,7 +764,11 @@ export default function MemoryGameBoard({
                 <span className="memory-tile-back-mark">✦</span>
               </span>
               <span className={`memory-tile-face ${symbolSizeClass}`}>
-                {card.value}
+                {/* Face-down cards no longer carry their value (#715), so an
+                    optimistic flip has nothing to show until the server confirms
+                    the move. Render a neutral placeholder for that brief window
+                    instead of a blank tile. */}
+                {card.value || (isFaceUp ? '·' : '')}
               </span>
             </span>
           </button>

--- a/app/lobby/[code]/rock-paper-scissors-page.tsx
+++ b/app/lobby/[code]/rock-paper-scissors-page.tsx
@@ -429,7 +429,7 @@ export default function RockPaperScissorsLobbyPage({ code, isSpectator = false }
 
     if (loading) {
         return (
-            <div className="min-h-[100dvh] bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center">
+            <div className="h-[calc(100dvh-4rem)] flex items-center justify-center" style={getThemePageStyle(lobby?.theme)}>
                 <LoadingSpinner size="lg" />
             </div>
         )
@@ -437,7 +437,7 @@ export default function RockPaperScissorsLobbyPage({ code, isSpectator = false }
 
     if (error || !lobby || !lobby.game) {
         return (
-            <div className="min-h-[100dvh] bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center p-4">
+            <div className="h-[calc(100dvh-4rem)] flex items-center justify-center p-4" style={getThemePageStyle(lobby?.theme)}>
                 <div className="rounded-2xl border border-rose-200 bg-[var(--bd-bg)] p-6 shadow-sm max-w-md text-center">
                     <p className="text-rose-700">{error || t('errors.gameNotFound')}</p>
                     <button
@@ -457,7 +457,7 @@ export default function RockPaperScissorsLobbyPage({ code, isSpectator = false }
 
     if (!currentPlayer && !isSpectator) {
         return (
-            <div className="min-h-[100dvh] bg-gradient-to-b from-sky-50 via-white to-indigo-50 flex items-center justify-center p-4">
+            <div className="h-[calc(100dvh-4rem)] flex items-center justify-center p-4" style={getThemePageStyle(lobby?.theme)}>
                 <div className="rounded-2xl border border-[var(--bd-line)] bg-[var(--bd-bg)] p-6 shadow-sm max-w-md text-center">
                     <p className="text-bd-ink-soft mb-4">You are not part of this match.</p>
                     <button

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,7 +1,17 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { useTranslation } from '@/lib/i18n-helpers'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
 
 interface ModalProps {
   isOpen: boolean
@@ -23,6 +33,9 @@ export default function Modal({
   bodyPadding = 'default',
 }: ModalProps) {
   const [isMounted, setIsMounted] = useState(false)
+  const { t } = useTranslation()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const titleId = useId()
 
   useEffect(() => {
     setIsMounted(true)
@@ -31,25 +44,72 @@ export default function Modal({
     }
   }, [])
 
-  // Close on Escape key
+  const getFocusableElements = useCallback((): HTMLElement[] => {
+    const dialog = dialogRef.current
+    if (!dialog) return []
+    return Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+      (element) => element.offsetParent !== null || element === document.activeElement
+    )
+  }, [])
+
+  // Close on Escape, and keep Tab inside the dialog while it's open. Without the
+  // trap, tabbing past the last control landed on the page behind a scroll-locked
+  // body, which is a dead end for keyboard and screen-reader users.
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
+    if (!isOpen) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
         onClose()
+        return
+      }
+
+      if (e.key !== 'Tab') return
+
+      const focusable = getFocusableElements()
+      if (focusable.length === 0) {
+        // Nothing to move to — keep focus on the dialog itself.
+        e.preventDefault()
+        dialogRef.current?.focus()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement
+
+      if (e.shiftKey && (active === first || active === dialogRef.current)) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
       }
     }
 
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape)
-      // Prevent body scroll when modal is open
-      document.body.style.overflow = 'hidden'
-    }
+    document.addEventListener('keydown', handleKeyDown)
+    // Prevent body scroll when modal is open
+    document.body.style.overflow = 'hidden'
 
     return () => {
-      document.removeEventListener('keydown', handleEscape)
+      document.removeEventListener('keydown', handleKeyDown)
       document.body.style.overflow = 'unset'
     }
-  }, [isOpen, onClose])
+  }, [isOpen, onClose, getFocusableElements])
+
+  // Move focus in on open and hand it back to the trigger on close, so keyboard
+  // users don't get dropped at the top of the document.
+  useEffect(() => {
+    if (!isOpen || !isMounted) return
+
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    const focusable = getFocusableElements()
+    ;(focusable[0] ?? dialogRef.current)?.focus()
+
+    return () => {
+      previouslyFocused?.focus?.()
+    }
+  }, [isOpen, isMounted, getFocusableElements])
 
   if (!isOpen || !isMounted) return null
 
@@ -73,14 +133,21 @@ export default function Modal({
       }`}
       style={{ padding: mobileFullscreen ? '0px' : `clamp(12px, 1.2vw, 20px)` }}
     >
-      {/* Backdrop */}
-      <div 
+      {/* Backdrop — presentational; Escape and the close button are the
+          keyboard-accessible ways out, so this isn't a focusable control. */}
+      <div
         className="absolute inset-0 z-0 bg-black/50 backdrop-blur-sm"
         onClick={onClose}
+        aria-hidden="true"
       />
-      
+
       {/* Modal Content */}
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        {...(title ? { 'aria-labelledby': titleId } : {})}
+        tabIndex={-1}
         className={`relative z-10 flex w-full flex-col shadow-2xl animate-scale-in ${
           mobileFullscreen
             ? 'h-[100dvh] max-h-[100dvh] rounded-none border-0 sm:h-auto sm:max-h-[92vh] sm:rounded-3xl sm:border'
@@ -102,6 +169,7 @@ export default function Modal({
             style={mobileFullscreen ? { borderColor: 'var(--bd-line)' } : { padding: `clamp(12px, 1.2vh, 20px)`, borderColor: 'var(--bd-line)' }}
           >
             <h2
+              id={titleId}
               className={`font-bold ${
                 mobileFullscreen ? 'pr-4 text-lg sm:text-2xl' : ''
               }`}
@@ -113,7 +181,7 @@ export default function Modal({
               onClick={onClose}
               className="transition-colors rounded-xl"
               style={{ padding: `clamp(3px, 0.3vh, 5px)`, color: 'var(--bd-ink-muted)' }}
-              aria-label="Close modal"
+              aria-label={t('common.close')}
             >
               <svg
                 className="fill-none stroke-current"

--- a/lib/broadcast-sanitize.ts
+++ b/lib/broadcast-sanitize.ts
@@ -1,6 +1,10 @@
+import type { SupportedGameType } from './game-registry'
 import { sanitizeSpyStateForBroadcast } from './games/spy-game'
 import { sanitizeRpsStateForBroadcast } from './games/rock-paper-scissors-game'
 import { sanitizeSketchAndGuessStateForBroadcast } from './games/sketch-and-guess-game'
+import { sanitizeMemoryStateForBroadcast } from './games/memory-game'
+import { sanitizeAliasStateForBroadcast } from './games/alias'
+import { sanitizeFakeArtistStateForBroadcast } from './games/fake-artist-game'
 
 /**
  * Single dispatch point for "strip secrets before this state leaves the
@@ -12,22 +16,56 @@ import { sanitizeSketchAndGuessStateForBroadcast } from './games/sketch-and-gues
  * landmine for the next bot-enabled sanitized game type).
  *
  * `viewerUserId` is only meaningful for sanitizers that keep a viewer's own
- * not-yet-revealed data visible to themselves (currently just RPS); pass
- * `null` for a shared broadcast payload with no single viewer.
+ * not-yet-revealed data visible to themselves; pass `null` for a shared
+ * broadcast payload with no single viewer, which redacts for everyone.
  */
+type Sanitizer = <T extends { data?: unknown; status?: string }>(
+  state: T,
+  viewerUserId: string | null
+) => T
+
+/**
+ * Every supported game must make an explicit sanitization decision. `null` means
+ * "this game has no hidden state" and is a deliberate declaration, not a default
+ * — the `Record<SupportedGameType, …>` type makes adding a game without deciding
+ * a compile error.
+ *
+ * This exhaustiveness is the actual fix for #716: the dispatcher previously fell
+ * through to `default: return state`, so nine of eleven games silently shipped
+ * their secrets and each new game inherited the same silence.
+ */
+const SANITIZERS: Record<SupportedGameType, Sanitizer | null> = {
+  guess_the_spy: (state) => sanitizeSpyStateForBroadcast(state),
+  rock_paper_scissors: (state, viewerUserId) => sanitizeRpsStateForBroadcast(state, viewerUserId),
+  sketch_and_guess: (state, viewerUserId) => sanitizeSketchAndGuessStateForBroadcast(state, viewerUserId),
+  memory: (state) => sanitizeMemoryStateForBroadcast(state),
+  alias: (state, viewerUserId) => sanitizeAliasStateForBroadcast(state, viewerUserId),
+  fake_artist: (state, viewerUserId) => sanitizeFakeArtistStateForBroadcast(state, viewerUserId),
+
+  // No hidden state: the whole board is public by design.
+  tic_tac_toe: null,
+  connect_four: null,
+  yahtzee: null,
+  // Every claim and challenge is made in the open; the bluff is social, not informational.
+  liars_party: null,
+  // Each step is revealed to the next player in the chain by design, and the
+  // full chain is only assembled at the reveal phase.
+  telephone_doodle: null,
+}
+
+function isSupportedGameType(gameType: string): gameType is SupportedGameType {
+  return Object.prototype.hasOwnProperty.call(SANITIZERS, gameType)
+}
+
 export function sanitizeStateForBroadcast<T extends { data?: unknown; status?: string }>(
   gameType: string,
   state: T,
   viewerUserId: string | null = null
 ): T {
-  switch (gameType) {
-    case 'guess_the_spy':
-      return sanitizeSpyStateForBroadcast(state)
-    case 'rock_paper_scissors':
-      return sanitizeRpsStateForBroadcast(state, viewerUserId)
-    case 'sketch_and_guess':
-      return sanitizeSketchAndGuessStateForBroadcast(state, viewerUserId)
-    default:
-      return state
+  if (!isSupportedGameType(gameType)) {
+    return state
   }
+
+  const sanitizer = SANITIZERS[gameType]
+  return sanitizer ? sanitizer(state, viewerUserId) : state
 }

--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -66,6 +66,22 @@ function isOriginAllowed(requestOrigin: string, allowedOrigin: string): boolean 
 }
 
 /**
+ * Server-to-server callbacks that authenticate the request body itself (signature
+ * verification) rather than the browser origin. They arrive with no Origin and no
+ * Referer, so the origin check would reject every delivery — see #713, where this
+ * silently blocked every Stripe subscription webhook in production.
+ *
+ * Only add a path here when the route handler verifies the caller
+ * cryptographically. Matching is exact, so a path merely starting with one of
+ * these is not exempt.
+ */
+const SIGNATURE_AUTHENTICATED_WEBHOOK_PATHS = new Set(['/api/stripe/webhook'])
+
+export function isSignatureAuthenticatedWebhook(pathname: string): boolean {
+  return SIGNATURE_AUTHENTICATED_WEBHOOK_PATHS.has(pathname)
+}
+
+/**
  * Verify that the request origin matches our allowed origins
  */
 export function verifyCsrfToken(request: NextRequest): boolean {

--- a/lib/games/alias.ts
+++ b/lib/games/alias.ts
@@ -328,3 +328,32 @@ export class AliasGame extends GameEngine {
     this.state.winner = winningTeam?.playerIds[0] ?? undefined
   }
 }
+
+/**
+ * Hides the active word card from everyone except the describer.
+ *
+ * `currentCard` holds the whole run of words for the turn, including ones the
+ * describer has not reached yet, and it was previously broadcast to every player
+ * — so a guesser could read the answers straight out of the network payload
+ * (#716). The UI only ever renders the word on the describer's screen, so
+ * redacting it for everyone else costs nothing visually.
+ *
+ * `currentCardResults` and `lastTurnResult` are left intact: those words have
+ * already been guessed or skipped in front of the whole table.
+ */
+export function sanitizeAliasStateForBroadcast<T extends { data?: unknown; status?: string }>(
+  state: T,
+  viewerUserId: string | null = null
+): T {
+  const data = state.data as AliasGameData | undefined
+  if (!data || !data.currentCard) return state
+
+  // Outside an active turn there is no live card to protect.
+  if (data.phase !== 'turn_active') return state
+
+  const currentTeam = Array.isArray(data.teams) ? data.teams[data.currentTeamIndex] : undefined
+  const describerId = currentTeam?.playerIds?.[currentTeam.describerIndex]
+  if (viewerUserId !== null && describerId === viewerUserId) return state
+
+  return { ...state, data: { ...data, currentCard: null } }
+}

--- a/lib/games/fake-artist-game.ts
+++ b/lib/games/fake-artist-game.ts
@@ -715,3 +715,35 @@ export class FakeArtistGame extends GameEngine {
     return `[AUTO TIMEOUT] ${playerId} skipped stroke in round ${round}, turn ${turnIndex + 1}.`
   }
 }
+
+/**
+ * Hides which player is the fake artist until the round is revealed.
+ *
+ * `fakeArtistId` sits directly in the broadcast state, so every player could
+ * read the impostor's identity out of the network payload — which is the entire
+ * game (#716). The fake artist themselves must still know, so they keep their
+ * own view. `promptFingerprint` is derived from the fake artist's position and
+ * is redacted alongside it.
+ *
+ * `roundResults` is left intact: those rounds have already been revealed.
+ *
+ * NOTE: this is necessary but not sufficient. `resolveFakeArtistId` picks the
+ * impostor by a deterministic round-robin over `playerOrder`, which is itself
+ * broadcast, so the identity remains computable client-side from public data.
+ * Making the secret genuinely secret requires choosing it randomly server-side
+ * and storing the result — tracked separately.
+ */
+export function sanitizeFakeArtistStateForBroadcast<T extends { data?: unknown; status?: string }>(
+  state: T,
+  viewerUserId: string | null = null
+): T {
+  const data = state.data as FakeArtistGameData | undefined
+  if (!data) return state
+
+  const isRevealed = data.phase === 'reveal' || state.status === 'finished'
+  if (isRevealed) return state
+
+  if (viewerUserId !== null && viewerUserId === data.fakeArtistId) return state
+
+  return { ...state, data: { ...data, fakeArtistId: '', promptFingerprint: '' } }
+}

--- a/lib/games/memory-game.ts
+++ b/lib/games/memory-game.ts
@@ -304,3 +304,34 @@ export class MemoryGame extends GameEngine {
     return tie ? null : winnerId
   }
 }
+
+/**
+ * Strips the face of every card the table cannot already see.
+ *
+ * `MemoryCard.value` was previously broadcast for every card regardless of
+ * `isFlipped`/`isMatched`, so any player could read the whole board out of the
+ * network payload and win every game (#715). A card is only safe to reveal once
+ * it is face up (`isFlipped`) or already claimed (`isMatched`).
+ *
+ * There is no viewer exception: no player, not even the one whose turn it is,
+ * may see a face-down card. `moveHistory` is left intact — it records values
+ * that were shown to everyone when the pair was flipped, and it does not map
+ * them back to card ids, so remembering them is the game rather than a leak.
+ */
+export function sanitizeMemoryStateForBroadcast<T extends { data?: unknown; status?: string }>(
+  state: T
+): T {
+  const data = state.data as MemoryGameData | undefined
+  if (!data || !Array.isArray(data.cards)) return state
+
+  let redactedAny = false
+  const sanitizedCards = data.cards.map((card) => {
+    if (!card || card.isFlipped || card.isMatched) return card
+    redactedAny = true
+    return { ...card, value: '' }
+  })
+
+  if (!redactedAny) return state
+
+  return { ...state, data: { ...data, cards: sanitizedCards } }
+}

--- a/lib/lobby-password.ts
+++ b/lib/lobby-password.ts
@@ -25,6 +25,12 @@ export async function hashLobbyPassword(password: string | null | undefined): Pr
   return hashPassword(normalized)
 }
 
+/**
+ * Returns true when the lobby is open (no password set) or the supplied password
+ * matches. Note the open-lobby case: this answers "does this password check
+ * out", not "is this user allowed in" — callers must not use it as a general
+ * authorization gate.
+ */
 export async function verifyLobbyPassword(
   storedPassword: string | null | undefined,
   providedPassword: string | null | undefined
@@ -39,14 +45,17 @@ export async function verifyLobbyPassword(
     return false
   }
 
-  if (isHashedLobbyPassword(normalizedStored)) {
-    try {
-      return await comparePassword(normalizedProvided, normalizedStored)
-    } catch {
-      return false
-    }
+  // Only bcrypt hashes are accepted. A stored value that isn't a hash is treated
+  // as invalid rather than compared as plain text (#721) — the previous fallback
+  // kept unhashed rows working indefinitely, so they were never migrated and
+  // stayed readable to anyone with database or backup access.
+  if (!isHashedLobbyPassword(normalizedStored)) {
+    return false
   }
 
-  // Legacy fallback for old lobbies that still store plain-text passwords.
-  return normalizedStored === normalizedProvided
+  try {
+    return await comparePassword(normalizedProvided, normalizedStored)
+  } catch {
+    return false
+  }
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -231,6 +231,17 @@ export const rateLimitPresets = {
     maxRequests: 5,
     message: 'Too many authentication attempts. Please try again in 15 minutes.'
   },
+
+  // Password sign-in via NextAuth's credentials callback (#714). Slightly more
+  // forgiving than `auth` because this is the primary login path for real users
+  // — a shared IP (household, cafe, office NAT) can legitimately produce several
+  // attempts in a window, and the limiter counts successes too, not just
+  // failures. Still bounds offline-style guessing to ~40 attempts/hour per IP.
+  credentialsLogin: {
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    maxRequests: 10,
+    message: 'Too many sign-in attempts. Please try again in 15 minutes.'
+  },
   
   // Standard limit for general API endpoints
   api: {

--- a/lib/spectator-state.ts
+++ b/lib/spectator-state.ts
@@ -1,5 +1,4 @@
-import { sanitizeRpsStateForBroadcast } from '@/lib/games/rock-paper-scissors-game'
-import { sanitizeSketchAndGuessStateForBroadcast } from '@/lib/games/sketch-and-guess-game'
+import { sanitizeStateForBroadcast } from '@/lib/broadcast-sanitize'
 
 type JsonObject = Record<string, unknown>
 
@@ -68,20 +67,29 @@ export function sanitizeGameStateForSpectator(
     return parsed
   }
 
-  // Reveal spy identity once the game is finished — spectators can discuss who was the spy
-  if (gameType === 'guess_the_spy' && gameStatus !== 'finished') {
+  // A finished game has nothing left to hide, and every per-game sanitizer
+  // already encodes that rule via `status === 'finished'`. The authoritative
+  // status arrives as a separate argument here and isn't always present on the
+  // state blob itself, so apply it once up front rather than relying on each
+  // sanitizer to find it.
+  if (gameStatus === 'finished') {
+    return parsed
+  }
+
+  // Spy keeps its own key-name scrubber because it also has to reach spy
+  // identity nested inside serialized `state`/`initialState`/`game` strings,
+  // which the structured per-game sanitizers don't walk into.
+  if (gameType === 'guess_the_spy') {
     return scrubSpyIdentity(parsed)
   }
 
-  // Spectators never own a choice, so always redact a still-pending one (no viewer exception)
-  if (gameType === 'rock_paper_scissors' && typeof parsed === 'object' && parsed !== null) {
-    return sanitizeRpsStateForBroadcast(parsed as { data?: unknown; status?: string })
+  if (typeof parsed !== 'object' || parsed === null) {
+    return parsed
   }
 
-  // Spectators are never a drawer, so always redact the live prompt (no viewer exception)
-  if (gameType === 'sketch_and_guess' && typeof parsed === 'object' && parsed !== null) {
-    return sanitizeSketchAndGuessStateForBroadcast(parsed as { data?: unknown; status?: string })
-  }
-
-  return parsed
+  // A spectator is never a participant, so they get the no-viewer treatment:
+  // every per-game sanitizer redacts fully when viewerUserId is null. Routing
+  // through the shared dispatcher means a newly added game is covered here the
+  // moment it's registered, instead of needing a second edit that gets forgotten.
+  return sanitizeStateForBroadcast(gameType, parsed as { data?: unknown; status?: string }, null)
 }

--- a/lib/supabase-storage.ts
+++ b/lib/supabase-storage.ts
@@ -2,12 +2,28 @@ import { createClient } from '@supabase/supabase-js'
 
 const BUCKET = 'avatars'
 const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024 // 2MB
-const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+
+/**
+ * The single source of truth for what an avatar may be. Deriving the storage
+ * key's extension from this map — rather than from the client-supplied
+ * `file.name` — keeps keys inside a known, closed set, which is what lets
+ * deleteAvatar reliably find and remove them (#719).
+ */
+const EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+}
+
+const KNOWN_AVATAR_EXTENSIONS = Array.from(new Set(Object.values(EXTENSION_BY_MIME_TYPE)))
 
 function getSupabaseAdmin() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  // Prefer service role key (bypasses RLS); fall back to anon key for server-side uploads
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  // Must be the service role key: uploads write to another user's prefix-scoped
+  // path under RLS, and silently falling back to the anon key would change the
+  // access model without any signal (#719).
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
   if (!url || !key) {
     throw new Error('Supabase storage not configured: missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY')
   }
@@ -16,18 +32,30 @@ function getSupabaseAdmin() {
 
 export function validateAvatarFile(file: File): string | null {
   if (file.size > MAX_FILE_SIZE_BYTES) return 'File too large (max 2MB)'
-  if (!ALLOWED_MIME_TYPES.includes(file.type)) return 'Invalid file type (JPEG, PNG, WebP, GIF only)'
+  if (!EXTENSION_BY_MIME_TYPE[file.type]) return 'Invalid file type (JPEG, PNG, WebP, GIF only)'
   return null
 }
 
 export async function uploadAvatar(userId: string, file: File): Promise<string> {
-  const ext = file.name.split('.').pop()?.toLowerCase() ?? 'jpg'
+  const ext = EXTENSION_BY_MIME_TYPE[file.type]
+  if (!ext) {
+    throw new Error('Unsupported avatar file type')
+  }
+
+  // Safe to pass through: the lookup above only succeeds for a MIME type in our
+  // own allowlist, so this is never arbitrary client-declared content.
+  const contentType = file.type
   const path = `${userId}/avatar.${ext}`
 
   const supabase = getSupabaseAdmin()
+
+  // A user switching formats (png -> jpg) would otherwise leave the previous
+  // object behind at its own key, still publicly served after being "replaced".
+  await removeStoredAvatars(supabase, userId, [path])
+
   const { error } = await supabase.storage
     .from(BUCKET)
-    .upload(path, file, { upsert: true, contentType: file.type })
+    .upload(path, file, { upsert: true, contentType })
 
   if (error) throw new Error(`Upload failed: ${error.message}`)
 
@@ -36,9 +64,35 @@ export async function uploadAvatar(userId: string, file: File): Promise<string> 
   return `${data.publicUrl}?t=${Date.now()}`
 }
 
+type StorageClient = ReturnType<typeof getSupabaseAdmin>
+
+/**
+ * Removes every stored avatar object for a user, optionally keeping one path.
+ * Lists the user's prefix rather than guessing extensions so nothing is left
+ * behind — a leftover object stays publicly readable after the user believes
+ * they deleted it.
+ */
+async function removeStoredAvatars(
+  supabase: StorageClient,
+  userId: string,
+  keepPaths: string[] = []
+): Promise<void> {
+  const keep = new Set(keepPaths)
+  const { data: listed, error } = await supabase.storage.from(BUCKET).list(userId)
+
+  const paths = error || !listed
+    ? // Listing failed — fall back to the known extension set rather than
+      // silently removing nothing.
+      KNOWN_AVATAR_EXTENSIONS.map((ext) => `${userId}/avatar.${ext}`)
+    : listed.map((entry) => `${userId}/${entry.name}`)
+
+  const removable = paths.filter((path) => !keep.has(path))
+  if (removable.length === 0) return
+
+  await supabase.storage.from(BUCKET).remove(removable)
+}
+
 export async function deleteAvatar(userId: string): Promise<void> {
   const supabase = getSupabaseAdmin()
-  const extensions = ['jpg', 'jpeg', 'png', 'webp', 'gif']
-  const paths = extensions.map((ext) => `${userId}/avatar.${ext}`)
-  await supabase.storage.from(BUCKET).remove(paths)
+  await removeStoredAvatars(supabase, userId)
 }

--- a/lib/validation/game-state.ts
+++ b/lib/validation/game-state.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+/**
+ * Request schema for POST /api/game/[gameId]/state — the authoritative move
+ * endpoint for most games. It previously parsed raw JSON and checked only that
+ * `move.type` was truthy, handing everything else straight to per-game
+ * validateMove/processMove implementations that vary in strictness (#722).
+ *
+ * `move.data` stays permissive on purpose: its shape is game-specific and the
+ * engines own that validation. What this pins down is the envelope, so a
+ * malformed request is rejected at the edge instead of reaching an engine that
+ * assumed well-formed input.
+ */
+export const MAX_MOVE_TYPE_LENGTH = 64
+
+export const gameMoveSchema = z.object({
+  type: z.string().trim().min(1).max(MAX_MOVE_TYPE_LENGTH),
+  data: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const autoActionContextSchema = z.object({
+  source: z.literal('turn-timeout'),
+  debounceKey: z.string().trim().min(1).max(256),
+  turnSnapshot: z.object({
+    currentPlayerId: z.string(),
+    currentPlayerIndex: z.number().int(),
+    lastMoveAt: z.number().nullable(),
+    rollsLeft: z.number(),
+    updatedAt: z.union([z.string(), z.number()]).nullable(),
+  }),
+})
+
+export const gameStateRequestSchema = z.object({
+  move: gameMoveSchema,
+  autoActionContext: autoActionContextSchema.optional(),
+})
+
+export type GameStateRequest = z.infer<typeof gameStateRequestSchema>
+export type GameMoveRequest = z.infer<typeof gameMoveSchema>
+export type AutoActionContextRequest = z.infer<typeof autoActionContextSchema>

--- a/prisma/migrations/20260806190000_add_stripe_webhook_events/migration.sql
+++ b/prisma/migrations/20260806190000_add_stripe_webhook_events/migration.sql
@@ -1,0 +1,13 @@
+-- Idempotency ledger for Stripe webhooks (#717).
+-- Stripe retries any non-2xx delivery and may send the same event more than
+-- once; the primary key on Stripe's own event.id makes a replay a no-op.
+CREATE TABLE IF NOT EXISTS "StripeWebhookEvents" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "processedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StripeWebhookEvents_pkey" PRIMARY KEY ("id")
+);
+
+-- Supports pruning old rows; the table is otherwise only read by primary key.
+CREATE INDEX IF NOT EXISTS "StripeWebhookEvents_processedAt_idx" ON "StripeWebhookEvents"("processedAt");

--- a/prisma/migrations/20260806191000_clear_plaintext_lobby_passwords/migration.sql
+++ b/prisma/migrations/20260806191000_clear_plaintext_lobby_passwords/migration.sql
@@ -1,0 +1,16 @@
+-- Clear leftover plain-text lobby passwords (#721).
+--
+-- verifyLobbyPassword used to fall back to a plain-text string comparison when
+-- the stored value wasn't a bcrypt hash, which kept legacy rows working and so
+-- meant they were never migrated. That fallback is now removed, and these rows
+-- would only ever fail to match.
+--
+-- Verified before writing this: 64 rows still held a non-bcrypt password and
+-- every one of them belongs to an inactive lobby, so nothing joinable changes.
+-- Guarded by "isActive" = false regardless, so an active lobby is never silently
+-- turned into an open one.
+UPDATE "Lobbies"
+SET "password" = NULL
+WHERE "password" IS NOT NULL
+  AND "password" !~ '^\$2[aby]\$[0-9]{2}\$'
+  AND "isActive" = false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -461,6 +461,17 @@ model AdminAuditLogs {
   @@index([targetType, createdAt])
 }
 
+/// Processed Stripe webhook event ids, so a redelivered event is a no-op (#717).
+/// Stripe retries on any non-2xx and can deliver the same event more than once;
+/// without this, each delivery re-ran the subscription write.
+model StripeWebhookEvents {
+  id          String   @id // Stripe's event.id — the natural idempotency key
+  type        String
+  processedAt DateTime @default(now()) @db.Timestamptz(3)
+
+  @@index([processedAt])
+}
+
 model Feedback {
   id        String   @id @default(cuid())
   type      String   // 'bug' | 'feature' | 'other'

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
-import { getSecurityHeaders, verifyCsrfToken } from '@/lib/csrf'
+import { getSecurityHeaders, isSignatureAuthenticatedWebhook, verifyCsrfToken } from '@/lib/csrf'
 
 const IS_DEVELOPMENT = process.env.NODE_ENV === 'development'
 const SECURITY_HEADERS = getSecurityHeaders()
@@ -188,7 +188,12 @@ export async function proxy(request: NextRequest) {
     }
 
     const isUnsafeMethod = !SAFE_METHODS.has(request.method.toUpperCase())
-    if (isUnsafeMethod && !isTrustedServerRequest(request) && !verifyCsrfToken(request)) {
+    if (
+      isUnsafeMethod &&
+      !isSignatureAuthenticatedWebhook(pathname) &&
+      !isTrustedServerRequest(request) &&
+      !verifyCsrfToken(request)
+    ) {
       return NextResponse.json(
         { error: 'Invalid origin. Possible CSRF attack.' },
         { status: 403 }


### PR DESCRIPTION
Fixes every issue filed by the white-box audit of `develop`: #713, #714, #715, #716, #717, #718, #719, #720, #721, #722, #723, #724.

One commit per issue group so each can be reviewed (or reverted) on its own.

## Critical

**#713 — Stripe webhooks were 403'd before reaching the handler.** `proxy.ts` applies an origin-based CSRF gate to every unsafe method under `/api`. Stripe posts server-to-server with no `Origin` and no `Referer`, so `verifyCsrfToken` returned false in production and every delivery died in the middleware — the webhook's own signature check never ran and `premiumUntil` was never written. Signature-authenticated webhook paths are now exempt, via an exact-match predicate in `lib/csrf.ts`.

## High

**#714** — password login was unthrottled. The `auth` preset guarded `/api/auth/login`, which **nothing in the app calls**; the real path is `signIn('credentials')` → `/api/auth/callback/credentials`. Now rate limited (scoped to that one callback, so session/csrf/OAuth polling is untouched), with the 429 reshaped into the envelope next-auth's client can parse.

**#715 / #716** — hidden state was sanitized for only 2 of 11 games. The dispatcher's `default: return state` meant Memory shipped every card value (including face-down), Alias shipped the live word, and Fake Artist shipped the impostor's identity. Added those three sanitizers and replaced the switch with a `Record<SupportedGameType, Sanitizer | null>`, so adding a game without an explicit sanitization decision is now a compile error. The spectator scrubber routes through the same dispatcher instead of being a second, divergent implementation.

## Medium

| Issue | Fix |
|---|---|
| #717 | `StripeWebhookEvents` idempotency ledger keyed on `event.id`; handle `checkout.session.completed`; log zero-match writes; fail closed on a missing webhook secret |
| #718 | `cancel`/`reactivate` require a real session instead of accepting a guest JWT; both gain a rate limit |
| #719 | Avatar keys derive from the validated MIME type, not `file.name`; deletion lists the user's prefix so nothing is left publicly served; service-role key required |
| #720 | `check-username` does one bounded prefix query instead of up to ~199 sequential ones |
| #721 | Lobby passwords: plain-text comparison fallback removed |
| #722 | The main move endpoint validates its request envelope with zod |
| #723 | `Modal` gains `role="dialog"`, `aria-modal`, a focus trap, and focus restore — 24 call sites |
| #724 | RPS transient screens use the right viewport height and inherit the theme instead of a light-only gradient |

## Notes for review

- **#721 was checked against production data before removing the fallback**: 64 rows still held a non-bcrypt password and *all* of them belong to inactive lobbies, so nothing joinable breaks. The included migration nulls those rows, guarded on `isActive = false`.
- **Two migrations** are included (`StripeWebhookEvents`, plain-text password cleanup), so `migrate.yml` will run on merge to develop.
- **#713's fix can't be verified end to end yet** — the Stripe account is still pre-business-verification, so no live webhook events are being delivered. Once live: `stripe trigger customer.subscription.created` against the deployed URL should return 2xx rather than 403. Everything in #717 is likewise untestable in production until then.
- **Memory's optimistic flip** now briefly has no value to render (the server no longer sends it for face-down cards), so it shows a neutral placeholder for that window. Worth a quick look in a real game.
- **`/api/auth/login` was left in place**, annotated. It's a second, independent copy of the credential check and nothing in this app uses it — but it's public API surface, so deleting it is your call.
- **Filed a follow-up, #725**: Sketch & Guess's prompt and Fake Artist's impostor are picked by deterministic formulas over state that is itself broadcast, so they remain computable client-side. The sanitizers here are necessary but not sufficient for those two.

## Verification

- `npm run ci:quick` — clean (lint 0 errors, typecheck clean, arch audit passed)
- `npx jest` — **787 passed, 0 failed**
- 36 suites still fail to *run* on the pre-existing #693 jest 30 environment breakage. Compared against a clean `develop` worktree: **no regressions** — the same suites fail there, and two that fail on develop pass here.
- Not verified in a browser: the Modal focus trap and the RPS dark-theme screens were checked by reading the code and running the component tests, not clicked through live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h84TDa7e9Hqe6Dt7G8wHi